### PR TITLE
Fix release_build

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,6 +16,12 @@ jobs:
           path: bakery
 
       # prepare build host
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: install prerequisites
         run: |
           set -euxo pipefail

--- a/create_nvidia_runtime_sysext.sh
+++ b/create_nvidia_runtime_sysext.sh
@@ -29,15 +29,15 @@ fi
 git clone -b ${VERSION} --depth 1 https://github.com/NVIDIA/libnvidia-container || true
 git clone -b ${VERSION} --depth 1 https://github.com/NVIDIA/nvidia-container-toolkit || true
 
-make -C libnvidia-container ubuntu20.04-${ARCH}
-make -C nvidia-container-toolkit ubuntu20.04-${ARCH}
+make -C libnvidia-container ubuntu18.04-${ARCH}
+make -C nvidia-container-toolkit ubuntu18.04-${ARCH}
 
 rm -rf "${SYSEXTNAME}"
 mkdir -p "${SYSEXTNAME}"
-for deb in libnvidia-container/dist/ubuntu20.04/${ARCH}/libnvidia-container{1_*,-tools_}*.deb; do
+for deb in libnvidia-container/dist/ubuntu18.04/${ARCH}/libnvidia-container{1_*,-tools_}*.deb; do
   dpkg-deb -x $deb "${SYSEXTNAME}"/
 done
-for deb in nvidia-container-toolkit/dist/ubuntu20.04/${ARCH}/nvidia-container-toolkit*.deb; do
+for deb in nvidia-container-toolkit/dist/ubuntu18.04/${ARCH}/nvidia-container-toolkit*.deb; do
   dpkg-deb -x $deb "${SYSEXTNAME}"/
 done
 rm -rf "${SYSEXTNAME}"/usr/share

--- a/release_build.sh
+++ b/release_build.sh
@@ -49,13 +49,13 @@ echo "=========================================="
 curl -fsSL --retry-delay 1 --retry 60 --retry-connrefused \
          --retry-max-time 60 --connect-timeout 20  \
          https://api.github.com/repos/flatcar/sysext-bakery/releases/latest \
-    | jq -r '.assets[].browser_download_url' | grep -E '\.raw$' | tee prev_release_sysexts.txt
+    | jq -r '.assets[] | "\(.name)\t\(.browser_download_url)"' | grep -E '\.raw$' | tee prev_release_sysexts.txt
 
-for asset in $(cat prev_release_sysexts.txt); do
+while IFS=$'\t' read -r name url; do
     echo
-    echo "  ## Fetching $(basename "${asset}") <-- ${asset}"
-    curl -O -fsSL --retry-delay 1 --retry 60 --retry-connrefused --retry-max-time 60 --connect-timeout 20  "${asset}"
-done
+    echo "  ## Fetching ${name} <-- ${url}"
+    curl -o "${name}" -fsSL --retry-delay 1 --retry 60 --retry-connrefused --retry-max-time 60 --connect-timeout 20  "${url}"
+done <prev_release_sysexts.txt
 
 streams=()
 
@@ -101,7 +101,7 @@ done
   
 echo "" >> Release.md
 echo "The release includes the following sysexts from previous releases:" >> Release.md
-sed 's/^/* /' prev_release_sysexts.txt >> Release.md
+awk '{ print "* ["$1"]("$2")" }' prev_release_sysexts.txt >>Release.md
 
 echo
 echo "Generating systemd-sysupdate configurations and SHA256SUM."

--- a/release_build.sh
+++ b/release_build.sh
@@ -35,6 +35,10 @@ git ls-remote --tags --sort=-v:refname https://github.com/cri-o/cri-o \
 
 CRIO=()
 for r in "${KBS_VERS_ARRAY[@]}"; do
+    if ! grep -q "v${r%.*}" crio.txt; then
+        echo "Skipping $r"
+        continue
+    fi
     version=$(cat crio.txt | grep "v${r%.*}" | head -n1)
     CRIO+=( "crio-${version:1}" )
 done


### PR DESCRIPTION
I tested the release process on a fork and there were issues:
- cri-o is missing releases for k8s 1.31 - skip
- nvidia-runtime needs to build with ubuntu 18 (not 20) because arm64 targets are missing
- needed to add cross-buildx to the workflow
- rke and k3s have '+' in filenames, this wasn't being handled correctly (asset urls contain an escape sequence)