### PR TITLE
create_docker_sysext.sh: Allow to limit sysext to Docker or containerd

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ OS=fedora ARCH=aarch64 ./create_docker_sysext.sh 20.10.13 mydocker
 
 See the above intro section on how to use the resulting sysext image.
 
+You can also limit the sysext image to only Docker (without containerd and runc) or only containerd (no Docker but runc) by passing the environment variables `ONLY_DOCKER=1` or `ONLY_CONTAINERD=1`.
+If you build both sysext images that way, you can load both combined and, e.g., only load the Docker sysext image for debugging while using the containerd sysext image by default for Kubernetes.
+
 ### Converting a Torcx image
 
 Torcx was a solution for switching between different Docker versions on Flatcar.

--- a/create_docker_sysext.sh
+++ b/create_docker_sysext.sh
@@ -3,6 +3,8 @@ set -euo pipefail
 
 ARCH="${ARCH-x86_64}"
 OS="${OS-flatcar}"
+ONLY_CONTAINERD="${ONLY_CONTAINERD:-0}"
+ONLY_DOCKER="${ONLY_DOCKER:-0}"
 
 if [ $# -lt 2 ] || [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
   echo "Usage: $0 VERSION SYSEXTNAME"
@@ -10,10 +12,17 @@ if [ $# -lt 2 ] || [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
   echo "A temporary directory named SYSEXTNAME in the current folder will be created and deleted again."
   echo "All files in the sysext image will be owned by root."
   echo "The necessary systemd services will be created by this script, by default only docker.socket will be enabled."
+  echo "To only package containerd without Docker, pass ONLY_CONTAINERD=1 as environment variable (current value is '${ONLY_CONTAINERD}')."
+  echo "To only package Docker without containerd and runc, pass ONLY_DOCKER=1 as environment variable (current value is '${ONLY_DOCKER}')."
   echo "To use arm64 pass 'ARCH=aarch64' as environment variable (current value is '${ARCH}')."
   echo "To build for another OS than Flatcar, pass 'OS=myosid' as environment variable (current value is '${OS}'), e.g., 'fedora' as found in 'ID' under '/etc/os-release'."
   echo "The '/etc/os-release' file of your OS has to include 'SYSEXT_LEVEL=1.0' as done in Flatcar."
   echo
+  exit 1
+fi
+
+if [ "${ONLY_CONTAINERD}" = 1 ] && [ "${ONLY_DOCKER}" = 1 ]; then
+  echo "Cannot set both ONLY_CONTAINERD and ONLY_DOCKER" >&2
   exit 1
 fi
 
@@ -22,6 +31,7 @@ SYSEXTNAME="$2"
 
 rm -f "docker-${VERSION}.tgz"
 curl -o "docker-${VERSION}.tgz" -fsSL "https://download.docker.com/linux/static/stable/${ARCH}/docker-${VERSION}.tgz"
+# TODO: Also allow to consume upstream containerd and runc release binaries with their respective versions
 rm -rf "${SYSEXTNAME}"
 mkdir -p "${SYSEXTNAME}"
 tar -xf "docker-${VERSION}.tgz" -C "${SYSEXTNAME}"
@@ -30,7 +40,13 @@ mkdir -p "${SYSEXTNAME}"/usr/bin
 mv "${SYSEXTNAME}"/docker/* "${SYSEXTNAME}"/usr/bin/
 rmdir "${SYSEXTNAME}"/docker
 mkdir -p "${SYSEXTNAME}/usr/lib/systemd/system"
-cat > "${SYSEXTNAME}/usr/lib/systemd/system/docker.socket" <<-'EOF'
+if [ "${ONLY_CONTAINERD}" = 1 ]; then
+  rm "${SYSEXTNAME}/usr/bin/docker" "${SYSEXTNAME}/usr/bin/dockerd" "${SYSEXTNAME}/usr/bin/docker-init" "${SYSEXTNAME}/usr/bin/docker-proxy"
+elif [ "${ONLY_DOCKER}" = 1 ]; then
+  rm "${SYSEXTNAME}/usr/bin/containerd" "${SYSEXTNAME}/usr/bin/containerd-shim" "${SYSEXTNAME}/usr/bin/containerd-shim-runc-v2" "${SYSEXTNAME}/usr/bin/ctr" "${SYSEXTNAME}/usr/bin/runc"
+fi
+if [ "${ONLY_CONTAINERD}" != 1 ]; then
+  cat > "${SYSEXTNAME}/usr/lib/systemd/system/docker.socket" <<-'EOF'
 	[Unit]
 	PartOf=docker.service
 	Description=Docker Socket for the API
@@ -42,9 +58,9 @@ cat > "${SYSEXTNAME}/usr/lib/systemd/system/docker.socket" <<-'EOF'
 	[Install]
 	WantedBy=sockets.target
 EOF
-mkdir -p "${SYSEXTNAME}/usr/lib/systemd/system/sockets.target.wants"
-ln -s ../docker.socket "${SYSEXTNAME}/usr/lib/systemd/system/sockets.target.wants/docker.socket"
-cat > "${SYSEXTNAME}/usr/lib/systemd/system/docker.service" <<-'EOF'
+  mkdir -p "${SYSEXTNAME}/usr/lib/systemd/system/sockets.target.wants"
+  ln -s ../docker.socket "${SYSEXTNAME}/usr/lib/systemd/system/sockets.target.wants/docker.socket"
+  cat > "${SYSEXTNAME}/usr/lib/systemd/system/docker.service" <<-'EOF'
 	[Unit]
 	Description=Docker Application Container Engine
 	After=containerd.service docker.socket network-online.target
@@ -76,7 +92,9 @@ cat > "${SYSEXTNAME}/usr/lib/systemd/system/docker.service" <<-'EOF'
 	[Install]
 	WantedBy=multi-user.target
 EOF
-cat > "${SYSEXTNAME}/usr/lib/systemd/system/containerd.service" <<-'EOF'
+fi
+if [ "${ONLY_DOCKER}" != 1 ]; then
+  cat > "${SYSEXTNAME}/usr/lib/systemd/system/containerd.service" <<-'EOF'
 	[Unit]
 	Description=containerd container runtime
 	After=network.target
@@ -96,10 +114,10 @@ cat > "${SYSEXTNAME}/usr/lib/systemd/system/containerd.service" <<-'EOF'
 	[Install]
 	WantedBy=multi-user.target
 EOF
-mkdir -p "${SYSEXTNAME}/usr/lib/systemd/system/multi-user.target.wants"
-ln -s ../containerd.service "${SYSEXTNAME}/usr/lib/systemd/system/multi-user.target.wants/containerd.service"
-mkdir -p "${SYSEXTNAME}/usr/share/containerd"
-cat > "${SYSEXTNAME}/usr/share/containerd/config.toml" <<-'EOF'
+  mkdir -p "${SYSEXTNAME}/usr/lib/systemd/system/multi-user.target.wants"
+  ln -s ../containerd.service "${SYSEXTNAME}/usr/lib/systemd/system/multi-user.target.wants/containerd.service"
+  mkdir -p "${SYSEXTNAME}/usr/share/containerd"
+  cat > "${SYSEXTNAME}/usr/share/containerd/config.toml" <<-'EOF'
 	version = 2
 	# set containerd's OOM score
 	oom_score = -999
@@ -109,7 +127,8 @@ cat > "${SYSEXTNAME}/usr/share/containerd/config.toml" <<-'EOF'
 	[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
 	SystemdCgroup = true
 EOF
-sed 's/SystemdCgroup = true/SystemdCgroup = false/g' "${SYSEXTNAME}/usr/share/containerd/config.toml" > "${SYSEXTNAME}/usr/share/containerd/config-cgroupfs.toml"
+  sed 's/SystemdCgroup = true/SystemdCgroup = false/g' "${SYSEXTNAME}/usr/share/containerd/config.toml" > "${SYSEXTNAME}/usr/share/containerd/config-cgroupfs.toml"
+fi
 mkdir -p "${SYSEXTNAME}/usr/lib/extension-release.d"
 { echo "ID=${OS}" ; echo "SYSEXT_LEVEL=1.0" ; } > "${SYSEXTNAME}/usr/lib/extension-release.d/extension-release.${SYSEXTNAME}"
 rm -f "${SYSEXTNAME}".raw

--- a/create_docker_sysext.sh
+++ b/create_docker_sysext.sh
@@ -96,6 +96,8 @@ cat > "${SYSEXTNAME}/usr/lib/systemd/system/containerd.service" <<-'EOF'
 	[Install]
 	WantedBy=multi-user.target
 EOF
+mkdir -p "${SYSEXTNAME}/usr/lib/systemd/system/multi-user.target.wants"
+ln -s ../containerd.service "${SYSEXTNAME}/usr/lib/systemd/system/multi-user.target.wants/containerd.service"
 mkdir -p "${SYSEXTNAME}/usr/share/containerd"
 cat > "${SYSEXTNAME}/usr/share/containerd/config.toml" <<-'EOF'
 	version = 2


### PR DESCRIPTION
- create_docker_sysext.sh: Allow to limit sysext to Docker or containerd
    
    With Kubernetes users may want to only ship containerd instead of also
    Docker. At the same time it may be handy to layer Docker on top if
    needed.
    Introduce arguments that allow to limit the build to one of Docker or
    containerd.
- create_docker_sysext.sh: Enable containerd.service by default
    
    This is also done in Flatcar for Kubernetes 1.24.
- create_docker_sysext.sh: Add workaround for missing squashfs tool
    
    On Flatcar we don't have mksquashfs but still want to create sysext
    images for testing.
    Allow to use btrfs or ext4 as alternative format but don't recommend
    it.

## How to use/Testing done

Serve the images locally after building with `ONLY_DOCKER=1 ./create_docker_sysext.sh 20.10.21 docker` and `ONLY_CONTAINERD=1 ./create_docker_sysext.sh 20.10.21 containerd`. Then boot up with this Ignition config:
```
{
  "ignition": {
    "version": "3.3.0"
  },
  "passwd": {
    "users": [
      {
        "name": "core",
        "sshAuthorizedKeys": [
          "ssh-rsa AAA…"
        ]
      }
    ]
  },
  "storage": {
    "files": [
      {
        "path": "/etc/extensions/docker.raw",
        "contents": {
          "source": "http://192.168.1.…:8000/docker.raw"
        },
        "mode": 420
      },
      {
       	"path": "/etc/extensions/containerd.raw",
        "contents": {
          "source": "http://192.168.1.…:8000/containerd.raw"
        },
	"mode": 420
      },
      {
        "path": "/etc/systemd/system-generators/torcx-generator"
      }
    ],
    "directories": [
      {
        "path": "/etc/extensions/docker-flatcar"
      },
      {
        "path": "/etc/extensions/containerd-flatcar"
      }
    ]
  }
}

```

Check with
```
core@localhost ~ $ systemd-sysext status
HIERARCHY EXTENSIONS SINCE                      
/opt      none       -                          
/usr      containerd Fri 2022-11-11 14:49:42 UTC
          docker     
```
Run `docker` or `ctr` and see that they are static binaries.
Check that unit files under `/usr` are used with `systemctl status docker containerd`.