### PR TITLE
Bump wasmtime to latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,9 +106,9 @@ variant: flatcar
 version: 1.0.0
 storage:
   files:
-    - path: /opt/extensions/wasmtime/wasmtime-17.0.1-x86-64.raw
+    - path: /opt/extensions/wasmtime/wasmtime-24.0.0-x86-64.raw
       contents:
-        source: https://github.com/flatcar/sysext-bakery/releases/download/latest/wasmtime-17.0.1-x86-64.raw
+        source: https://github.com/flatcar/sysext-bakery/releases/download/latest/wasmtime-24.0.0-x86-64.raw
     - path: /opt/extensions/docker/docker-24.0.9-x86-64.raw
       contents:
         source: https://github.com/flatcar/sysext-bakery/releases/download/latest/docker-24.0.9-x86-64.raw
@@ -123,7 +123,7 @@ storage:
       contents:
         source: https://github.com/flatcar/sysext-bakery/releases/download/latest/docker.conf
   links:
-    - target: /opt/extensions/wasmtime/wasmtime-17.0.1-x86-64.raw
+    - target: /opt/extensions/wasmtime/wasmtime-24.0.0-x86-64.raw
       path: /etc/extensions/wasmtime.raw
       hard: false
     - target: /opt/extensions/docker/docker-24.0.9-x86-64.raw
@@ -456,7 +456,7 @@ Refer to `./bake_flatcar_image.sh --help` for more information.
 
 Example usage:
 ```
-./bake_flatcar_image.sh --fetch --vendor qemu_uefi wasmtime:wasmtime-17.0.1-x86-64.raw
+./bake_flatcar_image.sh --fetch --vendor qemu_uefi wasmtime:wasmtime-24.0.0-x86-64.raw
 ```
 
 Example usage with local sysext:

--- a/release_build_versions.txt
+++ b/release_build_versions.txt
@@ -15,8 +15,7 @@ docker_compose-2.24.5
 
 wasmtime-12.0.0
 wasmtime-13.0.0 # Used in Flatcar wasm OS demo
-wasmtime-17.0.1 # Used in README.md. Update readme when version changes.
-wasmtime-18.0.1
+wasmtime-24.0.0 # Used in README.md. Update readme when version changes.
 
 wasmcloud-0.82.0
 wasmcloud-1.0.0


### PR DESCRIPTION
This also updates the README to use the latest version.

## How to use

As far as I remember we need to create a new `latest` release after merging.

## Testing done

Built the new version locally and tested it on my Debian environment.