### PR TITLE
sysext: add wasmedge recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ For extensions that are not part of the GitHub Release or which you want to cust
 | `rke2` | released |
 | `keepalived` | build script |
 | `ollama` | released |
+| `wasmedge` | released |
 
 
 ### Consuming the published images
@@ -439,6 +440,25 @@ systemd:
 Note that this configuration can be customized in terms of where Ollama is configured to store its models, configuration and runtime libraries by changing the `HOME`, `OLLAMA_MODELS` and `OLLAMA_RUNNERS_DIR`.
 
 Please refer to the [Ollama documentation for further details](https://github.com/ollama/ollama/tree/main/docs).
+
+#### WasmEdge
+
+The wasmedge sysext can be configured by using the following snippet:
+
+```
+variant: flatcar
+version: 1.0.0
+storage:
+  files:
+    - path: /opt/extensions/wasmedge-0.14.1-x86-64.raw
+      mode: 0420
+      contents:
+        source: https://github.com/flatcar/sysext-bakery/releases/download/wasmedge-0.14.1-x86-64.raw
+  links:
+    - target: /opt/extensions/wasmedge-0.14.1-x86-64.raw
+      path: /etc/extensions/wasmedge.raw
+      hard: false
+```
 
 ### Building sysext images
 

--- a/create_wasmedge_sysext.sh
+++ b/create_wasmedge_sysext.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export ARCH="${ARCH-x86-64}"
+SCRIPTFOLDER="$(dirname "$(readlink -f "$0")")"
+
+if [ $# -lt 2 ] || [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
+  echo "Usage: $0 VERSION SYSEXTNAME"
+  echo "The script will download the WasmEdge release tar ball (e.g., for 0.14.1) and create a sysext squashfs image with the name SYSEXTNAME.raw in the current folder."
+  echo "A temporary directory named SYSEXTNAME in the current folder will be created and deleted again."
+  echo "All files in the sysext image will be owned by root."
+  echo "To use arm64 pass 'ARCH=arm64' as environment variable (current value is '${ARCH}')."
+  "${SCRIPTFOLDER}"/bake.sh --help
+  exit 1
+fi
+
+VERSION="$1"
+SYSEXTNAME="$2"
+
+# The github release uses different arch identifiers, we map them here
+# and rely on bake.sh to map them back to what systemd expects
+if [ "${ARCH}" = "amd64" ] || [ "${ARCH}" = "x86-64" ]; then
+  ARCH="x86_64"
+elif [ "${ARCH}" = "arm64" ]; then
+  ARCH="aarch64"
+fi
+
+rm -f "WasmEdge-${VERSION}.tar.gz"
+curl -o "WasmEdge-${VERSION}.tar.gz" -fsSL "https://github.com/WasmEdge/WasmEdge/releases/download/${VERSION}/WasmEdge-${VERSION}-ubuntu20.04_${ARCH}.tar.gz"
+rm -rf "${SYSEXTNAME}"
+mkdir -p "${SYSEXTNAME}"
+tar --force-local -xvf "WasmEdge-${VERSION}.tar.gz" -C "${SYSEXTNAME}"
+rm "WasmEdge-${VERSION}.tar.gz"
+mkdir -p "${SYSEXTNAME}"/usr/bin
+mkdir -p "${SYSEXTNAME}"/usr/lib # for .so files
+mv "${SYSEXTNAME}"/"WasmEdge-${VERSION}-Linux"/bin/wasmedge "${SYSEXTNAME}"/usr/bin/
+mv "${SYSEXTNAME}"/"WasmEdge-${VERSION}-Linux"/lib/* "${SYSEXTNAME}"/usr/lib/
+rm -r "${SYSEXTNAME}"/"WasmEdge-${VERSION}-Linux"
+"${SCRIPTFOLDER}"/bake.sh "${SYSEXTNAME}"
+rm -rf "${SYSEXTNAME}"

--- a/release_build_versions.txt
+++ b/release_build_versions.txt
@@ -30,3 +30,5 @@ nvidia_runtime-v1.16.2
 ollama-0.3.9
 
 containerd-2.0.0
+
+wasmedge-0.14.1


### PR DESCRIPTION
# Add WasmEdge sysext

This PR creates a sysext for running [WasmEdge](https://github.com/WasmEdge/WasmEdge/) on Flatcar.

## How to use

Run `create_wasmedge_sysext.sh` for building the `.raw` file.

Then, use the following config:

```yaml
variant: flatcar
version: 1.0.0
storage:
  files:
    - path: /opt/extensions/wasmedge-0.14.1-x86-64.raw
      mode: 0420
      contents:
        source: https://github.com/flatcar/sysext-bakery/releases/download/wasmedge-0.14.1-x86-64.raw
  links:
    - target: /opt/extensions/wasmedge-0.14.1-x86-64.raw
      path: /etc/extensions/wasmedge.raw
      hard: false
```

## Testing done

I deployed an instance with Flatcar-Stable-4081.2.0 on DigitalOcean. You can provide any wasm file to verify it. I just used a very simple wasm that adds two numbers.

```bash
Last login: Tue Nov 26 04:32:52 UTC 2024 from 60.248.109.122 on ssh
Flatcar Container Linux by Kinvolk stable 4081.2.0 for DigitalOcean
core@core-3 ~ $ wasmedge --reactor /tmp/add.wasm add 1 3
4
```

Note:

For testing, I used the following template:

```yaml
variant: flatcar
version: 1.0.0
storage:
  files:
    - path: /opt/extensions/wasmedge-0.14.1-x86-64.raw
      mode: 0420
      contents:
        source: https://github.com/second-state/flatcar-sysext-bakery/releases/download/0.0.1/wasmedge-0.14.1-x86-64.raw
  links:
    - target: /opt/extensions/wasmedge-0.14.1-x86-64.raw
      path: /etc/extensions/wasmedge.raw
      hard: false
```