### PR TITLE
bake.sh: Gate mksquashfs xattr exclusion behind version check

### DIFF
--- a/bake.sh
+++ b/bake.sh
@@ -63,6 +63,13 @@ elif [ "${FORMAT}" = "ext4" ] || [ "${FORMAT}" = "ext2" ]; then
   mkfs."${FORMAT}" -E root_owner=0:0 -d "${SYSEXTNAME}" "${SYSEXTNAME}".raw
   resize2fs -M "${SYSEXTNAME}".raw
 else
-  mksquashfs "${SYSEXTNAME}" "${SYSEXTNAME}".raw -all-root -noappend -xattrs-exclude '^btrfs.'
+  VER=$({ mksquashfs -version || true ; } | head -n1 | cut -d " " -f 3)
+  VERMAJ=$(echo "${VER}" | cut -d . -f 1)
+  VERMIN=$(echo "${VER}" | cut -d . -f 2)
+  ARG=(-all-root -noappend)
+  if [ "${VERMAJ}" -gt 4 ] && [ "${VERMIN}" -gt 6 ]; then
+    ARG+=('-xattrs-exclude' '^btrfs.')
+  fi
+  mksquashfs "${SYSEXTNAME}" "${SYSEXTNAME}".raw "${ARG[@]}"
 fi
 echo "Created ${SYSEXTNAME}.raw"


### PR DESCRIPTION
Old mksquashfs versions don't support the xattr exclusion that was added to prevent harmless warnings getting printed. To support old mksquashfs versions, gate this behind a version check.

## How to use


## Testing done

I tested `./create_wasmtime_sysext.sh 4.0.0 wasmtime` with a 4.6 version, and for an older version it was also [tested](https://kubernetes.slack.com/archives/C03GQ8B5XNJ/p1713360007210139?thread_ts=1713355624.708779&cid=C03GQ8B5XNJ)