### PR TITLE
.github: Bump github actions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,7 @@ jobs:
       contents: write
     steps:
       # checkout the sources
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       # prepare build host
       - name: install prerequisites
         run: |
@@ -28,7 +28,7 @@ jobs:
         run: release_build.sh
 
       - name: delete previous latest release
-  	    uses: actions/checkout@v3
+        uses: actions/checkout@v4
         run: gh release delete latest --cleanup-tag
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This is to avoid using deprecated node16.
