### PR TITLE
workflow: trigger on tag like 20230802

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,7 +2,7 @@ name: Build and release Systemd sysext images
 on:
   push:
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - '*'
 jobs:
   build:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
As discussed on Matrix, we can use date of the release as tag. I wanted to use a regex check (`[0-9]{8}`) but it does not seem to be supported by the parser (https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet)

(tested: https://github.com/tormath1/sysext-bakery/releases/tag/20230802)