### PR TITLE
bake: fix mksquashfs version check

### DIFF
--- a/bake.sh
+++ b/bake.sh
@@ -38,6 +38,10 @@ elif [ "${ARCH}" = "aarch64" ]; then
   ARCH="arm64"
 fi
 
+function version_ge() {
+    test "$(printf '%s\n' "$@" | sort -rV | head -n 1)" == "$1";
+}
+
 mkdir -p "${SYSEXTNAME}/usr/lib/extension-release.d"
 {
   echo "ID=${OS}"
@@ -64,10 +68,9 @@ elif [ "${FORMAT}" = "ext4" ] || [ "${FORMAT}" = "ext2" ]; then
   resize2fs -M "${SYSEXTNAME}".raw
 else
   VER=$({ mksquashfs -version || true ; } | head -n1 | cut -d " " -f 3)
-  VERMAJ=$(echo "${VER}" | cut -d . -f 1)
-  VERMIN=$(echo "${VER}" | cut -d . -f 2)
   ARG=(-all-root -noappend)
-  if [[ "${VERMAJ}" -gt 4 || ( "${VERMAJ}" -eq 4 && "${VERMIN}" -gt 5 ) ]]; then
+  # use sort semver to check if current version is >= 4.6.1
+  if version_ge "$VER" "4.6.1"; then
     ARG+=('-xattrs-exclude' '^btrfs.')
   fi
   mksquashfs "${SYSEXTNAME}" "${SYSEXTNAME}".raw "${ARG[@]}"

--- a/bake.sh
+++ b/bake.sh
@@ -67,7 +67,7 @@ else
   VERMAJ=$(echo "${VER}" | cut -d . -f 1)
   VERMIN=$(echo "${VER}" | cut -d . -f 2)
   ARG=(-all-root -noappend)
-  if [ "${VERMAJ}" -gt 4 ] && [ "${VERMIN}" -gt 6 ]; then
+  if [[ "${VERMAJ}" -gt 4 || ( "${VERMAJ}" -eq 4 && "${VERMIN}" -gt 5 ) ]]; then
     ARG+=('-xattrs-exclude' '^btrfs.')
   fi
   mksquashfs "${SYSEXTNAME}" "${SYSEXTNAME}".raw "${ARG[@]}"


### PR DESCRIPTION
The mksquashfs version that supports the xattrs-exclude flag is 4.6.1, but the logic excluded the version because of a strict (greater than) comparison.

See: https://github.com/flatcar/sysext-bakery/pull/60/commits/d1419fc1254f9723a3614811bdd29f9d6a3bba9d

## Testing done

[Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got.]

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
