### PR TITLE
Add wasmcloud 1.1.1 to release build versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,9 +210,9 @@ variant: flatcar
 version: 1.0.0
 storage:
   files:
-    - path: /opt/extensions/wasmcloud/wasmcloud-1.0.0-x86-64.raw
+    - path: /opt/extensions/wasmcloud/wasmcloud-1.1.1-x86-64.raw
       contents:
-        source: https://github.com/flatcar/sysext-bakery/releases/download/latest/wasmcloud-1.0.0-x86-64.raw
+        source: https://github.com/flatcar/sysext-bakery/releases/download/latest/wasmcloud-1.1.1-x86-64.raw
     - path: /etc/sysupdate.d/noop.conf
       contents:
         source: https://github.com/flatcar/sysext-bakery/releases/download/latest/noop.conf
@@ -238,7 +238,7 @@ storage:
         inline: |
           <redacted>
   links:
-    - target: /opt/extensions/wasmcloud/wasmcloud-1.0.0-x86-64.raw
+    - target: /opt/extensions/wasmcloud/wasmcloud-1.1.1-x86-64.raw
       path: /etc/extensions/wasmcloud.raw
       hard: false
 systemd:

--- a/release_build_versions.txt
+++ b/release_build_versions.txt
@@ -20,6 +20,7 @@ wasmtime-18.0.1
 
 wasmcloud-0.82.0
 wasmcloud-1.0.0
+wasmcloud-1.1.1
 
 tailscale-1.70.0
 


### PR DESCRIPTION
# Adds release build version for wasmCloud 1.1.1

With wasmCloud `v1.1.1` having been released with a number of improvements, especially around integration with other wasmCloud ecosystem components, I feel that it would be beneficial to update the systemd-sysext for it so that environments running Flatcar can benefit from these changes as well!

## How to use

Once the image is built, you can employ the following configuration ignition configuration (replacing <your-repository-goes-here> with the appropriate value) to consume it:

```yaml
---
variant: flatcar
version: 1.0.0
storage:
  files:
    - path: /opt/extensions/wasmcloud/wasmcloud-1.1.1-x86-64.raw
      contents:
        source: https://github.com/<your-repository-goes-here>/sysext-bakery/releases/download/latest/wasmcloud-1.1.1-x86-64.raw
    - path: /etc/sysupdate.wasmcloud.d/wasmcloud.conf
      contents:
        source: https://github.com/<your-repository-goes-here>/sysext-bakery/releases/download/latest/wasmcloud.conf
  links:
    - target: /opt/extensions/wasmcloud/wasmcloud-1.1.1-x86-64.raw
      path: /etc/extensions/wasmcloud.raw
      hard: false
systemd:
  units:
    - name: systemd-sysupdate.timer
      enabled: true
    - name: systemd-sysupdate.service
      dropins:
        - name: wasmcloud.conf
          contents: |
            [Service]
            ExecStartPre=/usr/lib/systemd/systemd-sysupdate -C wasmcloud update
        - name: sysext.conf
          contents: |
            [Service]
            ExecStartPost=systemctl restart systemd-sysext
```

## Testing done

I spun up an instance on DigitalOcean using the above and verified that it ships with the appropriate versions:
```shell
core@flatcar-demo-01 ~ $ /usr/bin/wasmcloud  --version                                                                                                                                                                                            
wasmcloud 1.1.1
core@flatcar-demo-01 ~ $ /usr/bin/nats-server --version                                                                                                                                                                                           
nats-server: v2.10.18
```

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
