### PR TITLE
update k3s sysext example

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,6 @@ want this to be a k3s server (controlplane):
 variant: flatcar
 version: 1.0.0
 storage:
-  links:
   files:
     # filename needs to be k3s.raw
     - path: /etc/extensions/k3s.raw
@@ -295,7 +294,12 @@ storage:
         source: https://github.com/flatcar/sysext-bakery/releases/download/latest/k3s-v1.29.2+k3s1-x86-64.raw
     - path: /etc/systemd/system/multi-user.target.wants/k3s.service
       target: /usr/local/lib/systemd/system/k3s.service
-      overwrite: true
+      overwrite: false
+    - path: /etc/rancher/k3s/k3s.yaml
+      user:
+        id: 500
+      group:
+        id: 500
 ```
 
 Please note that this way you will not get automatic updates via


### PR DESCRIPTION
- with `overwrite` set to true, butane was complaining and I was not able to transpile the same config to JSON. 
- This also updates the user and group of kubeconfig (/etc/rancher/k3s/k3s.yaml) so that we don't have to use sudo with `kubectl` commands. 