### PR TITLE
bake.sh: Add mksquashfs flags to prevent appending and reduce warnings

### DIFF
--- a/bake.sh
+++ b/bake.sh
@@ -63,6 +63,6 @@ elif [ "${FORMAT}" = "ext4" ] || [ "${FORMAT}" = "ext2" ]; then
   mkfs."${FORMAT}" -E root_owner=0:0 -d "${SYSEXTNAME}" "${SYSEXTNAME}".raw
   resize2fs -M "${SYSEXTNAME}".raw
 else
-  mksquashfs "${SYSEXTNAME}" "${SYSEXTNAME}".raw -all-root
+  mksquashfs "${SYSEXTNAME}" "${SYSEXTNAME}".raw -all-root -noappend -xattrs-exclude '^btrfs.'
 fi
 echo "Created ${SYSEXTNAME}.raw"


### PR DESCRIPTION
While the use of mksquashfs here happens in a way where no existing file should be there to append to, it's better to always overwrite. Since one might get a lot of warnings on btrfs systems about unknown xattrs, we can also silence these.

## How to use


## Testing done

Created a wasmtime sysext