### PR TITLE
releases: update docker 25 to 25.0.3, wasmtime to 17.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,9 +88,9 @@ variant: flatcar
 version: 1.0.0
 storage:
   files:
-    - path: /opt/extensions/wasmtime/wasmtime-13.0.0-x86-64.raw
+    - path: /opt/extensions/wasmtime/wasmtime-17.0.1-x86-64.raw
       contents:
-        source: https://github.com/flatcar/sysext-bakery/releases/download/latest/wasmtime-13.0.0-x86-64.raw
+        source: https://github.com/flatcar/sysext-bakery/releases/download/latest/wasmtime-17.0.1-x86-64.raw
     - path: /opt/extensions/docker/docker-24.0.9-x86-64.raw
       contents:
         source: https://github.com/flatcar/sysext-bakery/releases/download/latest/docker-24.0.9-x86-64.raw
@@ -105,7 +105,7 @@ storage:
       contents:
         source: https://github.com/flatcar/sysext-bakery/releases/download/latest/docker.conf
   links:
-    - target: /opt/extensions/wasmtime/wasmtime-13.0.0-x86-64.raw
+    - target: /opt/extensions/wasmtime/wasmtime-17.0.1-x86-64.raw
       path: /etc/extensions/wasmtime.raw
       hard: false
     - target: /opt/extensions/docker/docker-24.0.9-x86-64.raw

--- a/release_build_versions.txt
+++ b/release_build_versions.txt
@@ -8,10 +8,11 @@ kubernetes-v1.28.5 # required for CAPO CI
 
 
 docker-24.0.9 # Used in README.md. Update readme when version changes.
-docker-25.0.2
+docker-25.0.3
 
 docker_compose-2.22.0
 docker_compose-2.24.5
 
 wasmtime-12.0.0
-wasmtime-13.0.0 # Used in README.md. Update readme when version changes.
+wasmtime-13.0.0 # Used in Flatcar wasm OS demo
+wasmtime-17.0.1 # Used in README.md. Update readme when version changes.


### PR DESCRIPTION
As is says in the title. README.md has been updated accordingly to discuss wasmtime 17.

This PR also serves as a test for the new CI release script; retag main with "latest" after merge to trigger a release.