### PR TITLE
Bump nvidia-runtime version to v1.16.2

### DIFF
--- a/release_build_versions.txt
+++ b/release_build_versions.txt
@@ -27,6 +27,6 @@ k3s-v1.29.2+k3s1
 
 rke2-v1.29.2+rke2r1
 
-nvidia_runtime-v1.16.1
+nvidia_runtime-v1.16.2
 
 ollama-0.3.9


### PR DESCRIPTION
v1.16.1 is affected by CVE-2024-0132 and CVE-2024-0133. See [1].

[1]: https://nvidia.custhelp.com/app/answers/detail/a_id/5582/~/security-bulletin%3A-nvidia-container-toolkit---september-2024