### PR TITLE
release.yaml: remove spurious checkout action to un-break CI

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,7 +28,6 @@ jobs:
         run: release_build.sh
 
       - name: delete previous latest release
-        uses: actions/checkout@v4
         run: gh release delete latest --cleanup-tag
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The "delete tag" action step included a spurious reference to the checkout action which lead to CI breakage:
```
  Error: .github#L1
  a step cannot have both the `uses` and `run` keys
```
This change fixes that issue.