### PR TITLE
Make script runnable on Alpine, faster Kubernetes builds

### DIFF
--- a/bake.sh
+++ b/bake.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 OS="${OS-flatcar}"

--- a/convert_torcx_image.sh
+++ b/convert_torcx_image.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 SCRIPTFOLDER="$(dirname "$(readlink -f "$0")")"

--- a/create_docker_compose_sysext.sh
+++ b/create_docker_compose_sysext.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 export ARCH="${ARCH-x86-64}"

--- a/create_docker_sysext.sh
+++ b/create_docker_sysext.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 export ARCH="${ARCH-x86-64}"

--- a/create_kubernetes_sysext.sh
+++ b/create_kubernetes_sysext.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 export ARCH="${ARCH-x86-64}"

--- a/create_kubernetes_sysext.sh
+++ b/create_kubernetes_sysext.sh
@@ -30,9 +30,10 @@ fi
 rm -f kubectl kubeadm kubelet
 
 # install kubernetes binaries.
-curl -o kubectl -fsSL "https://dl.k8s.io/${VERSION}/bin/linux/${ARCH}/kubectl"
-curl -o kubeadm -fsSL "https://dl.k8s.io/${VERSION}/bin/linux/${ARCH}/kubeadm"
-curl -o kubelet -fsSL "https://dl.k8s.io/${VERSION}/bin/linux/${ARCH}/kubelet"
+curl --parallel --fail --silent --show-error --location \
+  --output kubectl "https://dl.k8s.io/${VERSION}/bin/linux/${ARCH}/kubectl" \
+  --output kubeadm "https://dl.k8s.io/${VERSION}/bin/linux/${ARCH}/kubeadm" \
+  --output kubelet "https://dl.k8s.io/${VERSION}/bin/linux/${ARCH}/kubelet"
 
 rm -rf "${SYSEXTNAME}"
 mkdir -p "${SYSEXTNAME}"/usr/bin

--- a/create_wasmtime_sysext.sh
+++ b/create_wasmtime_sysext.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 export ARCH="${ARCH-x86-64}"


### PR DESCRIPTION
Two somewhat unrelated changes that you may or may not care for:

1. Switch to `/usr/bin/env bash`, so that the bakery scripts can be run on Alpine (i.e., inside some Docker containers).
2. Download some Kubernetes dependencies in parallel, to be slightly faster.

## How to use

The easiest way to test both changes, is to create a new Kubernetes sysext build.

## Testing done

I built the Kubernetes sysext on the official Alpine-based Bash image.