### PR TITLE
Add wasmCloud 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,9 +141,9 @@ variant: flatcar
 version: 1.0.0
 storage:
   files:
-    - path: /opt/extensions/wasmcloud/wasmcloud-0.82.0-x86-64.raw
+    - path: /opt/extensions/wasmcloud/wasmcloud-1.0.0-x86-64.raw
       contents:
-        source: https://github.com/flatcar/sysext-bakery/releases/download/latest/wasmcloud-0.82.0-x86-64.raw
+        source: https://github.com/flatcar/sysext-bakery/releases/download/latest/wasmcloud-1.0.0-x86-64.raw
     - path: /etc/sysupdate.d/noop.conf
       contents:
         source: https://github.com/flatcar/sysext-bakery/releases/download/latest/noop.conf
@@ -169,7 +169,7 @@ storage:
         inline: |
           <redacted>
   links:
-    - target: /opt/extensions/wasmcloud/wasmcloud-0.82.0-x86-64.raw
+    - target: /opt/extensions/wasmcloud/wasmcloud-1.0.0-x86-64.raw
       path: /etc/extensions/wasmcloud.raw
       hard: false
 systemd:

--- a/create_wasmcloud_sysext.sh
+++ b/create_wasmcloud_sysext.sh
@@ -6,7 +6,7 @@ SCRIPTFOLDER="$(dirname "$(readlink -f "$0")")"
 
 if [ $# -lt 2 ] || [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
   echo "Usage: $0 VERSION SYSEXTNAME [NATS_VERSION]"
-  echo "The script will download the wasmcloud release (e.g. 0.82.0) and create a sysext squashfs image with the name SYSEXTNAME.raw in the current folder."
+  echo "The script will download the wasmcloud release (e.g. 1.0.0) and create a sysext squashfs image with the name SYSEXTNAME.raw in the current folder."
   echo "A temporary directory named SYSEXTNAME in the current folder will be created and deleted again."
   echo "All files in the sysext image will be owned by root."
   echo "To use arm64 pass 'ARCH=arm64' as environment variable (current value is '${ARCH}')."
@@ -47,7 +47,7 @@ fi
 version="v${version#v}"
 
 rm -f "nats-server.tar.gz"
-curl -o nats-server.tar.gz -fvSL "https://github.com/nats-io/nats-server/releases/download/${version}/nats-server-${version}-linux-${GOARCH}.tar.gz"
+curl -o nats-server.tar.gz -fsSL "https://github.com/nats-io/nats-server/releases/download/${version}/nats-server-${version}-linux-${GOARCH}.tar.gz"
 tar -xf "nats-server.tar.gz" -C "${SYSEXTNAME}"
 mv "${SYSEXTNAME}/nats-server-${version}-linux-${GOARCH}/nats-server" "${SYSEXTNAME}/usr/bin/"
 rm -r "${SYSEXTNAME}/nats-server-${version}-linux-${GOARCH}"

--- a/release_build_versions.txt
+++ b/release_build_versions.txt
@@ -19,3 +19,4 @@ wasmtime-17.0.1 # Used in README.md. Update readme when version changes.
 wasmtime-18.0.1
 
 wasmcloud-0.82.0
+wasmcloud-1.0.0


### PR DESCRIPTION
# Adds wasmCloud 1.0 into the release versions

[wasmCloud 1.0 landed yesterday](https://wasmcloud.com/blog/wasmcloud-1.0-webassembly-apps-production-any-cloud-any-edge), so this adds that as a new build version.

## How to use

Once the image is built, you can employ the following configuration ignition configuration (replacing <your-repository-goes-here> with the appropriate value) to consume it:

```yaml
---
variant: flatcar
version: 1.0.0
storage:
  files:
    - path: /opt/extensions/wasmcloud/wasmcloud-1.0.0-x86-64.raw
      contents:
        source: https://github.com/<your-repository-goes-here>/sysext-bakery/releases/download/latest/wasmcloud-1.0.0-x86-64.raw
    - path: /etc/sysupdate.wasmcloud.d/wasmcloud.conf
      contents:
        source: https://github.com/<your-repository-goes-here>/sysext-bakery/releases/download/latest/wasmcloud.conf
  links:
    - target: /opt/extensions/wasmcloud/wasmcloud-1.0.0-x86-64.raw
      path: /etc/extensions/wasmcloud.raw
      hard: false
systemd:
  units:
    - name: systemd-sysupdate.timer
      enabled: true
    - name: systemd-sysupdate.service
      dropins:
        - name: wasmcloud.conf
          contents: |
            [Service]
            ExecStartPre=/usr/lib/systemd/systemd-sysupdate -C wasmcloud update
        - name: sysext.conf
          contents: |
            [Service]
            ExecStartPost=systemctl restart systemd-sysext
```

## Testing done

I spun up an instance on DigitalOcean using the above and verified that it ships with the appropriate versions:
```shell
core@flatcar-demo-01 ~ $ /usr/bin/wasmcloud  --version                                                                                                                                                                                            
wasmcloud 1.0.0
core@flatcar-demo-01 ~ $ /usr/bin/nats-server --version                                                                                                                                                                                           
nats-server: v2.10.14
```

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
