### PR TITLE
release: do not fail if there is no release artifact

### DIFF
--- a/release_build.sh
+++ b/release_build.sh
@@ -49,7 +49,7 @@ echo "=========================================="
 curl -fsSL --retry-delay 1 --retry 60 --retry-connrefused \
          --retry-max-time 60 --connect-timeout 20  \
          https://api.github.com/repos/flatcar/sysext-bakery/releases/latest \
-    | jq -r '.assets[] | "\(.name)\t\(.browser_download_url)"' | grep -E '\.raw$' | tee prev_release_sysexts.txt
+    | jq -r '.assets[] | "\(.name)\t\(.browser_download_url)"' | { grep -E '\.raw$' || true; } | tee prev_release_sysexts.txt
 
 while IFS=$'\t' read -r name url; do
     echo


### PR DESCRIPTION
if there is no release artifact, grep command will return an exit-code different from 0 so the script is failing. (https://github.com/flatcar/sysext-bakery/actions/runs/10685052349/job/29616925462)

---

For an unknown reason yet the last release has failed - but it's impossible to rerun has the release script expect to have existing artifacts already released.