### PR TITLE
release: handle new major release of kubernetes

### DIFF
--- a/release_build.sh
+++ b/release_build.sh
@@ -15,7 +15,7 @@ echo "================================================="
 KBS_VERS=$(curl -fsSL --retry-delay 1 --retry 60 --retry-connrefused \
                 --retry-max-time 60 --connect-timeout 20  \
                 https://raw.githubusercontent.com/kubernetes/website/main/data/releases/schedule.yaml \
-                | yq -r '.schedules[].previousPatches[0].release' \
+		| yq -r '.schedules[] | .previousPatches[0] // (.release = .release + ".0") | .release' \
                 | awk '{print "kubernetes-v"$1}')
 if [[ -z "${KBS_VERS}" ]] ; then
     echo "Failed fetching Kubernetes versions"


### PR DESCRIPTION
When there is a new major of Kubernetes there is no `previousPatches` in the `schedule.yaml` file:
```yaml
- release: 1.30
  releaseDate: 2024-04-17
  next:
    release: 1.30.1
    cherryPickDeadline: 2024-05-10
    targetDate: 2024-05-15
  maintenanceModeStartDate: 2025-04-28
  endOfLifeDate: 2025-06-28
```

In this case, we extend the current `release` with `.0` to build the full version.

Closes: https://github.com/flatcar/sysext-bakery/issues/61

### Testing done
```
$ KBS_VERS=$(curl -fsSL --retry-delay 1 --retry 60 --retry-connrefused \
                --retry-max-time 60 --connect-timeout 20  \
                https://raw.githubusercontent.com/kubernetes/website/main/data/releases/schedule.yaml \
                | yq -r '.schedules[] | .previousPatches[0] // (.release = .release + ".0") | .release' \
                | awk '{print "kubernetes-v"$1}')
$ KBS_VERS_ARRAY=(${KBS_VERS})
$ printf "%s\n" "${KBS_VERS_ARRAY[@]}"
kubernetes-v1.30.0
kubernetes-v1.29.3
kubernetes-v1.28.8
kubernetes-v1.27.12
```