### PR TITLE
release: bump tailscale

### DIFF
--- a/release_build_versions.txt
+++ b/release_build_versions.txt
@@ -21,7 +21,7 @@ wasmtime-18.0.1
 wasmcloud-0.82.0
 wasmcloud-1.0.0
 
-tailscale-1.64.0
+tailscale-1.70.0
 
 crio-1.28.4
 


### PR DESCRIPTION
This fix CVE-2024-24790

Closes: https://github.com/flatcar/sysext-bakery/issues/81

cc @guilhem 

Locally tested:
```
$ sudo systemd-dissect --with tailscale.raw
orchid /tmp/.#systemd-dissect17970a3acbb05470 # usr/local/bin/tailscale --version
1.70.0
  tailscale commit: 0e0a212418fbf8243cb3f06634367b61e81ea9db
  other commit: 26f80df929d9ae698931e4dd1fbdf05f2138ff6f
  go version: go1.22.5
```