### PR TITLE
create_docker_sysext.sh: no containerd-shim in v23 and higher

### DIFF
--- a/create_docker_sysext.sh
+++ b/create_docker_sysext.sh
@@ -49,7 +49,11 @@ mkdir -p "${SYSEXTNAME}/usr/lib/systemd/system"
 if [ "${ONLY_CONTAINERD}" = 1 ]; then
   rm "${SYSEXTNAME}/usr/bin/docker" "${SYSEXTNAME}/usr/bin/dockerd" "${SYSEXTNAME}/usr/bin/docker-init" "${SYSEXTNAME}/usr/bin/docker-proxy"
 elif [ "${ONLY_DOCKER}" = 1 ]; then
-  rm "${SYSEXTNAME}/usr/bin/containerd" "${SYSEXTNAME}/usr/bin/containerd-shim" "${SYSEXTNAME}/usr/bin/containerd-shim-runc-v2" "${SYSEXTNAME}/usr/bin/ctr" "${SYSEXTNAME}/usr/bin/runc"
+  rm "${SYSEXTNAME}/usr/bin/containerd" "${SYSEXTNAME}/usr/bin/containerd-shim-runc-v2" "${SYSEXTNAME}/usr/bin/ctr" "${SYSEXTNAME}/usr/bin/runc"
+  if [[ "${VERSION%%.*}" -lt 23 ]] ; then
+    # Binary releases 23 and higher don't ship containerd-shim
+    rm "${SYSEXTNAME}/usr/bin/containerd-shim"
+  fi
 fi
 if [ "${ONLY_CONTAINERD}" != 1 ]; then
   cat > "${SYSEXTNAME}/usr/lib/systemd/system/docker.socket" <<-'EOF'


### PR DESCRIPTION
This change fixes a bug with ONLY_DOCKER builds in create_docker_sysext.sh. Docker binary releases version 23 and above do not ship /usr/bin/containerd-shim anymore, leading to the following error when building a "docker only" sysext w/o containerd:

```shell
rm: cannot remove 'docker/usr/bin/containerd-shim': No such file or directory
```

This PR handles versions below major release 23 separately and only deletes containerd-shim for these versions.

Tested with docker releases 20.10.9, 23.0.0, and 24.0.6.