### PR TITLE
create_k3s_sysext.sh: create systemd unit files

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,35 @@ In the [Flatcar docs](https://www.flatcar.org/docs/latest/provisioning/sysext/) 
 
 The updates works by [`systemd-sysupdate`](https://www.freedesktop.org/software/systemd/man/sysupdate.d.html) fetching the `SHA256SUMS` file of the generated artifacts, which holds the list of built images with their respective SHA256 digest.
 
+The k3s sysext can be configured by using the following snippet, in case you
+want this to be a k3s server (controlplane):
+
+```yaml
+variant: flatcar
+version: 1.0.0
+storage:
+  links:
+    - path: /etc/systemd/system/multi-user.target.wants/k3s.service
+      target: /usr/local/lib/systemd/k3s.service
+      overwrite: true
+```
+
+For a k3s agent (worker node) you would use something like this snippet:
+
+```yaml
+variant: flatcar
+version: 1.0.0
+storage:
+  links:
+    - path: /etc/systemd/system/multi-user.target.wants/k3s-agent.service
+      target: /usr/local/lib/systemd/k3s-agent.service
+      overwrite: true
+```
+
+Of course, any configuration you need should be prepared before starting the
+services, like providing a token for an agent or server to join or creating a
+`config.yaml` file.
+
 ### Creating a custom Docker sysext image
 
 The Docker releases publish static binaries including containerd and the only missing piece are the systemd units.

--- a/create_k3s_sysext.sh
+++ b/create_k3s_sysext.sh
@@ -95,5 +95,5 @@ ExecStartPre=-/sbin/modprobe overlay
 ExecStart=/usr/local/bin/k3s agent
 EOF
 
-"${SCRIPTFOLDER}"/bake.sh "${SYSEXTNAME}"
+RELOAD=1 "${SCRIPTFOLDER}"/bake.sh "${SYSEXTNAME}"
 rm -rf "${SYSEXTNAME}"

--- a/create_k3s_sysext.sh
+++ b/create_k3s_sysext.sh
@@ -29,5 +29,71 @@ rm -rf "${SYSEXTNAME}"
 mkdir -p "${SYSEXTNAME}"/usr/local/bin
 curl -o "${SYSEXTNAME}/usr/local/bin/k3s" -fsSL "${URL}"
 chmod +x "${SYSEXTNAME}"/usr/local/bin/k3s
+
+mkdir -p "${SYSEXTNAME}"/usr/local/lib/systemd/system/
+cat > "${SYSEXTNAME}"/usr/local/lib/systemd/system/k3s.service << EOF
+[Unit]
+Description=Lightweight Kubernetes
+Documentation=https://k3s.io
+Wants=network-online.target
+After=network-online.target
+
+[Install]
+WantedBy=multi-user.target
+
+[Service]
+Type=notify
+EnvironmentFile=-/etc/default/%N
+EnvironmentFile=-/etc/sysconfig/%N
+EnvironmentFile=-/usr/local/lib/systemd/system/k3s.service.env
+KillMode=process
+Delegate=yes
+# Having non-zero Limit*s causes performance problems due to accounting overhead
+# in the kernel. We recommend using cgroups to do container-local accounting.
+LimitNOFILE=1048576
+LimitNPROC=infinity
+LimitCORE=infinity
+TasksMax=infinity
+TimeoutStartSec=0
+Restart=always
+RestartSec=5s
+ExecStartPre=/bin/sh -xc '! /usr/bin/systemctl is-enabled --quiet nm-cloud-setup.service 2>/dev/null'
+ExecStartPre=-/sbin/modprobe br_netfilter
+ExecStartPre=-/sbin/modprobe overlay
+ExecStart=/usr/local/bin/k3s server
+EOF
+
+cat > "${SYSEXTNAME}"/usr/local/lib/systemd/system/k3s-agent.service << EOF
+[Unit]
+Description=Lightweight Kubernetes
+Documentation=https://k3s.io
+Wants=network-online.target
+After=network-online.target
+
+[Install]
+WantedBy=multi-user.target
+
+[Service]
+Type=notify
+EnvironmentFile=-/etc/default/%N
+EnvironmentFile=-/etc/sysconfig/%N
+EnvironmentFile=-/usr/local/lib/systemd/system/k3s-agent.service.env
+KillMode=process
+Delegate=yes
+# Having non-zero Limit*s causes performance problems due to accounting overhead
+# in the kernel. We recommend using cgroups to do container-local accounting.
+LimitNOFILE=1048576
+LimitNPROC=infinity
+LimitCORE=infinity
+TasksMax=infinity
+TimeoutStartSec=0
+Restart=always
+RestartSec=5s
+ExecStartPre=/bin/sh -xc '! /usr/bin/systemctl is-enabled --quiet nm-cloud-setup.service 2>/dev/null'
+ExecStartPre=-/sbin/modprobe br_netfilter
+ExecStartPre=-/sbin/modprobe overlay
+ExecStart=/usr/local/bin/k3s agent
+EOF
+
 "${SCRIPTFOLDER}"/bake.sh "${SYSEXTNAME}"
 rm -rf "${SYSEXTNAME}"


### PR DESCRIPTION
#  create systemd unit files

create `/usr/local/lib/systemd/system/k3s.service` and `/usr/local/lib/systemd/system/k3s-agent.service`

unit files were taken from the k3s install script at [get.k3s.io](https://get.k3s.io/).