### PR TITLE
release: Rework publishing to mark the arch and add sysupdate conf files

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ jobs:
       # build the images and generate a manifest
       - name: build
         run: |
-          set -euo pipefail
+          set -euxo pipefail
 
           sudo apt update -qq && sudo apt install -yqq \
             curl \
@@ -33,9 +33,34 @@ jobs:
           for image in ${images[@]}; do
               component="${image%-*}"
               version="${image#*-}"
-              "./create_${component}_sysext.sh" "${version}" "${component}"
-              mv "${component}.raw" "${image}.raw"
+              for arch in x86-64 arm64; do
+                ARCH="${arch}" "./create_${component}_sysext.sh" "${version}" "${component}"
+                mv "${component}.raw" "${image}-${arch}.raw"
+              done
+              cat << EOF > "${component}.conf"
+           [Transfer]
+           Verify=false
+           [Source]
+           Type=url-file
+           Path=https://github.com/flatcar/sysext-bakery/releases/latest/download/
+           MatchPattern=${component}-@v-%a.raw
+           [Target]
+           InstancesMax=3
+           Type=regular-file
+           Path=/opt/extensions/${component}
+           CurrentSymlink=/etc/extensions/${component}.raw
+          EOF
           done
+
+          cat << EOF > "noop.conf"
+          [Source]
+          Type=regular-file
+          Path=/
+          MatchPattern=invalid@v.raw
+          [Target]
+          Type=regular-file
+          Path=/
+          EOF
 
           sha256sum *.raw > SHA256SUMS
       # create a Github release with the generated artifacts
@@ -45,3 +70,4 @@ jobs:
           files: |
             SHA256SUMS
             *.raw
+            *.conf

--- a/create_kubernetes_sysext.sh
+++ b/create_kubernetes_sysext.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-export ARCH="${ARCH-amd64}"
+export ARCH="${ARCH-x86-64}"
 SCRIPTFOLDER="$(dirname "$(readlink -f "$0")")"
 
 if [ $# -lt 2 ] || [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
@@ -18,9 +18,15 @@ fi
 VERSION="$1"
 SYSEXTNAME="$2"
 CNI_VERSION="${3-latest}"
-if [ "${ARCH}" = aarch64 ]; then
-  ARCH=arm64
+
+# The github release uses different arch identifiers (not the same as in the other scripts here),
+# we map them here and rely on bake.sh to map them back to what systemd expects
+if [ "${ARCH}" = "x86_64" ] || [ "${ARCH}" = "x86-64" ]; then
+  ARCH="amd64"
+elif [ "${ARCH}" = "aarch64" ]; then
+  ARCH="arm64"
 fi
+
 rm -f kubectl kubeadm kubelet
 
 # install kubernetes binaries.


### PR DESCRIPTION
The publishing was assuming x86-64 as only architecture. Add arm64 as well and while at it provide the .conf sysupdate files for inclusion via HTTP from Ignition.

## How to use/testing done

Made a release with this: https://github.com/flatcar/sysext-bakery/releases/tag/20230901
and tested the Butane config.