### PR TITLE
ADD create_rke2_sysext.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ systemd:
 This also configures systemd-sysupdate for auto-updates. The `noop.conf` is a workaround for systemd-sysupdate to run without error messages.
 Since the configuration sets up a custom Docker version, it also disables Torcx and the future `docker-flatcar` and `containerd-flatcar` extensions to prevent conflicts.
 
+#### wasmcloud
+
 For another example of how you can further customize the recipes provided in this repository, the following recipe uses the image built with `create_wasmcloud_sysext.sh`:
 ```yaml
 variant: flatcar
@@ -213,6 +215,8 @@ In the [Flatcar docs](https://www.flatcar.org/docs/latest/provisioning/sysext/) 
 
 The updates works by [`systemd-sysupdate`](https://www.freedesktop.org/software/systemd/man/sysupdate.d.html) fetching the `SHA256SUMS` file of the generated artifacts, which holds the list of built images with their respective SHA256 digest.
 
+#### k3s
+
 The k3s sysext can be configured by using the following snippet, in case you
 want this to be a k3s server (controlplane):
 
@@ -235,6 +239,37 @@ storage:
   links:
     - path: /etc/systemd/system/multi-user.target.wants/k3s-agent.service
       target: /usr/local/lib/systemd/k3s-agent.service
+      overwrite: true
+```
+
+Of course, any configuration you need should be prepared before starting the
+services, like providing a token for an agent or server to join or creating a
+`config.yaml` file.
+
+#### rke2
+
+The rke2 sysext can be configured by using the following snippet, in case you
+want this to be a rke2 server (controlplane):
+
+```yaml
+variant: flatcar
+version: 1.0.0
+storage:
+  links:
+    - path: /etc/systemd/system/multi-user.target.wants/rke2-server.service
+      target: /usr/local/lib/systemd/rke2-server.service
+      overwrite: true
+```
+
+For a rke2 agent (worker node) you would use something like this snippet:
+
+```yaml
+variant: flatcar
+version: 1.0.0
+storage:
+  links:
+    - path: /etc/systemd/system/multi-user.target.wants/rke2-agent.service
+      target: /usr/local/lib/systemd/rke2-agent.service
       overwrite: true
 ```
 

--- a/create_rke2_sysext.sh
+++ b/create_rke2_sysext.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export ARCH="${ARCH-x86-64}"
+SCRIPTFOLDER="$(dirname "$(readlink -f "$0")")"
+
+if [ $# -lt 2 ] || [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
+  echo "Usage: $0 VERSION SYSEXTNAME"
+  echo "The script will download the rke2 binary (e.g., for v1.29.2+rke2r1) and create a sysext squashfs image with the name SYSEXTNAME.raw in the current folder."
+  echo "A temporary directory named SYSEXTNAME in the current folder will be created and deleted again."
+  echo "All files in the sysext image will be owned by root."
+  echo "To use arm64 pass 'ARCH=arm64' as environment variable (current value is '${ARCH}')."
+  "${SCRIPTFOLDER}"/bake.sh --help
+  exit 1
+fi
+
+VERSION="$1"
+SYSEXTNAME="$2"
+
+# The github release uses different arch identifiers, we map them here
+# and rely on bake.sh to map them back to what systemd expects
+if [ "${ARCH}" = "amd64" ] || [ "${ARCH}" = "x86-64" ]; then
+  URL="https://github.com/rancher/rke2/releases/download/${VERSION}/rke2.linux-amd64.tar.gz"
+  SHA256SUMS="https://github.com/rancher/rke2/releases/download/${VERSION}/sha256sum-amd64.txt"
+elif [ "${ARCH}" = "arm64" ] || [ "${ARCH}" = "aarch64" ]; then
+  URL="https://github.com/rancher/rke2/releases/download/${VERSION}/rke2.linux-arm64.tar.gz"
+  SHA256SUMS="https://github.com/rancher/rke2/releases/download/${VERSION}/sha256sum-arm64.txt"
+fi
+
+rm -rf "${SYSEXTNAME}"
+mkdir -p "${SYSEXTNAME}/usr/local/"
+
+TMP_DIR="${SYSEXTNAME}/tmp/"
+mkdir -p "${TMP_DIR}"
+curl -o "${TMP_DIR}/rke2.linux-amd64.tar.gz"  -fsSL "${URL}"
+curl -o "${TMP_DIR}/sha256sums"  -fsSL "${SHA256SUMS}"
+pushd "${TMP_DIR}" > /dev/null
+grep rke2.linux-amd64.tar.gz ./sha256sums | sha256sum -c -
+popd  > /dev/null
+
+tar xf "${TMP_DIR}/rke2.linux-amd64.tar.gz" -C "${SYSEXTNAME}/usr/local/"
+rm "${SYSEXTNAME}/usr/local/bin/rke2-uninstall.sh"
+
+# remove TMP_DIR before building the sysext
+rm -rf "${TMP_DIR}"
+
+"${SCRIPTFOLDER}"/bake.sh "${SYSEXTNAME}"
+
+# cleanup
+rm -rf "${SYSEXTNAME}"

--- a/create_rke2_sysext.sh
+++ b/create_rke2_sysext.sh
@@ -20,12 +20,12 @@ SYSEXTNAME="$2"
 # The github release uses different arch identifiers, we map them here
 # and rely on bake.sh to map them back to what systemd expects
 if [ "${ARCH}" = "amd64" ] || [ "${ARCH}" = "x86-64" ]; then
-  URL="https://github.com/rancher/rke2/releases/download/${VERSION}/rke2.linux-amd64.tar.gz"
-  SHA256SUMS="https://github.com/rancher/rke2/releases/download/${VERSION}/sha256sum-amd64.txt"
+        export ARCH="amd64"
 elif [ "${ARCH}" = "arm64" ] || [ "${ARCH}" = "aarch64" ]; then
-  URL="https://github.com/rancher/rke2/releases/download/${VERSION}/rke2.linux-arm64.tar.gz"
-  SHA256SUMS="https://github.com/rancher/rke2/releases/download/${VERSION}/sha256sum-arm64.txt"
+        export ARCH="arm64"
 fi
+URL="https://github.com/rancher/rke2/releases/download/${VERSION}/rke2.linux-${ARCH}.tar.gz"
+SHA256SUMS="https://github.com/rancher/rke2/releases/download/${VERSION}/sha256sum-${ARCH}.txt"
 
 rm -rf "${SYSEXTNAME}"
 mkdir -p "${SYSEXTNAME}/usr/local/"

--- a/create_rke2_sysext.sh
+++ b/create_rke2_sysext.sh
@@ -44,7 +44,7 @@ rm "${SYSEXTNAME}/usr/local/bin/rke2-uninstall.sh"
 # remove TMP_DIR before building the sysext
 rm -rf "${TMP_DIR}"
 
-"${SCRIPTFOLDER}"/bake.sh "${SYSEXTNAME}"
+RELOAD=1 "${SCRIPTFOLDER}"/bake.sh "${SYSEXTNAME}"
 
 # cleanup
 rm -rf "${SYSEXTNAME}"


### PR DESCRIPTION
# add script to create a RKE2 sysext

Add a new script that builds a sysext containing the [Rancher rke2](https://github.com/rancher/rke2/) binary and its systemd units.

## How to use

```bash
./create_rke2_sysext.sh v1.29.2+rke2r1 rke2-v1.29.2+rke2r1
```

This will download rke2 in version `v1.29.2+rke2r1` and create a sysext named `rke2-v1.29.2+rke2r1.raw`.

## Testing done

I tested the script locally and got a working sysext.
