### PR TITLE
Update tailscale to latest (1.76.6)

### DIFF
--- a/release_build_versions.txt
+++ b/release_build_versions.txt
@@ -23,7 +23,7 @@ wasmcloud-1.0.0
 wasmcloud-1.1.1
 wasmcloud-1.2.1
 
-tailscale-1.70.0
+tailscale-1.76.6
 
 nvidia_runtime-v1.16.2
 


### PR DESCRIPTION


# Update tailscale to latest (1.76.6)

Tailscale v1.76.0 fixes Tailscale SSH breaking on some terminals when resizing the application window. 1.74.0 also makes use of GRO. This updates tailscale to the latest version (with those fixes and others).

## How to use

Update to latest version and profit.

## Testing done

Run tailscale 1.76.6 on other OSes in the same tailnet.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

