### PR TITLE
Add wasmCloud recipe

### DIFF
--- a/create_wasmcloud_sysext.sh
+++ b/create_wasmcloud_sysext.sh
@@ -35,13 +35,13 @@ rm -rf "${SYSEXTNAME}"
 mkdir -p "${SYSEXTNAME}"/usr/bin
 
 VERSION="v${VERSION#v}"
-curl -o "${SYSEXTNAME}"/usr/bin/wasmcloud -fvSL "https://github.com/wasmcloud/wasmcloud/releases/download/${VERSION}/wasmcloud-${ARCH}-unknown-linux-musl"
+curl -o "${SYSEXTNAME}"/usr/bin/wasmcloud -fsSL "https://github.com/wasmcloud/wasmcloud/releases/download/${VERSION}/wasmcloud-${ARCH}-unknown-linux-musl"
 chmod +x "${SYSEXTNAME}"/usr/bin/wasmcloud
 
 # Install NATS
 version="${NATS_VERSION}"
 if [[ "${NATS_VERSION}" == "latest" ]]; then
-  version=$(curl -fvSL https://api.github.com/repos/nats-io/nats-server/releases/latest | jq -r .tag_name)
+  version=$(curl -fsSL https://api.github.com/repos/nats-io/nats-server/releases/latest | jq -r .tag_name)
   echo "Using latest version: ${version} for NATS Server"
 fi
 version="v${version#v}"

--- a/create_wasmcloud_sysext.sh
+++ b/create_wasmcloud_sysext.sh
@@ -70,6 +70,7 @@ RestartSec=5
 WantedBy=multi-user.target
 EOF
 
+# Based on https://github.com/nats-io/nats-server/blob/main/util/nats-server.service
 cat > "${SYSEXTNAME}/usr/lib/systemd/system/nats.service" <<-'EOF'
 [Unit]
 Description=NATS Server

--- a/create_wasmcloud_sysext.sh
+++ b/create_wasmcloud_sysext.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export ARCH="${ARCH-x86-64}"
+SCRIPTFOLDER="$(dirname "$(readlink -f "$0")")"
+
+if [ $# -lt 2 ] || [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
+  echo "Usage: $0 VERSION SYSEXTNAME [NATS_VERSION]"
+  echo "The script will download the wasmcloud release (e.g. 0.82.0) and create a sysext squashfs image with the name SYSEXTNAME.raw in the current folder."
+  echo "A temporary directory named SYSEXTNAME in the current folder will be created and deleted again."
+  echo "All files in the sysext image will be owned by root."
+  echo "To use arm64 pass 'ARCH=arm64' as environment variable (current value is '${ARCH}')."
+  "${SCRIPTFOLDER}"/bake.sh --help
+  exit 1
+fi
+
+VERSION="$1"
+SYSEXTNAME="$2"
+NATS_VERSION="${3-latest}"
+
+# The github release uses different arch identifiers, we map them here
+# and rely on bake.sh to map them back to what systemd expects
+if [ "${ARCH}" = "amd64" ] || [ "${ARCH}" = "x86-64" ]; then
+  ARCH="x86_64"
+  GOARCH="amd64"
+elif [ "${ARCH}" = "arm64" ]; then
+  ARCH="aarch64"
+  GOARCH="arm64"
+else
+  echo "Unknown architecture ('${ARCH}') provided, supported values are 'amd64', 'arm64'."
+  exit 1
+fi
+
+rm -rf "${SYSEXTNAME}"
+mkdir -p "${SYSEXTNAME}"/usr/bin
+
+VERSION="v${VERSION#v}"
+curl -o "${SYSEXTNAME}"/usr/bin/wasmcloud -fvSL "https://github.com/wasmcloud/wasmcloud/releases/download/${VERSION}/wasmcloud-${ARCH}-unknown-linux-musl"
+chmod +x "${SYSEXTNAME}"/usr/bin/wasmcloud
+
+# Install NATS
+version="${NATS_VERSION}"
+if [[ "${NATS_VERSION}" == "latest" ]]; then
+  version=$(curl -fvSL https://api.github.com/repos/nats-io/nats-server/releases/latest | jq -r .tag_name)
+  echo "Using latest version: ${version} for NATS Server"
+fi
+version="v${version#v}"
+
+rm -f "nats-server.tar.gz"
+curl -o nats-server.tar.gz -fvSL "https://github.com/nats-io/nats-server/releases/download/${version}/nats-server-${version}-linux-${GOARCH}.tar.gz"
+tar -xf "nats-server.tar.gz" -C "${SYSEXTNAME}"
+mv "${SYSEXTNAME}/nats-server-${version}-linux-${GOARCH}/nats-server" "${SYSEXTNAME}/usr/bin/"
+rm -r "${SYSEXTNAME}/nats-server-${version}-linux-${GOARCH}"
+rm "nats-server.tar.gz"
+
+mkdir -p "${SYSEXTNAME}/usr/lib/systemd/system"
+cat > "${SYSEXTNAME}/usr/lib/systemd/system/wasmcloud.service" <<-'EOF'
+[Unit]
+Description=wasmCloud Host
+Documentation=https://wasmcloud.com/docs/
+After=nats.service network-online.target
+Wants=network-online.target
+Requires=nats.service
+[Service]
+ExecStart=/usr/bin/wasmcloud
+Restart=always
+StartLimitInterval=0
+RestartSec=5
+[Install]
+WantedBy=multi-user.target
+EOF
+
+cat > "${SYSEXTNAME}/usr/lib/systemd/system/nats.service" <<-'EOF'
+[Unit]
+Description=NATS Server
+After=network-online.target systemd-timesyncd.service
+[Service]
+PrivateTmp=true
+Type=simple
+Environment=NATS_CONFIG=/usr/share/nats/nats.conf
+ExecStart=/usr/bin/nats-server --jetstream --config ${NATS_CONFIG}
+ExecReload=/bin/kill -s HUP $MAINPID
+ExecStop=/bin/kill -s SIGINT $MAINPID
+# The nats-server uses SIGUSR2 to trigger using Lame Duck Mode (LDM) shutdown
+KillSignal=SIGUSR2
+# You might want to adjust TimeoutStopSec too.
+[Install]
+WantedBy=multi-user.target
+EOF
+
+mkdir -p "${SYSEXTNAME}/usr/lib/systemd/system/multi-user.target.d"
+{ echo "[Unit]"; echo "Upholds=wasmcloud.service"; } > "${SYSEXTNAME}/usr/lib/systemd/system/multi-user.target.d/10-wasmcloud-service.conf"
+{ echo "[Unit]"; echo "Upholds=nats.service"; } > "${SYSEXTNAME}/usr/lib/systemd/system/multi-user.target.d/10-nats-service.conf"
+
+mkdir -p "${SYSEXTNAME}/usr/share/nats"
+cat > "${SYSEXTNAME}/usr/share/nats/nats.conf" <<-'EOF'
+port: 4222
+monitor_port: 8222
+EOF
+
+RELOAD=1 "${SCRIPTFOLDER}"/bake.sh "${SYSEXTNAME}"
+rm -rf "${SYSEXTNAME}"

--- a/release_build_versions.txt
+++ b/release_build_versions.txt
@@ -17,3 +17,5 @@ wasmtime-12.0.0
 wasmtime-13.0.0 # Used in Flatcar wasm OS demo
 wasmtime-17.0.1 # Used in README.md. Update readme when version changes.
 wasmtime-18.0.1
+
+wasmcloud-0.82.0


### PR DESCRIPTION
# Add wasmCloud recipe

This adds a new recipe for baking a [wasmCloud](https://wasmcloud.com/) sysext image.

## How to use

Once the image is built, you can employ the following configuration ignition configuration (replacing `<your-repository-goes-here>` with the appropriate value) to consume it:
```yaml
---
variant: flatcar
version: 1.0.0
storage:
  files:
    - path: /opt/extensions/wasmcloud/wasmcloud-0.82.0-x86-64.raw
      contents:
        source: https://github.com/<your-repository-goes-here>/sysext-bakery/releases/download/latest/wasmcloud-0.82.0-x86-64.raw
    - path: /etc/sysupdate.wasmcloud.d/wasmcloud.conf
      contents:
        source: https://github.com/<your-repository-goes-here>/sysext-bakery/releases/download/latest/wasmcloud.conf
  links:
    - target: /opt/extensions/wasmcloud/wasmcloud-0.82.0-x86-64.raw
      path: /etc/extensions/wasmcloud.raw
      hard: false
systemd:
  units:
    - name: systemd-sysupdate.timer
      enabled: true
    - name: systemd-sysupdate.service
      dropins:
        - name: wasmcloud.conf
          contents: |
            [Service]
            ExecStartPre=/usr/lib/systemd/systemd-sysupdate -C wasmcloud update
        - name: sysext.conf
          contents: |
            [Service]
            ExecStartPost=systemctl restart systemd-sysext
```

## Testing done

I've set up a [testing branch](https://github.com/flatcar/sysext-bakery/compare/main...joonas:sysext-bakery:test-local) on top of this branch to customize things ever so slightly to allow me to test using the above configuration on my own by pushing a [`latest` tag to kick off CI](https://github.com/joonas/sysext-bakery/actions/runs/8617680318/job/23618199693) and [create a new "latest" release.](https://github.com/joonas/sysext-bakery/releases/tag/latest)

Once I had a release ready to go, I ended up [provisioning a DigitalOcean Droplet with Terraform loosely following Flatcar's docs](https://www.flatcar.org/docs/latest/installing/cloud/digitalocean/#terraform) to test the release.

When it was all said and done, I was able to successfully verify that the binaries and versions I would expect were indeed installed on the machine:
```
Flatcar Container Linux by Kinvolk stable 3815.2.1 for DigitalOcean
core@flatcar-demo-01 ~ $ /usr/bin/wasmcloud --version                                                                                                                                                                                                                       
wasmcloud 0.82.0                                                                                                                                                                                                              
core@flatcar-demo-01 ~ $ /usr/bin/nats-server --version                                                                                                                                                                                                                     
nats-server: v2.10.12
core@flatcar-demo-01 ~ $ /usr/bin/wasmcloud 
Error: failed to initialize host

Caused by:
    0: failed to establish NATS control server connection
    1: failed to connect to NATS
    2: IO error: Connection refused (os error 111)
core@flatcar-demo-01 ~ $ /usr/bin/nats-server                                                                                                                                                                                                                               
[1350] 2024/04/09 15:02:02.848630 [INF] Starting nats-server
[1350] 2024/04/09 15:02:02.856769 [INF]   Version:  2.10.12
[1350] 2024/04/09 15:02:02.856912 [INF]   Git:      [121169ea]
[1350] 2024/04/09 15:02:02.857020 [INF]   Name:     NCYLISGT6Z4R7E66WAAZU7LH5F7D6QJDIRH7J4CUWUXASXCAFPIM76QD
[1350] 2024/04/09 15:02:02.857103 [INF]   ID:       NCYLISGT6Z4R7E66WAAZU7LH5F7D6QJDIRH7J4CUWUXASXCAFPIM76QD
[1350] 2024/04/09 15:02:02.860211 [INF] Listening for client connections on 0.0.0.0:4222
[1350] 2024/04/09 15:02:02.860609 [INF] Server is ready
^C[1350] 2024/04/09 15:02:05.358731 [INF] Initiating Shutdown...
[1350] 2024/04/09 15:02:05.358864 [INF] Server Exiting..
```

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

Please note a couple more things:

1. This ships wasmCloud 0.82.0, which is currently the [latest stable version](https://github.com/wasmCloud/wasmCloud/releases/latest). wasmCloud 1.0 release is imminent, but rather than block this work waiting on that, I figured I'd get this foundation in place, and make the update to bump to 1.0 once it's ready to go.
2. I wasn't sure if I should be adding the wasmCloud entries to `release_build_versions.txt`, please let me know if you'd prefer I back those changes out and focus these changes on just the recipe.