### PR TITLE
Rework sysext release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: build release artifacts
         run: |
           pushd bakery
-          ./release_build.sh
+          REPO=${{ github.repository }} ./release_build.sh
 
       - name: delete previous latest release
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,6 +3,7 @@ on:
   push:
     tags:
       - 'latest'
+      - '[0-9]+'
 jobs:
   build:
     runs-on: ubuntu-22.04
@@ -38,18 +39,36 @@ jobs:
           pushd bakery
           REPO=${{ github.repository }} ./release_build.sh
 
-      - name: delete previous latest release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          pushd bakery
-          gh release delete latest --cleanup-tag
-
-      - name: create a new latest release with all artifacts
-        uses: softprops/action-gh-release@v1
+      - name: create a new latest release with some artifacts
+        uses: softprops/action-gh-release@v2
         with:
+          make_latest: true
           body_path: bakery/Release.md
           files: |
             bakery/SHA256SUMS
-            bakery/*.raw
+            bakery/!(kubernetes|crio|ollama)*.raw
             bakery/*.conf
+
+      - name: upload kubernetes x86-64 artifacts
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            bakery/kubernetes*-x86-64.raw
+
+      - name: upload kubernetes arm64 artifacts
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            bakery/kubernetes*-arm64.raw
+
+      - name: upload crio artifacts
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            bakery/crio*.raw
+
+      - name: upload ollama artifacts
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            bakery/ollama*.raw

--- a/bake_flatcar_image.sh
+++ b/bake_flatcar_image.sh
@@ -16,7 +16,7 @@ install_to="root:/opt/extensions/"
 
 set -euo pipefail
 workdir="$(pwd)/flatcar-os-image"
-bakery_base_url="https://github.com/flatcar/sysext-bakery/releases/download/latest"
+bakery_base_url="https://github.com/flatcar/sysext-bakery/releases/latest/download"
 
 # ./run_sdk_container ./image_to_vm.sh --help 2>&1 | grep '\--format'
 supported_vendors=( "ami" "ami_vmdk" "azure" "cloudsigma" "cloudstack" "cloudstack_vhd" "digitalocean" "exoscale" "gce" "hyperv" "iso" "openstack" "openstack_mini" "packet" "parallels" "pxe" "qemu" "qemu_uefi" "qemu_uefi_secure" "rackspace" "rackspace_onmetal" "rackspace_vhd" "vagrant" "vagrant_parallels" "vagrant_virtualbox" "vagrant_vmware_fusion" "virtualbox" "vmware" "vmware_insecure" "vmware_ova" "vmware_raw" "xen" )

--- a/release_build.sh
+++ b/release_build.sh
@@ -8,6 +8,7 @@
 
 set -euo pipefail
 
+: ${REPO:=flatcar/sysext-bakery}
 
 echo
 echo "Fetching list of latest Kubernetes minor releases"
@@ -48,7 +49,7 @@ echo "Fetching previous 'latest' release sysexts"
 echo "=========================================="
 curl -fsSL --retry-delay 1 --retry 60 --retry-connrefused \
          --retry-max-time 60 --connect-timeout 20  \
-         https://api.github.com/repos/flatcar/sysext-bakery/releases/latest \
+         https://api.github.com/repos/"${REPO}"/releases/latest \
     | jq -r '.assets[] | "\(.name)\t\(.browser_download_url)"' | { grep -E '\.raw$' || true; } | tee prev_release_sysexts.txt
 
 while IFS=$'\t' read -r name url; do


### PR DESCRIPTION
Fix issues we have had with sysext releases. Previously upload failure would cause us to lose release assets, because the release gets deleted before upload.