### PR TITLE
Bake Sysdig/CNCF Falco

### DIFF
--- a/create_falco_sysext.sh
+++ b/create_falco_sysext.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export ARCH="${ARCH-x86-64}"
+SCRIPTFOLDER="$(dirname "$(readlink -f "$0")")"
+
+if [ $# -lt 2 ] || [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
+  echo "Usage: $0 VERSION SYSEXTNAME"
+  echo "The script will download the k3s binary (e.g., for v1.29.2+k3s1) and create a sysext squashfs image with the name SYSEXTNAME.raw in the current folder."
+  echo "A temporary directory named SYSEXTNAME in the current folder will be created and deleted again."
+  echo "All files in the sysext image will be owned by root."
+  echo "To use arm64 pass 'ARCH=arm64' as environment variable (current value is '${ARCH}')."
+  "${SCRIPTFOLDER}"/bake.sh --help
+  exit 1
+fi
+
+VERSION="$1"
+SYSEXTNAME="$2"
+
+# The github release uses different arch identifiers, we map them here
+# and rely on bake.sh to map them back to what systemd expects
+if [ "${ARCH}" = "amd64" ] || [ "${ARCH}" = "x86-64" ]; then
+  URL="https://download.falco.org/packages/bin/x86_64/falco-${VERSION}-x86_64.tar.gz"
+elif [ "${ARCH}" = "arm64" ] || [ "${ARCH}" = "aarch64" ]; then
+  URL="https://download.falco.org/packages/bin/aarch64/falco-${VERSION}-aarch64.tar.gz"
+fi
+
+rm -rf "${SYSEXTNAME}"
+mkdir -p "${SYSEXTNAME}"/
+curl -o - -fsSL "${URL}" | tar --strip-components 1 -xzvf - -C "${SYSEXTNAME}/"
+
+RELOAD=1 "${SCRIPTFOLDER}"/bake.sh "${SYSEXTNAME}"
+rm -rf "${SYSEXTNAME}"


### PR DESCRIPTION
# Bake Falco as a systemd sysext image.

This PR aims to bake [Falco](https://sysdig.com/opensource/falco/) as a systemd sysext

## How to use

The following CL file use official falcon systemd files and also the workshop falco configuration (falco requires yaml configuration in place to work):

```yaml
systemd:
  units:
    #source: https://raw.githubusercontent.com/falcosecurity/falco/master/scripts/systemd/falco-bpf.service
    - name: falco-modern-bpf.service
      enabled: true
      contents: |
        [Unit]
        Description=Falco: Container Native Runtime Security with modern ebpf
        Documentation=https://falco.org/docs/
        Before=falcoctl-artifact-follow.service
        Wants=falcoctl-artifact-follow.service
        
        [Service]
        Type=simple
        User=root
        ExecStart=/usr/bin/falco -o engine.kind=modern_ebpf
        ExecReload=kill -1 $MAINPID
        UMask=0077
        TimeoutSec=30
        RestartSec=15s
        Restart=on-failure
        PrivateTmp=true
        NoNewPrivileges=yes
        ProtectHome=read-only
        ProtectSystem=full
        ProtectKernelTunables=true
        RestrictRealtime=true
        RestrictAddressFamilies=~AF_PACKET
        StandardOutput=null
        
        [Install]
        WantedBy=multi-user.target

    # source: https://raw.githubusercontent.com/falcosecurity/falco/master/scripts/systemd/falcoctl-artifact-follow.service
    - name: falcoctl-artifact-follow.service
      contents: |
        [Unit]
        Description=Falcoctl Artifact Follow: automatic artifacts update service
        Documentation=https://falco.org/docs/
        PartOf=falco-bpf.service falco-kmod.service falco-modern-bpf.service falco-custom.service
        
        [Service]
        Type=simple
        User=root
        ExecStart=/usr/bin/falcoctl artifact follow --allowed-types=rulesfile
        UMask=0077
        TimeoutSec=30
        RestartSec=15s
        Restart=on-failure
        PrivateTmp=true
        NoNewPrivileges=yes
        ProtectSystem=true
        ReadWriteDirectories=/usr/share/falco
        ProtectKernelTunables=true
        RestrictRealtime=true
        
        [Install]
        WantedBy=multi-user.target

storage:
  files:
    - path: /etc/falco/falco.yaml
      contents:
        source: "https://raw.githubusercontent.com/sysdiglabs/falco-workshop/master/falco.yaml"
    - path: /etc/falco/falco_rules.yaml
      contents:
        source: "https://raw.githubusercontent.com/sysdiglabs/falco-workshop/master/falco_rules.yaml"
    - path: /etc/extensions/falco.raw
      contents:
        source: "<LINK>"
```
Checking the output of the `falco-modern-bpf.service` outputs some events (a k3s cluster running im my case):

![image](https://github.com/flatcar/sysext-bakery/assets/640897/77fca1a8-7424-478f-b80d-abb9618321c9)

## Testing done

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

