### PR TITLE
Update instructions to opt-out of a future Flatcar Docker sysext

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,13 @@ storage:
         remote:
           url: https://myserver.net/mydocker.raw
     - path: /etc/systemd/system-generators/torcx-generator
-  directories:
-    - path: /etc/extensions/docker-flatcar
-    - path: /etc/extensions/containerd-flatcar
+  links:
+    - path: /etc/extensions/docker-flatcar.raw
+      target: /dev/null
+      overwrite: true
+    - path: /etc/extensions/containerd-flatcar.raw
+      target: /dev/null
+      overwrite: true
 ```
 
 ## Systemd-sysext on other distributions


### PR DESCRIPTION
Instances deployed with a custom Docker version shouldn't suddenly get the default one of Flatcar when we ship it as sysext. The docs to opt- out were assuming that they should mask the default sysext from /usr. However, /usr as location for sysext images is removed and we have to enable the Flatcar default sysext through a symlink in /etc. Document that the user should create this symlink to prevent it from popping up through an update.

## How to use

## Testing done
