### PR TITLE
release.yaml: fix git repo directory

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,6 +12,9 @@ jobs:
     steps:
       # checkout the sources
       - uses: actions/checkout@v4
+        with:
+          path: bakery
+
       # prepare build host
       - name: install prerequisites
         run: |
@@ -25,12 +28,16 @@ jobs:
             gawk
 
       - name: build release artifacts
-        run: release_build.sh
+        run: |
+          pushd bakery
+          ./release_build.sh
 
       - name: delete previous latest release
-        run: gh release delete latest --cleanup-tag
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          pushd bakery
+          gh release delete latest --cleanup-tag
 
       - name: create a new latest release with all artifacts
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
This change fixes an issue with the release github action that led to the release build script not being found after check-out:
```
 > Run release_build.sh
    /home/runner/work/_temp/8f920e48-5134-4d40-afcc-45d61f2f9226.sh: line 1: release_build.sh: command not found
    Error: Process completed with exit code 127.
```
See e.g. https://github.com/flatcar/sysext-bakery/actions/runs/7884817335/job/21514630897