### PR TITLE
Add docker compose CLI plugin sysext

### DIFF
--- a/create_docker_compose_sysext.sh
+++ b/create_docker_compose_sysext.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -euo pipefail
+
+export ARCH="${ARCH-x86_64}"
+SCRIPTFOLDER="$(dirname "$(readlink -f "$0")")"
+
+if [ $# -lt 2 ] || [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
+  echo "Usage: $0 VERSION SYSEXTNAME"
+  echo "The script will download the docker compose CLI plugin binary (e.g., for 2.18.1) and create a sysext squashfs image with the name SYSEXTNAME.raw in the current folder."
+  echo "A temporary directory named SYSEXTNAME in the current folder will be created and deleted again."
+  echo "All files in the sysext image will be owned by root."
+  echo "To use arm64 pass 'ARCH=aarch64' as environment variable (current value is '${ARCH}')."
+  "${SCRIPTFOLDER}"/bake.sh --help
+  exit 1
+fi
+
+VERSION="$1"
+SYSEXTNAME="$2"
+
+rm -rf "${SYSEXTNAME}"
+mkdir -p "${SYSEXTNAME}"/usr/local/lib/docker/cli-plugins
+curl -o "${SYSEXTNAME}"/usr/local/lib/docker/cli-plugins/docker-compose -fsSL "https://github.com/docker/compose/releases/download/v${VERSION}/docker-compose-linux-${ARCH}"
+chmod +x "${SYSEXTNAME}"/usr/local/lib/docker/cli-plugins/docker-compose
+"${SCRIPTFOLDER}"/bake.sh "${SYSEXTNAME}"
+rm -rf "${SYSEXTNAME}"


### PR DESCRIPTION
The standalone docker-compose binary is replaced by a new CLI plugin. This CLI plugin needs to live under /usr, thus we have to use a sysext image.
Add a helper to create a sysext image. While we could also add it by default to the docker sysext script, the separate usage is of more interest because it can be used with Flatcar's default Docker.
Done by following
https://docs.docker.com/compose/install/linux/#install-the-plugin-manually


## How to use


## Testing done

```
$ ./create_docker_compose_sysext.sh 2.18.1 docker-compose-2.18.1
$ scp -r -C -P 2222 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null docker-compose-2.18.1.raw      core@127.0.0.1:
$ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p 2222 core@127.0.0.1
# on the VM:
$ sudo mkdir /etc/extensions
$ sudo mv docker-compose-2.18.1.raw /etc/extensions/
$ sudo systemctl restart systemd-sysext ensure-sysext
$ docker compose version
Docker Compose version v2.18.1
```