### PR TITLE
Fix typo in command in `oci-rootfs.sh` for podman-based hosts

### DIFF
--- a/oci-rootfs.sh
+++ b/oci-rootfs.sh
@@ -47,7 +47,7 @@ fi
 echo "Using temporary container ${ID}"
 trap "'${DOCKER}' rm --force --time 0 '${ID}'" EXIT INT
 if [ "${CMD}" != "" ]; then
-  docker run --name "${ID}" "${IMAGE}" sh -c "${CMD}"
+  "${DOCKER}" run --name "${ID}" "${IMAGE}" sh -c "${CMD}"
 fi
 rm -f "${FOLDER}.tar"
 "${DOCKER}" export "${ID}" -o "${FOLDER}.tar"


### PR DESCRIPTION
#74 added the `oci-rootfs.sh` script which automatically selects `podman` instead of `docker` when it is available on the system running the `oci-rootfs.sh` script. This PR fixes the following command in that script:
https://github.com/flatcar/sysext-bakery/blob/11280db5e80530505857385af088525d3be1675a/oci-rootfs.sh#L50
which assumes the use of `docker`, even when `podman` is used for all other commands, and which had resulted in the script quitting with an error when `podman` is selected instead of `docker` for https://github.com/flatcar/sysext-bakery/blob/11280db5e80530505857385af088525d3be1675a/oci-rootfs.sh#L53

## Testing done

### "it works on my machine"

