### PR TITLE
Use only systemd arch identifiers for user parameters

### DIFF
--- a/create_docker_compose_sysext.sh
+++ b/create_docker_compose_sysext.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-export ARCH="${ARCH-x86_64}"
+export ARCH="${ARCH-x86-64}"
 SCRIPTFOLDER="$(dirname "$(readlink -f "$0")")"
 
 if [ $# -lt 2 ] || [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
@@ -9,13 +9,21 @@ if [ $# -lt 2 ] || [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
   echo "The script will download the docker compose CLI plugin binary (e.g., for 2.18.1) and create a sysext squashfs image with the name SYSEXTNAME.raw in the current folder."
   echo "A temporary directory named SYSEXTNAME in the current folder will be created and deleted again."
   echo "All files in the sysext image will be owned by root."
-  echo "To use arm64 pass 'ARCH=aarch64' as environment variable (current value is '${ARCH}')."
+  echo "To use arm64 pass 'ARCH=arm64' as environment variable (current value is '${ARCH}')."
   "${SCRIPTFOLDER}"/bake.sh --help
   exit 1
 fi
 
 VERSION="$1"
 SYSEXTNAME="$2"
+
+# The github release uses different arch identifiers, we map them here
+# and rely on bake.sh to map them back to what systemd expects
+if [ "${ARCH}" = "amd64" ] || [ "${ARCH}" = "x86-64" ]; then
+  ARCH="x86_64"
+elif [ "${ARCH}" = "arm64" ]; then
+  ARCH="aarch64"
+fi
 
 rm -rf "${SYSEXTNAME}"
 mkdir -p "${SYSEXTNAME}"/usr/local/lib/docker/cli-plugins

--- a/create_docker_sysext.sh
+++ b/create_docker_sysext.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-export ARCH="${ARCH-x86_64}"
+export ARCH="${ARCH-x86-64}"
 SCRIPTFOLDER="$(dirname "$(readlink -f "$0")")"
 ONLY_CONTAINERD="${ONLY_CONTAINERD:-0}"
 ONLY_DOCKER="${ONLY_DOCKER:-0}"
@@ -14,7 +14,7 @@ if [ $# -lt 2 ] || [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
   echo "The necessary systemd services will be created by this script, by default only docker.socket will be enabled."
   echo "To only package containerd without Docker, pass ONLY_CONTAINERD=1 as environment variable (current value is '${ONLY_CONTAINERD}')."
   echo "To only package Docker without containerd and runc, pass ONLY_DOCKER=1 as environment variable (current value is '${ONLY_DOCKER}')."
-  echo "To use arm64 pass 'ARCH=aarch64' as environment variable (current value is '${ARCH}')."
+  echo "To use arm64 pass 'ARCH=arm64' as environment variable (current value is '${ARCH}')."
   "${SCRIPTFOLDER}"/bake.sh --help
   exit 1
 fi
@@ -26,6 +26,14 @@ fi
 
 VERSION="$1"
 SYSEXTNAME="$2"
+
+# The github release uses different arch identifiers, we map them here
+# and rely on bake.sh to map them back to what systemd expects
+if [ "${ARCH}" = "amd64" ] || [ "${ARCH}" = "x86-64" ]; then
+  ARCH="x86_64"
+elif [ "${ARCH}" = "arm64" ]; then
+  ARCH="aarch64"
+fi
 
 rm -f "docker-${VERSION}.tgz"
 curl -o "docker-${VERSION}.tgz" -fsSL "https://download.docker.com/linux/static/stable/${ARCH}/docker-${VERSION}.tgz"

--- a/create_wasmtime_sysext.sh
+++ b/create_wasmtime_sysext.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-export ARCH="${ARCH-x86_64}"
+export ARCH="${ARCH-x86-64}"
 SCRIPTFOLDER="$(dirname "$(readlink -f "$0")")"
 
 if [ $# -lt 2 ] || [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
@@ -9,13 +9,21 @@ if [ $# -lt 2 ] || [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
   echo "The script will download the wasmtime release tar ball (e.g., for 4.0.0) and create a sysext squashfs image with the name SYSEXTNAME.raw in the current folder."
   echo "A temporary directory named SYSEXTNAME in the current folder will be created and deleted again."
   echo "All files in the sysext image will be owned by root."
-  echo "To use arm64 pass 'ARCH=aarch64' as environment variable (current value is '${ARCH}')."
+  echo "To use arm64 pass 'ARCH=arm64' as environment variable (current value is '${ARCH}')."
   "${SCRIPTFOLDER}"/bake.sh --help
   exit 1
 fi
 
 VERSION="$1"
 SYSEXTNAME="$2"
+
+# The github release uses different arch identifiers, we map them here
+# and rely on bake.sh to map them back to what systemd expects
+if [ "${ARCH}" = "amd64" ] || [ "${ARCH}" = "x86-64" ]; then
+  ARCH="x86_64"
+elif [ "${ARCH}" = "arm64" ]; then
+  ARCH="aarch64"
+fi
 
 rm -f "wasmtime-${VERSION}.tar.xz"
 curl -o "wasmtime-${VERSION}.tar.xz" -fsSL "https://github.com/bytecodealliance/wasmtime/releases/download/v${VERSION}/wasmtime-v${VERSION}-${ARCH}-linux.tar.xz"


### PR DESCRIPTION
The difference in architecture identifiers from upstream binary releases and what systemd expects in the extension metadata or the update manifest easily causes confusion.
Recommend the use of the systemd identifiers as they will show up in filenames. Map the identifiers internally and try to do the right thing even if a slighly different identifier was called.

The list of systemd identifiers is here https://www.freedesktop.org/software/systemd/man/systemd.unit.html#ConditionArchitecture=

## Testing done

Built the wasmtime image with the default arch (x86-64) and for arm64.