### PR TITLE
Bake K3S

### DIFF
--- a/create_k3s_sysext.sh
+++ b/create_k3s_sysext.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export ARCH="${ARCH-x86-64}"
+SCRIPTFOLDER="$(dirname "$(readlink -f "$0")")"
+
+if [ $# -lt 2 ] || [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
+  echo "Usage: $0 VERSION SYSEXTNAME"
+  echo "The script will download the k3s binary (e.g., for v1.29.2+k3s1) and create a sysext squashfs image with the name SYSEXTNAME.raw in the current folder."
+  echo "A temporary directory named SYSEXTNAME in the current folder will be created and deleted again."
+  echo "All files in the sysext image will be owned by root."
+  echo "To use arm64 pass 'ARCH=arm64' as environment variable (current value is '${ARCH}')."
+  "${SCRIPTFOLDER}"/bake.sh --help
+  exit 1
+fi
+
+VERSION="$1"
+SYSEXTNAME="$2"
+
+# The github release uses different arch identifiers, we map them here
+# and rely on bake.sh to map them back to what systemd expects
+if [ "${ARCH}" = "amd64" ] || [ "${ARCH}" = "x86-64" ]; then
+  ARCH="x86_64"
+  URL="https://github.com/k3s-io/k3s/releases/download/${VERSION}/k3s"
+elif [ "${ARCH}" = "arm64" ]; then
+  ARCH="aarch64"
+  URL="https://github.com/k3s-io/k3s/releases/download/${VERSION}%2Bk3s1/k3s-arm64"
+fi
+
+rm -rf "${SYSEXTNAME}"
+mkdir -p "${SYSEXTNAME}"/usr/local/bin
+curl -o "${SYSEXTNAME}/usr/local/bin/k3s" -fsSL "${URL}"
+chmod +x "${SYSEXTNAME}"/usr/local/bin/k3s
+"${SCRIPTFOLDER}"/bake.sh "${SYSEXTNAME}"
+rm -rf "${SYSEXTNAME}"

--- a/create_k3s_sysext.sh
+++ b/create_k3s_sysext.sh
@@ -21,7 +21,7 @@ SYSEXTNAME="$2"
 # and rely on bake.sh to map them back to what systemd expects
 if [ "${ARCH}" = "amd64" ] || [ "${ARCH}" = "x86-64" ]; then
   URL="https://github.com/k3s-io/k3s/releases/download/${VERSION}/k3s"
-elif [ "${ARCH}" = "arm64" ]; then
+elif [ "${ARCH}" = "arm64" ] || [ "${ARCH}" = "aarch64" ]; then
   ARCH="aarch64"
   URL="https://github.com/k3s-io/k3s/releases/download/${VERSION}%2Bk3s1/k3s-arm64"
 fi

--- a/create_k3s_sysext.sh
+++ b/create_k3s_sysext.sh
@@ -22,7 +22,7 @@ SYSEXTNAME="$2"
 if [ "${ARCH}" = "amd64" ] || [ "${ARCH}" = "x86-64" ]; then
   URL="https://github.com/k3s-io/k3s/releases/download/${VERSION}/k3s"
 elif [ "${ARCH}" = "arm64" ] || [ "${ARCH}" = "aarch64" ]; then
-  URL="https://github.com/k3s-io/k3s/releases/download/${VERSION}%2Bk3s1/k3s-arm64"
+  URL="https://github.com/k3s-io/k3s/releases/download/${VERSION}/k3s-arm64"
 fi
 
 rm -rf "${SYSEXTNAME}"

--- a/create_k3s_sysext.sh
+++ b/create_k3s_sysext.sh
@@ -22,7 +22,6 @@ SYSEXTNAME="$2"
 if [ "${ARCH}" = "amd64" ] || [ "${ARCH}" = "x86-64" ]; then
   URL="https://github.com/k3s-io/k3s/releases/download/${VERSION}/k3s"
 elif [ "${ARCH}" = "arm64" ] || [ "${ARCH}" = "aarch64" ]; then
-  ARCH="aarch64"
   URL="https://github.com/k3s-io/k3s/releases/download/${VERSION}%2Bk3s1/k3s-arm64"
 fi
 

--- a/create_k3s_sysext.sh
+++ b/create_k3s_sysext.sh
@@ -20,7 +20,6 @@ SYSEXTNAME="$2"
 # The github release uses different arch identifiers, we map them here
 # and rely on bake.sh to map them back to what systemd expects
 if [ "${ARCH}" = "amd64" ] || [ "${ARCH}" = "x86-64" ]; then
-  ARCH="x86_64"
   URL="https://github.com/k3s-io/k3s/releases/download/${VERSION}/k3s"
 elif [ "${ARCH}" = "arm64" ]; then
   ARCH="aarch64"


### PR DESCRIPTION
# Bake K3S as a systemd sysext image.

This PR aims to bake [K3S](https://k3s.io/) as a systemd sysext and also provide a systemd unit file to manage k3s.

## How to use

[ describe what reviewers need to do in order to validate this PR ]

## Testing done

[Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got.]

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
