### PR TITLE
bake_flatcar_image: Fix check for empty sysext list

### DIFF
--- a/bake_flatcar_image.sh
+++ b/bake_flatcar_image.sh
@@ -273,7 +273,7 @@ while [ $# -gt 0 ]; do
     esac
 done
 
-if [ -z "${sysexts[@]}" ] ; then
+if [ -z "${sysexts[*]}" ] ; then
     echo -e "\nERROR: No sysexts specified.\n"
     print_help
     exit 1


### PR DESCRIPTION
"${sysexts[@]}" expands every argument separately, while we need all array members to be expanded into a single string for the test to work. "${sysexts[*]}" is what we want.