### PR TITLE
workflow: build and release images

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,47 @@
+name: Build and release Systemd sysext images
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    permissions:
+      # allow the action to create a release
+      contents: write
+    steps:
+      # checkout the sources
+      - uses: actions/checkout@v3
+      # build the images and generate a manifest
+      - name: build
+        run: |
+          set -euo pipefail
+
+          sudo apt update -qq && sudo apt install -yqq \
+            curl \
+            jq \
+            squashfs-tools \
+            xz-utils
+
+          images=(
+              "kubernetes-v1.27.4"
+              "docker-24.0.5"
+              "docker_compose-2.17.2"
+              "wasmtime-11.0.1"
+          )
+
+          for image in ${images[@]}; do
+              component="${image%-*}"
+              version="${image#*-}"
+              "./create_${component}_sysext.sh" "${version}" "${component}"
+              mv "${component}.raw" "${image}.raw"
+          done
+
+          sha256sum *.raw > SHA256SUMS
+      # create a Github release with the generated artifacts
+      - name: release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            SHA256SUMS
+            *.raw


### PR DESCRIPTION
Tested on my fork: https://github.com/tormath1/sysext-bakery/releases/tag/v0.0.1 (https://github.com/tormath1/sysext-bakery/actions/runs/5740907239/job/15559784511)

Tested with systemd-sysupdate:
```yaml
storage:
  files:
    - path: /etc/sysupdate.kubernetes.d/kubernetes.conf
      contents:
        inline: |
          [Transfer]
          Verify=false

          [Source]
          Type=url-file
          Path=https://github.com/tormath1/sysext-bakery/releases/latest/download/
          MatchPattern=kubernetes-@v.raw

          [Target]
          InstancesMax=3
          Type=regular-file
          Path=/opt/extensions/kubernetes
          CurrentSymlink=/etc/extensions/kubernetes.raw
```
