### PR TITLE
release-build: build cri-o for each Kubernetes version

### DIFF
--- a/release_build_versions.txt
+++ b/release_build_versions.txt
@@ -1,6 +1,6 @@
 # Versions to build.
 
-# For Kubernetes, we fetch the latest versions to be built.
+# For Kubernetes and CRI-O, we fetch the latest versions to be built.
 # The below lists _additional_ kubernetes versions to be built.
 
 kubernetes-v1.28.5 # required for CAPO CI
@@ -22,8 +22,6 @@ wasmcloud-0.82.0
 wasmcloud-1.0.0
 
 tailscale-1.70.0
-
-crio-1.28.4
 
 k3s-v1.29.2+k3s1
 


### PR DESCRIPTION
CRI-O is coupled to Kubernetes for the releases, while the major and the minor follows Kubernetes streams, the patch version is independant, so we need to fetch the latest patch release for each minor Kubernetes version.

sysupdate configuration is generated similar to Kubernetes. 

---

Locally tested, will trigger a release right after to generate cri-o missing images.

Related to: https://github.com/flatcar/sysext-bakery/issues/42