### PR TITLE
versions: add old kubernetes for CAPG CI

### DIFF
--- a/release_build_versions.txt
+++ b/release_build_versions.txt
@@ -4,6 +4,7 @@
 # The below lists _additional_ kubernetes versions to be built.
 
 kubernetes-v1.28.5 # required for CAPO CI
+kubernetes-v1.27.3 # required for CAPG CI
 
 
 


### PR DESCRIPTION
CAPG (Cluster API GCP) uses an old and outdated Kubernetes version in the CI. Let's match it to have Flatcar CI tests working.

Related to: https://github.com/kubernetes-sigs/cluster-api-provider-gcp/pull/1378 