### PR TITLE
Add a sysext for vim-huge

### DIFF
--- a/create_vim-huge_sysext.sh
+++ b/create_vim-huge_sysext.sh
@@ -45,5 +45,32 @@ EOF
 chmod +x "${SYSEXTNAME}"/build.sh
 docker run -v "${PWD}/${SYSEXTNAME}":/install_root/  --rm "${IMG}" /bin/sh -c /install_root/build.sh
 rm -f "${SYSEXTNAME}"/build.sh
+cat > "${SYSEXTNAME}"/usr/share/vim/vimrc  <<-"EOF"
+" Vim will load $VIMRUNTIME/defaults.vim if the user does not have a vimrc.
+" This happens after /etc/vim/vimrc(.local) are loaded, so it will override
+" any settings in these files.
+" Thus we source the default and disable load defaults afterwords so we can override
+" options in these files.
+" Use :verbose set $option? or :scriptnames to see the where any option is being set from
+if filereadable("/usr/share/vim/vim90/defaults.vim")
+  source /usr/share/vim/vim90/defaults.vim
+endif
+let g:skip_defaults_vim = 1
+
+" Read vimrc.local from /etc if it exists. (read-write root images)
+if filereadable("/etc/vim/vimrc.local")
+  source /etc/vim/vimrc.local
+endif
+
+" Useful config for editing yaml files 
+set ai ts=2 sw=2 et
+set pastetoggle=<F3>
+set ignorecase
+set mouse-=a
+inoremap <S-Tab> <C-d>
+map <silent> <F5> :set cursorcolumn!<CR>
+set maxmempattern=50000
+EOF
+
 RELOAD=1 "${SCRIPTFOLDER}"/bake.sh "${SYSEXTNAME}"
 rm -rf "${SYSEXTNAME}"


### PR DESCRIPTION
There are several cases when the user needs to edit k8s yamls inplace directly on the master nodes and having syntax highlighting and advanced formatting of vim available is a nice feature since the default vim of flatcar have those disabled.

