### PR TITLE
Bump wasmcloud to 1.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,9 +212,9 @@ variant: flatcar
 version: 1.0.0
 storage:
   files:
-    - path: /opt/extensions/wasmcloud/wasmcloud-1.1.1-x86-64.raw
+    - path: /opt/extensions/wasmcloud/wasmcloud-1.2.1-x86-64.raw
       contents:
-        source: https://github.com/flatcar/sysext-bakery/releases/download/latest/wasmcloud-1.1.1-x86-64.raw
+        source: https://github.com/flatcar/sysext-bakery/releases/download/latest/wasmcloud-1.2.1-x86-64.raw
     - path: /etc/sysupdate.d/noop.conf
       contents:
         source: https://github.com/flatcar/sysext-bakery/releases/download/latest/noop.conf
@@ -240,7 +240,7 @@ storage:
         inline: |
           <redacted>
   links:
-    - target: /opt/extensions/wasmcloud/wasmcloud-1.1.1-x86-64.raw
+    - target: /opt/extensions/wasmcloud/wasmcloud-1.2.1-x86-64.raw
       path: /etc/extensions/wasmcloud.raw
       hard: false
 systemd:

--- a/release_build_versions.txt
+++ b/release_build_versions.txt
@@ -17,9 +17,9 @@ wasmtime-12.0.0
 wasmtime-13.0.0 # Used in Flatcar wasm OS demo
 wasmtime-24.0.0 # Used in README.md. Update readme when version changes.
 
-wasmcloud-0.82.0
 wasmcloud-1.0.0
 wasmcloud-1.1.1
+wasmcloud-1.2.1
 
 tailscale-1.70.0
 


### PR DESCRIPTION
# Update wasmCloud to 1.2.1

This brings wasmCloud up to date with the latest release, [v1.2.1](https://github.com/wasmCloud/wasmCloud/releases/tag/v1.2.1).

It also removes `v0.82.0`, because realistically no-one should be using that as it is not really supported or compatible with the latest the `v1.x` line of wasmCloud releases.

## How to use

Once the image is built, you can employ the following configuration ignition configuration (replacing with the appropriate value) to consume it as outlined in the updated README.

## Testing done

I've built and deployed this on to a DigitalOcean Droplet to validate that it works as expected:

```shell
Flatcar Container Linux by Kinvolk stable 3975.2.1 for DigitalOcean
core@flatcar-sysext-01 ~ $ wasmcloud --version
wasmcloud 1.2.1
```

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
