### PR TITLE
Kubernetes: Correct symlink creation

### DIFF
--- a/create_kubernetes_sysext.sh
+++ b/create_kubernetes_sysext.sh
@@ -82,9 +82,9 @@ EOF
 mkdir -p "${SYSEXTNAME}/usr/local/share/"
 echo "${VERSION}" > "${SYSEXTNAME}/usr/local/share/kubernetes-version"
 
-mkdir -p "${SYSEXTNAME}/usr/libexec/kubernetes/kubelet-plugins/volume/exec/"
+mkdir -p "${SYSEXTNAME}/usr/libexec/kubernetes/kubelet-plugins/volume/"
 # /var/kubernetes/... will be created at runtime by the kubelet unit.
-ln -sf "/var/kubernetes/kubelet-plugins/volume/exec/" "${SYSEXTNAME}/usr/libexec/kubernetes/kubelet-plugins/volume/exec/"
+ln -sf "/var/kubernetes/kubelet-plugins/volume/exec" "${SYSEXTNAME}/usr/libexec/kubernetes/kubelet-plugins/volume/exec"
 
 mkdir -p "${SYSEXTNAME}/usr/lib/systemd/system/multi-user.target.d"
 { echo "[Unit]"; echo "Upholds=kubelet.service"; } > "${SYSEXTNAME}/usr/lib/systemd/system/multi-user.target.d/10-kubelet-service.conf"


### PR DESCRIPTION
The symlink for the directory in /usr/libexec has to be created like a file or otherwise it will land inside the existing directory (which shouldn't have existed).
Fix the symlink creation. A better solution would be https://github.com/flatcar/Flatcar/issues/1193 but that's for future releases.

## How to use



## Testing done

Checked that the correct symlink is part of the image