On my computer (which is running the https://github.com/ublue-os/bluefin/pkgs/container/aurora-dx custom Fedora OS image), I attempted to run the following command:
```
 CMD="apk -U add w3m" ./oci-rootfs.sh alpine:latest /tmp/alpine-w3m
```

Before I made the change in this PR, this command would fail on my computer with the following output:
```
Trying to pull docker.io/amd64/alpine:latest...
Getting image source signatures
Copying blob 4abcf2066143 skipped: already exists
Copying config 05455a0888 done   |
Writing manifest to image destination
05455a08881ea9cf0e752bc48e61bbd71a34c029bb13df01e40e3e70e0d007bd
Using temporary container 2090805
fetch https://dl-cdn.alpinelinux.org/alpine/v3.19/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.19/community/x86_64/APKINDEX.tar.gz
(1/6) Installing libgcc (13.2.1_git20231014-r0)
(2/6) Installing libstdc++ (13.2.1_git20231014-r0)
(3/6) Installing gc (8.2.4-r1)
(4/6) Installing ncurses-terminfo-base (6.4_p20231125-r0)
(5/6) Installing libncursesw (6.4_p20231125-r0)
(6/6) Installing w3m (0.5.3.20230718-r1)
Executing busybox-1.36.1-r15.trigger
OK: 12 MiB in 21 packages
Error: no container with name or ID "2090805" found: no such container
```

When I had turned on debugging output (by changing the shebang line from `#!/usr/bin/env bash` to `#!/usr/bin/env -S bash -eux`), I saw the following output:
```
+ set -euo pipefail
+ REGISTRY=docker.io
+ ARCH=amd64
+ CMD='apk -U add w3m'
+ FETCH=1
+ '[' 2 -lt 2 ']'
+ '[' alpine:latest = -h ']'
+ '[' alpine:latest = --help ']'
+ IMAGE=alpine:latest
+ FOLDER=/var/tmp/alpine-w3m
+ SUFFIX=
+ '[' amd64 = x86-64 ']'
+ '[' amd64 = x86_64 ']'
+ '[' amd64 = aarch64 ']'
+ '[' amd64 = arm64 ']'
+ IMAGE=docker.io/amd64/alpine:latest
+ DOCKER=docker
+ command -v podman
+ DOCKER=podman
+ rm -rf /var/tmp/alpine-w3m
+ '[' 1 = 1 ']'
+ podman pull docker.io/amd64/alpine:latest
Trying to pull docker.io/amd64/alpine:latest...
Getting image source signatures
Copying blob 4abcf2066143 skipped: already exists
Copying config 05455a0888 done   |
Writing manifest to image destination
05455a08881ea9cf0e752bc48e61bbd71a34c029bb13df01e40e3e70e0d007bd
+ '[' 'apk -U add w3m' '!=' '' ']'
+ ID=2322803
+ echo 'Using temporary container 2322803'
Using temporary container 2322803
+ trap ''\''podman'\'' rm --force --time 0 '\''2322803'\''' EXIT INT
+ '[' 'apk -U add w3m' '!=' '' ']'
+ docker run --name 2322803 docker.io/amd64/alpine:latest sh -c 'apk -U add w3m'
fetch https://dl-cdn.alpinelinux.org/alpine/v3.19/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.19/community/x86_64/APKINDEX.tar.gz
(1/6) Installing libgcc (13.2.1_git20231014-r0)
(2/6) Installing libstdc++ (13.2.1_git20231014-r0)
(3/6) Installing gc (8.2.4-r1)
(4/6) Installing ncurses-terminfo-base (6.4_p20231125-r0)
(5/6) Installing libncursesw (6.4_p20231125-r0)
(6/6) Installing w3m (0.5.3.20230718-r1)
Executing busybox-1.36.1-r15.trigger
OK: 12 MiB in 21 packages
+ rm -f /var/tmp/alpine-w3m.tar
+ podman export 2322803 -o /var/tmp/alpine-w3m.tar
Error: no container with name or ID "2322803" found: no such container
+ podman rm --force --time 0 2322803
```

After the change in this PR, I no longer have errors on my computer when running the same command:
```
Trying to pull docker.io/amd64/alpine:latest...
Getting image source signatures
Copying blob 4abcf2066143 skipped: already exists
Copying config 05455a0888 done   |
Writing manifest to image destination
05455a08881ea9cf0e752bc48e61bbd71a34c029bb13df01e40e3e70e0d007bd
Using temporary container 2324638
fetch https://dl-cdn.alpinelinux.org/alpine/v3.19/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.19/community/x86_64/APKINDEX.tar.gz
(1/6) Installing libgcc (13.2.1_git20231014-r0)
(2/6) Installing libstdc++ (13.2.1_git20231014-r0)
(3/6) Installing gc (8.2.4-r1)
(4/6) Installing ncurses-terminfo-base (6.4_p20231125-r0)
(5/6) Installing libncursesw (6.4_p20231125-r0)
(6/6) Installing w3m (0.5.3.20230718-r1)
Executing busybox-1.36.1-r15.trigger
OK: 12 MiB in 21 packages
2324638
```

### "it works on GitHub Actions's machines"

After making the fix in this PR, I also attempted to use `oci-rootfs.sh` on GitHub Actions. The version of Podman or Docker available in the ubuntu-22.04 runner appeared to be too old, resulting in this error in the following output (full CI logs [here](https://github.com/ethanjli/ublue-forklift-sysext-demo/actions/runs/9091782571/job/24987065958)):
```
Trying to pull docker.io/amd64/alpine:3.19.1...
Getting image source signatures
Copying blob sha256:4abcf20661432fb2d719aaf90656f55c287f8ca915dc1c92ec14ff61e67fbaf8
Copying blob sha256:4abcf20661432fb2d719aaf90656f55c287f8ca915dc1c92ec14ff61e67fbaf8
Copying config sha256:05455a08881ea9cf0e752bc48e61bbd71a34c029bb13df01e40e3e70e0d007bd
Writing manifest to image destination
Storing signatures
05455a08881ea9cf0e752bc48e61bbd71a34c029bb13df01e40e3e70e0d007bd
Using temporary container 2501
fetch https://dl-cdn.alpinelinux.org/alpine/v3.19/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.19/community/x86_64/APKINDEX.tar.gz
(1/6) Installing libgcc (13.2.1_git20231014-r0)
(2/6) Installing libstdc++ (13.2.1_git20231014-r0)
(3/6) Installing gc (8.2.4-r1)
(4/6) Installing ncurses-terminfo-base (6.4_p20231125-r0)
(5/6) Installing libncursesw (6.4_p20231125-r0)
(6/6) Installing w3m (0.5.3.20230718-r1)
Executing busybox-1.36.1-r15.trigger
OK: 12 MiB in 21 packages
Error: unknown flag: --time
Error: Process completed with exit code 125.
```

This error was easily resolved by upgrading to the ubuntu-24.04 runner (refer to the GitHub Actions CI log [here](https://github.com/ethanjli/ublue-forklift-sysext-demo/actions/runs/9091795577/job/24987108774), and the associated commit [here](https://github.com/ethanjli/ublue-forklift-sysext-demo/pull/6/commits/f4e959bf4810a279d434e4fb66c64d919d6e297c), and the context for that change [here](https://github.com/ethanjli/ublue-forklift-sysext-demo/pull/6)). To conclude, this confirms for me that the script, [even] after the changes made in this PR, can work as expected on GitHub Actions (as long as we use the ubuntu-24.04 runner).