### PR TITLE
Fix tailscale

### DIFF
--- a/create_tailscale_sysext.sh
+++ b/create_tailscale_sysext.sh
@@ -34,13 +34,16 @@ curl -o "${TMP_DIR}/${TARBALL}" -fsSL "${URL}"
 
 tar xf "${TMP_DIR}/${TARBALL}" -C "${TMP_DIR}" --strip-components=1
 
-mkdir -p "${SYSEXTNAME}"/usr/local/{bin,sbin,lib/{systemd/system,extension-release.d}}
+mkdir -p "${SYSEXTNAME}"/usr/{bin,sbin,lib/{systemd/system,extension-release.d,tmpfiles.d},share/tailscale}
 
-mv "${TMP_DIR}/tailscale" "${SYSEXTNAME}/usr/local/bin/tailscale"
-mv "${TMP_DIR}/tailscaled" "${SYSEXTNAME}/usr/local/sbin/tailscaled"
-mv "${TMP_DIR}/systemd/tailscaled.service" "${SYSEXTNAME}/usr/local/lib/systemd/system/tailscaled.service"
+mv "${TMP_DIR}/tailscale" "${SYSEXTNAME}/usr/bin/tailscale"
+mv "${TMP_DIR}/tailscaled" "${SYSEXTNAME}/usr/sbin/tailscaled"
+mv "${TMP_DIR}/systemd/tailscaled.service" "${SYSEXTNAME}/usr/lib/systemd/system/tailscaled.service"
+mv "${TMP_DIR}/systemd/tailscaled.defaults" "${SYSEXTNAME}/usr/share/tailscale/tailscaled.defaults"
 
-sed -i 's/--port.*//g' "${SYSEXTNAME}/usr/local/lib/systemd/system/tailscaled.service"
+cat <<EOF >"${SYSEXTNAME}"/usr/lib/tmpfiles.d/10-tailscale.conf
+C /etc/default/tailscaled - - - - /usr/share/tailscale/tailscaled.defaults
+EOF
 
 rm -rf "${TMP_DIR}"
 

--- a/create_tailscale_sysext.sh
+++ b/create_tailscale_sysext.sh
@@ -34,19 +34,12 @@ curl -o "${TMP_DIR}/${TARBALL}" -fsSL "${URL}"
 
 tar xf "${TMP_DIR}/${TARBALL}" -C "${TMP_DIR}" --strip-components=1
 
-mkdir -p "${SYSEXTNAME}"/usr/{bin,sbin,lib/{systemd/system/tailscaled.service.d,systemd/network,extension-release.d,tmpfiles.d},share/tailscale}
+mkdir -p "${SYSEXTNAME}"/usr/{bin,sbin,lib/{systemd/system,systemd/network,extension-release.d,tmpfiles.d},share/tailscale}
 
 mv "${TMP_DIR}/tailscale" "${SYSEXTNAME}/usr/bin/tailscale"
 mv "${TMP_DIR}/tailscaled" "${SYSEXTNAME}/usr/sbin/tailscaled"
 mv "${TMP_DIR}/systemd/tailscaled.service" "${SYSEXTNAME}/usr/lib/systemd/system/tailscaled.service"
 mv "${TMP_DIR}/systemd/tailscaled.defaults" "${SYSEXTNAME}/usr/share/tailscale/tailscaled.defaults"
-
-cat <<EOF >"${SYSEXTNAME}"/usr/lib/systemd/system/tailscaled.service.d/10-networkd-reload.conf
-# Reload systemd-networkd.service to pick up 50-tailscale.network
-
-[Service]
-ExecStartPre=systemctl reload systemd-networkd.service
-EOF
 
 cat <<EOF >"${SYSEXTNAME}"/usr/lib/tmpfiles.d/10-tailscale.conf
 C /etc/default/tailscaled - - - - /usr/share/tailscale/tailscaled.defaults

--- a/create_tailscale_sysext.sh
+++ b/create_tailscale_sysext.sh
@@ -34,15 +34,31 @@ curl -o "${TMP_DIR}/${TARBALL}" -fsSL "${URL}"
 
 tar xf "${TMP_DIR}/${TARBALL}" -C "${TMP_DIR}" --strip-components=1
 
-mkdir -p "${SYSEXTNAME}"/usr/{bin,sbin,lib/{systemd/system,extension-release.d,tmpfiles.d},share/tailscale}
+mkdir -p "${SYSEXTNAME}"/usr/{bin,sbin,lib/{systemd/system/tailscaled.service.d,systemd/network,extension-release.d,tmpfiles.d},share/tailscale}
 
 mv "${TMP_DIR}/tailscale" "${SYSEXTNAME}/usr/bin/tailscale"
 mv "${TMP_DIR}/tailscaled" "${SYSEXTNAME}/usr/sbin/tailscaled"
 mv "${TMP_DIR}/systemd/tailscaled.service" "${SYSEXTNAME}/usr/lib/systemd/system/tailscaled.service"
 mv "${TMP_DIR}/systemd/tailscaled.defaults" "${SYSEXTNAME}/usr/share/tailscale/tailscaled.defaults"
 
+cat <<EOF >"${SYSEXTNAME}"/usr/lib/systemd/system/tailscaled.service.d/10-networkd-reload.conf
+# Reload systemd-networkd.service to pick up 50-tailscale.network
+
+[Service]
+ExecStartPre=systemctl reload systemd-networkd.service
+EOF
+
 cat <<EOF >"${SYSEXTNAME}"/usr/lib/tmpfiles.d/10-tailscale.conf
 C /etc/default/tailscaled - - - - /usr/share/tailscale/tailscaled.defaults
+EOF
+
+cat <<EOF >"${SYSEXTNAME}"/usr/lib/systemd/network/50-tailscale.network
+[Match]
+Kind=tun
+Name=tailscale*
+
+[Link]
+Unmanaged=yes
 EOF
 
 rm -rf "${TMP_DIR}"

--- a/release_build_versions.txt
+++ b/release_build_versions.txt
@@ -23,7 +23,7 @@ wasmcloud-1.0.0
 wasmcloud-1.1.1
 wasmcloud-1.2.1
 
-tailscale-1.76.6
+tailscale-1.78.1
 
 nvidia_runtime-v1.16.2
 


### PR DESCRIPTION
# Fix tailscale sysext so the service can start by default

The tailscale sysext had a number of issues as described in #105. Specifically:
- The binaries were placed in a different directory than the vendor supplied systemd service expected
- There was no `EnvironmentFile`, so service could not start up
- `networkd` was managing the `tailscale0` service so Tailscale couldn't enable `MagicDNS`.

## How to use

1. Build the sysext: `./create_tailscale_sysext.sh 1.76.6 tailscale` and `scp` to a running Flatcar machine without the `tailscale` sysext already configured. `ssh` into the Flatcar machine.
2. Ensure `systemctl status tailscaled.service` does not exist
3. `mv /path/to/tailscale.raw /etc/extensions/tailscale.raw`
4. `systemd-sysext refresh`
5. Ensure `systemctl status tailscaled.service` now exists
6. `systemctl start tailscaled.service`
7. Ensure `networkctl list` shows `tailscale0` as `unmanaged` (note, the state will show as `degraded` until you `tailscale up` which isn't needed for this test).

## Testing done

- [x] Ran the above tests
- [x] Ran `flatcar-reset` with an Ignition config that fetched the `tailscale.raw` from an S3 bucket, and checked starting service / checked interface unmanaged / etc...


Closes: https://github.com/flatcar/sysext-bakery/issues/105
