### PR TITLE
workflow: bump docker release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,7 +30,7 @@ jobs:
           KBS_VERS_ARRAY=(${KBS_VERS})
 
           images=(
-              "docker-24.0.6"
+              "docker-24.0.9"
               "docker_compose-2.22.0"
               "wasmtime-13.0.0"
           )


### PR DESCRIPTION
To prepare the landing of Docker >= 24.0.9 in https://download.docker.com/linux/static/stable/x86_64/

Related to: https://github.com/flatcar/sysext-bakery/issues/37