### PR TITLE
Add extension overview and release all repackaged extensions

### DIFF
--- a/release_build_versions.txt
+++ b/release_build_versions.txt
@@ -22,3 +22,9 @@ wasmcloud-0.82.0
 wasmcloud-1.0.0
 
 tailscale-1.64.0
+
+crio-1.28.4
+
+k3s-v1.29.2+k3s1
+
+rke2-v1.29.2+rke2r1


### PR DESCRIPTION
Recently more build scripts got added and not all are covered in the release yet. Add a table that gives an overview on available extensions and whether they are released or not. We try to release all extensions, I didn't do it for keepalived now because it was quite slow to build for arm64. While at it fix the README order a bit, added a Butane template and made the release instructions more robust against mistakes.

## How to use

Create a new release after merge.

## Testing done

[Checked rendering](https://github.com/flatcar/sysext-bakery/tree/kai/overview?tab=readme-ov-file#available-extensions)