### PR TITLE
kubernetes: Place cni binaries in /opt/cni/bin

### DIFF
--- a/create_kubernetes_sysext.sh
+++ b/create_kubernetes_sysext.sh
@@ -71,8 +71,8 @@ EnvironmentFile=-/var/lib/kubelet/kubeadm-flags.env
 # the .NodeRegistration.KubeletExtraArgs object in the configuration files instead. KUBELET_EXTRA_ARGS should be sourced from this file.
 EnvironmentFile=-/etc/sysconfig/kubelet
 ExecStart=
-ExecStartPre=/usr/bin/mkdir -p /opt/libexec /opt/libexec.work
-ExecStartPre=/usr/bin/cp -r /usr/local/bin/cni/ /opt/bin/cni
+ExecStartPre=/usr/bin/mkdir -p /opt/cni/bin
+ExecStartPre=/usr/bin/cp -r /usr/local/bin/cni/. /opt/cni/bin/
 ExecStartPre=/usr/bin/cp /usr/local/share/kubernetes-version /etc/kubernetes-version
 ExecStartPre=/usr/bin/mkdir -p /var/kubernetes/kubelet-plugins/volume/exec/
 ExecStart=/usr/bin/kubelet $KUBELET_KUBECONFIG_ARGS $KUBELET_CONFIG_ARGS $KUBELET_KUBEADM_ARGS $KUBELET_EXTRA_ARGS


### PR DESCRIPTION
# kubernetes: Place cni binaries in /opt/cni/bin

Containerd expects cni binaries in /opt/cni/bin. We need to make sure that directory exists before running the cp, and need to run cp in a way that doesn't result in the source directory being created in target (we only want the executables).

The /opt/libexec thing was an experiment that can be removed as well, as we found another way of dealing with volume plugins.

## How to use

[ describe what reviewers need to do in order to validate this PR ]

## Testing done

Tested that kubeadm can create a cluster with this.