### PR TITLE
README, docs/: overhaul the bakery documentation

### DIFF
--- a/docs/containerd.md
+++ b/docs/containerd.md
@@ -1,0 +1,55 @@
+# Containerd sysext
+
+This sysext ships a custom [containerd](https://github.com/containerd/containerd).
+It can be used to diverge from the containerd included in Flatcar's OS image, e.g. to upgrade or downgrade manually, or to test a newer version than what's included in the stock OS image.
+
+The sysext includes a service unit file to start containerd at boot as well as a basic `containerd.toml` configuration.
+
+## Usage
+
+Download and merge the sysext at provisioning time using the below butane snippet.
+It deactivates the default containerd included in the Flatcar OS image by masking the respective sysext.
+
+The snippet includes automated updates via systemd-sysupdate.
+Sysupdate will stage updates and request a reboot by creating a flag file at `/run/reboot-required`.
+You can deactivate updates by changing `enabled: true` to `enabled: false` in `systemd-sysupdate.timer`.
+
+Note that the snippet is for the x86-64 version of containerd 2.0.0.
+
+```yaml
+variant: flatcar
+version: 1.0.0
+
+storage:
+  files:
+    - path: /opt/extensions/containerd/containerd-2.0.0-x86-64.raw
+      mode: 0644
+      contents:
+        source: https://github.com/flatcar/sysext-bakery/releases/download/latest/containerd-2.0.0-x86-64.raw
+    - path: /etc/sysupdate.containerd.d/containerd.conf
+      contents:
+        source: https://github.com/flatcar/sysext-bakery/releases/download/latest/containerd.conf
+    - path: /etc/sysupdate.d/noop.conf
+      contents:
+        source: https://github.com/flatcar/sysext-bakery/releases/download/latest/noop.conf
+  links:
+    - target: /opt/extensions/containerd/containerd-2.0.0-x86-64.raw
+      path: /etc/extensions/containerd.raw
+      hard: false
+    - path: /etc/extensions/containerd-flatcar.raw
+      target: /dev/null
+      overwrite: true
+systemd:
+  units:
+    - name: systemd-sysupdate.timer
+      enabled: true
+    - name: systemd-sysupdate.service
+      dropins:
+        - name: containerd.conf
+          contents: |
+            [Service]
+            ExecStartPre=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/containerd.raw > /tmp/containerd"
+            ExecStartPre=/usr/lib/systemd/systemd-sysupdate -C containerd update
+            ExecStartPost=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/containerd.raw > /tmp/containerd-new"
+            ExecStartPost=/usr/bin/sh -c "if ! cmp --silent /tmp/containerd /tmp/containerd-new; then touch /run/reboot-required; fi"
+```

--- a/docs/crio.md
+++ b/docs/crio.md
@@ -1,0 +1,55 @@
+# CRI-O sysext
+
+This sysext ships [cri-o](https://github.com/cri-o/cri-o).
+
+The sysext includes a service unit file to start cri-o at boot as well as a basic configuration.
+
+To use Kubernetes with cri-o in flatcar, you will need to pass the criSocket to kubeadm, like e.g.
+```
+kubeadm init --pod-network-cidr=10.244.0.0/16 --kubernetes-version v1.29.2 --cri-socket=unix:///var/run/crio/crio.sock
+```
+
+## Usage
+
+Download and merge the sysext at provisioning time using the below butane snippet.
+
+The snippet includes automated updates via systemd-sysupdate.
+Sysupdate will stage updates and request a reboot by creating a flag file at `/run/reboot-required`.
+You can deactivate updates by changing `enabled: true` to `enabled: false` in `systemd-sysupdate.timer`.
+
+Note that the snippet is for the x86-64 version of cri-o v1.31.3.
+
+```yaml
+variant: flatcar
+version: 1.0.0
+
+storage:
+  files:
+    - path: /opt/extensions/crio/crio-v1.31.3-x86-64.raw
+      mode: 0644
+      contents:
+        source: https://github.com/flatcar/sysext-bakery/releases/download/latest/crio-v1.31.3-x86-64.raw
+    - path: /etc/sysupdate.crio.d/crio.conf
+      contents:
+        source: https://github.com/flatcar/sysext-bakery/releases/download/latest/crio.conf
+    - path: /etc/sysupdate.d/noop.conf
+      contents:
+        source: https://github.com/flatcar/sysext-bakery/releases/download/latest/noop.conf
+  links:
+    - target: /opt/extensions/crio/crio-v1.31.3-x86-64.raw
+      path: /etc/extensions/crio.raw
+      hard: false
+systemd:
+  units:
+    - name: systemd-sysupdate.timer
+      enabled: true
+    - name: systemd-sysupdate.service
+      dropins:
+        - name: crio.conf
+          contents: |
+            [Service]
+            ExecStartPre=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/crio.raw > /tmp/crio"
+            ExecStartPre=/usr/lib/systemd/systemd-sysupdate -C crio update
+            ExecStartPost=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/crio.raw > /tmp/crio-new"
+            ExecStartPost=/usr/bin/sh -c "if ! cmp --silent /tmp/crio /tmp/crio-new; then touch /run/reboot-required; fi"
+```

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,0 +1,60 @@
+# Docker sysext
+
+This sysext ships a custom [docker](https://docker.com)
+The docker sysext comes with containerd and runc as bundled by upstream in https://download.docker.com/linux/static/stable/x86_64/.
+It can be used to diverge from the docker included in Flatcar's OS image, e.g. to upgrade or downgrade manually, or to test a newer version than what's included in the stock OS image.
+
+The sysext includes a service unit file to start containerd at boot and the docker daemon via socket activation, as well as basic configuration.
+
+## Usage
+
+Download and merge the sysext at provisioning time using the below butane snippet.
+It deactivates the default containerd and docker included in the Flatcar OS image by masking the respective sysexts.
+
+The snippet includes automated updates via systemd-sysupdate.
+Sysupdate will stage updates and request a reboot by creating a flag file at `/run/reboot-required`.
+You can deactivate updates by changing `enabled: true` to `enabled: false` in `systemd-sysupdate.timer`.
+
+Note that the snippet is for the x86-64 version of docker 25.0.3.
+
+```yaml
+variant: flatcar
+version: 1.0.0
+
+storage:
+  files:
+    - path: /opt/extensions/docker/docker-25.0.3-x86-64.raw
+      mode: 0644
+      contents:
+        source: https://github.com/flatcar/sysext-bakery/releases/download/latest/docker-25.0.3-x86-64.raw
+    - path: /etc/sysupdate.docker.d/docker.conf
+      contents:
+        source: https://github.com/flatcar/sysext-bakery/releases/download/latest/docker.conf
+    - path: /etc/sysupdate.d/noop.conf
+      contents:
+        source: https://github.com/flatcar/sysext-bakery/releases/download/latest/noop.conf
+  links:
+    - target: /opt/extensions/docker/docker-25.0.3-x86-64.raw
+      path: /etc/extensions/docker.raw
+      hard: false
+    - path: /etc/extensions/docker-flatcar.raw
+      target: /dev/null
+      overwrite: true
+    - path: /etc/extensions/containerd-flatcar.raw
+      target: /dev/null
+      overwrite: true
+systemd:
+  units:
+    - name: systemd-sysupdate.timer
+      enabled: true
+    - name: systemd-sysupdate.service
+      dropins:
+        - name: docker.conf
+          contents: |
+            [Service]
+            ExecStartPre=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/docker.raw > /tmp/docker"
+            ExecStartPre=/usr/lib/systemd/systemd-sysupdate -C docker update
+            ExecStartPost=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/docker.raw > /tmp/docker-new"
+            ExecStartPost=/usr/bin/sh -c "if ! cmp --silent /tmp/docker /tmp/docker-new; then touch /run/reboot-required; fi"
+```
+

--- a/docs/docker_compose.md
+++ b/docs/docker_compose.md
@@ -1,0 +1,49 @@
+# Docker-compose sysext
+
+This sysext ships [docker-compose](https://github.com/docker/compose).
+
+## Usage
+
+Download and merge the sysext at provisioning time using the below butane snippet.
+
+The snippet includes automated updates via systemd-sysupdate.
+Sysupdate will stage updates and request a reboot by creating a flag file at `/run/reboot-required`.
+You can deactivate updates by changing `enabled: true` to `enabled: false` in `systemd-sysupdate.timer`.
+
+Note that the snippet is for the x86-64 version of docker-compose 2.24.5.
+
+```yaml
+variant: flatcar
+version: 1.0.0
+
+storage:
+  files:
+    - path: /opt/extensions/docker-compose/docker-compose-2.24.5-x86-64.raw
+      mode: 0644
+      contents:
+        source: https://github.com/flatcar/sysext-bakery/releases/download/latest/docker-compose-2.24.5-x86-64.raw
+    - path: /etc/sysupdate.docker-compose.d/docker-compose.conf
+      contents:
+        source: https://github.com/flatcar/sysext-bakery/releases/download/latest/docker-compose.conf
+    - path: /etc/sysupdate.d/noop.conf
+      contents:
+        source: https://github.com/flatcar/sysext-bakery/releases/download/latest/noop.conf
+  links:
+    - target: /opt/extensions/docker-compose/docker-compose-2.24.5-x86-64.raw
+      path: /etc/extensions/docker-compose.raw
+      hard: false
+systemd:
+  units:
+    - name: systemd-sysupdate.timer
+      enabled: true
+    - name: systemd-sysupdate.service
+      dropins:
+        - name: docker-compose.conf
+          contents: |
+            [Service]
+            ExecStartPre=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/docker-compose.raw > /tmp/docker-compose"
+            ExecStartPre=/usr/lib/systemd/systemd-sysupdate -C docker-compose update
+            ExecStartPost=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/docker-compose.raw > /tmp/docker-compose-new"
+            ExecStartPost=/usr/bin/sh -c "if ! cmp --silent /tmp/docker-compose /tmp/docker-compose-new; then touch /run/reboot-required; fi"
+```
+

--- a/docs/falco.md
+++ b/docs/falco.md
@@ -1,0 +1,64 @@
+# Falco sysext
+
+This sysext ships [falco](https://falco.org).
+It includes the [Falco Modern EBPF](https://github.com/falcosecurity/falco/blob/master/scripts/systemd/falco-modern-bpf.service).
+Create systemd drop-ins in the below example config or replace the service to suit your needs if necessary. 
+
+The default falco config and rules files are included.
+If you need to ship custom configuration - e.g. SysDig's Falco workshop rules - add the following to your butane config:
+```yaml
+storage:
+  files:
+    - path: /etc/falco/falco_rules.local.yaml
+      contents:
+        source: "https://raw.githubusercontent.com/sysdiglabs/falco-workshop/refs/heads/master/falco_rules.local.yaml"
+```
+
+Of course its also possible to use the 
+[artifact-follower](https://falco.org/blog/falcoctl-install-manage-rules-plugins/#follow-artifacts) to download falco artifacts automatically.
+
+## Usage
+
+Download and merge the sysext at provisioning time using the below butane snippet.
+
+The snippet includes automated updates via systemd-sysupdate.
+Sysupdate will stage updates and request a reboot by creating a flag file at `/run/reboot-required`.
+You can deactivate updates by changing `enabled: true` to `enabled: false` in `systemd-sysupdate.timer`.
+
+Note that the snippet is for the x86-64 version of falco 0.39.1.
+
+```yaml
+variant: flatcar
+version: 1.0.0
+
+storage:
+  files:
+    - path: /opt/extensions/falco/falco-0.39.1-x86-64.raw
+      mode: 0644
+      contents:
+        source: https://github.com/flatcar/sysext-bakery/releases/download/latest/falco-0.39.1-x86-64.raw
+    - path: /etc/sysupdate.falco.d/falco.conf
+      contents:
+        source: https://github.com/flatcar/sysext-bakery/releases/download/latest/falco.conf
+    - path: /etc/sysupdate.d/noop.conf
+      contents:
+        source: https://github.com/flatcar/sysext-bakery/releases/download/latest/noop.conf
+  links:
+    - target: /opt/extensions/falco/falco-0.39.1-x86-64.raw
+      path: /etc/extensions/falco.raw
+      hard: false
+systemd:
+  units:
+    - name: systemd-sysupdate.timer
+      enabled: true
+    - name: systemd-sysupdate.service
+      dropins:
+        - name: falco.conf
+          contents: |
+            [Service]
+            ExecStartPre=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/falco.raw > /tmp/falco"
+            ExecStartPre=/usr/lib/systemd/systemd-sysupdate -C falco update
+            ExecStartPost=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/falco.raw > /tmp/falco-new"
+            ExecStartPost=/usr/bin/sh -c "if ! cmp --silent /tmp/falco /tmp/falco-new; then touch /run/reboot-required; fi"
+```
+

--- a/docs/k3s.md
+++ b/docs/k3s.md
@@ -1,0 +1,77 @@
+# K3s sysext
+
+This extension ships [k3s](https://k3s.io/).
+
+The k3s sysext can be configured as an agent or a server.
+This is determined by the systemd service unit started at boot, so the sysext does not include a default service unit.
+Instead, we symlink the respective unit file in the butane config.
+
+## Usage
+
+Download and merge the sysext at provisioning time using the below butane snippet.
+
+The snippet includes automated updates via systemd-sysupdate.
+Sysupdate will stage updates and request a reboot by creating a flag file at `/run/reboot-required`.
+You can deactivate updates by changing `enabled: true` to `enabled: false` in `systemd-sysupdate.timer`.
+Updates are only supported within the same minor release, e.g. v1.31.2 -> v1.31.3; _never_ across releases (v1.31.x -> v1.32.x).
+This is because upstream Kubernetes does not support unattended automated upgrades across minor releases.
+
+Note that the snippet is for the x86-64 version of k3s v1.31.3 w/ k3s1.
+
+Any specific configuration required would need to be added to the below configuration,
+e.g. by providing a token for an agent or server to join or creating a `config.yaml` file.
+
+Generic configuration for both Server (control plane) and Agent (worker):
+```yaml
+variant: flatcar
+version: 1.0.0
+
+storage:
+  files:
+    - path: /opt/extensions/k3s/k3s-v1.31.3+k3s1-x86-64.raw
+      mode: 0644
+      contents:
+        source: https://github.com/flatcar/sysext-bakery/releases/download/latest/k3s-v1.31.3+k3s1-x86-64.raw
+    - path: /etc/sysupdate.k3s.d/k3s-v1.31.conf
+      contents:
+        source: https://github.com/flatcar/sysext-bakery/releases/download/latest/k3s.conf
+    - path: /etc/sysupdate.d/noop.conf
+      contents:
+        source: https://github.com/flatcar/sysext-bakery/releases/download/latest/noop.conf
+  links:
+    - target: /opt/extensions/k3s/k3s-v1.31.3+k3s1-x86-64.raw
+      path: /etc/extensions/k3s.raw
+      hard: false
+systemd:
+  units:
+    - name: systemd-sysupdate.timer
+      enabled: true
+    - name: systemd-sysupdate.service
+      dropins:
+        - name: k3s.conf
+          contents: |
+            [Service]
+            ExecStartPre=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/k3s.raw > /tmp/k3s"
+            ExecStartPre=/usr/lib/systemd/systemd-sysupdate -C k3s-v1.31 update
+            ExecStartPost=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/k3s.raw > /tmp/k3s-new"
+            ExecStartPost=/usr/bin/sh -c "if ! cmp --silent /tmp/k3s /tmp/k3s-new; then touch /run/reboot-required; fi"
+```
+
+For the *server* node, add to the section
+```yaml
+storage:
+  links:
+```
+the following:
+```yaml
+    - path: /etc/systemd/system/multi-user.target.wants/k3s.service
+      target: /usr/local/lib/systemd/system/k3s.service
+      overwrite: true
+```
+
+For a k3s agent (worker node) add this instead:
+```yaml
+    - path: /etc/systemd/system/multi-user.target.wants/k3s-agent.service
+      target: /usr/local/lib/systemd/system/k3s-agent.service
+      overwrite: true
+```

--- a/docs/keepalived.md
+++ b/docs/keepalived.md
@@ -1,0 +1,56 @@
+# Keepalive-Daemon sysext
+
+For the keepalive-daemon extension only the build script is provided.
+The Bakery does not regularly build this extension nor host ready-to-use sysexts for download at this time.
+We recommend to build, and either self-host the extension or to bake it right into a Flatcar OS image.
+
+The build process will build a statically compiled keepalived in a transient Alpine docker image, export the resulting binary, and build a sysext.
+
+# Usage
+
+Review the keepalived releases and pick a release version: https://github.com/acassen/keepalived
+The example below uses keepalived v2.3.1.
+
+Clone the bakery repo and build the sysext.
+```bash
+git clone https://github.com/flatcar/sysext-bakery.git
+cd sysext-bakery
+./create_keepalived_sysext.sh v2.3.1 keepalived
+```
+
+This will produce `keepalived.raw` in the local directory.
+
+You may now bake it into a Flatcar image - say, the latest Stable release.
+**NOTE** this requires `sudo` access at one point and might prompt you for a password.
+`sudo` is required to loopback-mount the image's root partition for installing the sysext.
+```bash
+./bake_flatcar_image.sh keepalived:keepalived.raw
+```
+
+If you want to produce an image for a specific vendor (e.g. AWS or Azure), instruct `bake_flatcar_image.sh` to do so:
+```bash
+./bake_flatcar_image.sh --vendor azure keepalived:keepalived.raw
+```
+This build will take a little longer as `bake_flatcar_image.sh` will now use the Flatcar SDK container to build an image for that vendor.
+
+### Self-host and consume at provisioning time
+
+Alternatively to baking keepalived into an OS image, users may as well host the sysext on a HTTP[S] endpoint and consume to at provisioning time.
+
+Assuming we hosted the sysext at https://sysexts.me/, here's a simple Butane config to consume the sysext:
+
+```yaml
+variant: flatcar
+version: 1.0.0
+
+storage:
+  files:
+    - path: /opt/extensions/keepalived/keepalived.raw
+      mode: 0644
+      contents:
+        source: https://sysexts.me/keepalived.raw
+  links:
+    - target: /opt/extensions/keepalived/keepalived.raw
+      path: /etc/extensions/keepalived.raw
+      hard: false
+```

--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -1,0 +1,64 @@
+# Kubernetes sysext
+
+Deploying Kubernetes is a complex topic; a full how-to guide is available at the [Flatcar Kubernetes docs](https://www.flatcar.org/docs/latest/container-runtimes/getting-started-with-kubernetes/).
+The how-to guides through the deployment of a full-blown Kubernetes cluster using only Flatcar native features like Butane / Ignition and sysexts.
+This makes the howto entirely portable and independent from any vendor / cloud provider.
+
+The Kubernetes sysext is used by the Flatcar project for ClusterAPI.
+Flatcar CAPI nodes are composited at provisioning time and can optionally in-place update Kubernetes.
+
+## Usage
+
+As mentioned above, a full howto is available.
+Below are a few config snippets from that howto.
+We'll discuss 2 node types - control plane and worker nodes - with minor differences in their configuration.
+
+Note that the snippets are for the x86-64 version of Kubernetes v1.31.3.
+The snippet includes automated updates via systemd-sysupdate.
+Sysupdate will stage updates and request a reboot by creating a flag file at `/run/reboot-required`.
+It is recommended to deploy [kured](https://kured.dev/) to the cluster to manage reboots.
+Alternatively, you can deactivate updates by changing `enabled: true` to `enabled: false` in `systemd-sysupdate.timer`.
+
+```yaml
+variant: flatcar
+version: 1.0.0
+
+storage:
+  links:
+    - target: /opt/extensions/kubernetes/kubernetes-v1.31.3-x86-64.raw
+      path: /etc/extensions/kubernetes.raw
+      hard: false
+  files:
+    - path: /etc/sysupdate.kubernetes.d/kubernetes-v1.31.conf
+      contents:
+        source: https://github.com/flatcar/sysext-bakery/releases/download/latest/kubernetes-v1.31.conf
+    - path: /etc/sysupdate.d/noop.conf
+      contents:
+        source: https://github.com/flatcar/sysext-bakery/releases/download/latest/noop.conf
+    - path: /opt/extensions/kubernetes/kubernetes-v1.31.3-x86-64.raw
+      contents:
+        source: https://github.com/flatcar/sysext-bakery/releases/download/latest/kubernetes-v1.31.3-x86-64.raw
+systemd:
+  units:
+    - name: systemd-sysupdate.timer
+      enabled: true
+    - name: systemd-sysupdate.service
+      dropins:
+        - name: kubernetes.conf
+          contents: |
+            [Service]
+            ExecStartPre=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/kubernetes.raw > /tmp/kubernetes"
+            ExecStartPre=/usr/lib/systemd/systemd-sysupdate -C kubernetes update
+            ExecStartPost=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/kubernetes.raw > /tmp/kubernetes-new"
+            ExecStartPost=/usr/bin/sh -c "if ! cmp --silent /tmp/kubernetes /tmp/kubernetes-new; then touch /run/reboot-required; fi"
+    - name: locksmithd.service
+      # Disable Flatcar native reboot coordination as KureD will handle OS updates, too
+      mask: true
+```
+
+This brings up a node with basic support for Kubernetes.
+At this point, orchestration would instruct the designated control plane to initialise and to generate secrets for worker nodes to join the cluster.
+Orchestration would then spawn worker nodes and instruct these to join.
+
+If you like to try step-by-step instructions for doing this with native Flatcar Butane / Ignition, check out
+[Flatcar Kubernetes docs](https://www.flatcar.org/docs/latest/container-runtimes/getting-started-with-kubernetes/).

--- a/docs/llamaedge.md
+++ b/docs/llamaedge.md
@@ -1,0 +1,74 @@
+#  Llamaedge sysext
+
+This sysext ships [llamaedge](https://github.com/LlamaEdge/LlamaEdge).
+It requires wasmedge to run, so we include the wamsedge sysext in the configuration snippets below.
+
+# Usage
+
+Note that the snippet merely provisions llamaedge.
+It does not start automatically.
+
+After provisioning you can interact with llamaedge on the instance:
+```bash
+wasmedge run /usr/lib/wasmedge/wasm/llama-api-server.wasm
+```
+
+The llamaedge sysext can be configured by using the following snippet.
+The snippet includes automated updates via systemd-sysupdate.
+Sysupdate will stage updates and request a reboot by creating a flag file at `/run/reboot-required`.
+You can deactivate updates by changing `enabled: true` to `enabled: false` in `systemd-sysupdate.timer`.
+
+Note that the snippet is for the x86-64 version of wasmedge 0.14.1 and llamaedge 0.14.16.
+
+```yaml
+variant: flatcar
+version: 1.0.0
+
+storage:
+  files:
+    - path: /opt/extensions/wasmedge-0.14.1-x86-64.raw
+      mode: 0420
+      contents:
+        source: https://github.com/flatcar/sysext-bakery/releases/download/latest/wasmaedge-0.14.1-x86-64.raw
+    - path: /opt/extensions/llamaedge-0.14.16-x86-64.raw
+      mode: 0420
+      contents:
+        source: https://github.com/flatcar/sysext-bakery/releases/download/latest/llamaedge-0.14.16-x86-64.raw
+    - path: /etc/sysupdate.wasmedge.d/wasmedge.conf
+      contents:
+        source: https://github.com/flatcar/sysext-bakery/releases/download/latest/wasmedge.conf
+    - path: /etc/sysupdate.wasmedge.d/llamaedge.conf
+      contents:
+        source: https://github.com/flatcar/sysext-bakery/releases/download/latest/llamaedge.conf
+    - path: /etc/sysupdate.d/noop.conf
+      contents:
+        source: https://github.com/flatcar/sysext-bakery/releases/download/latest/noop.conf
+  links:
+    - target: /opt/extensions/wasmedge-0.14.1-x86-64.raw
+      path: /etc/extensions/wasmedge.raw
+      hard: false
+    - target: /opt/extensions/llamaedge-0.14.16-x86-64.raw
+      path: /etc/extensions/llamaedge.raw
+      hard: false
+
+systemd:
+  units:
+    - name: systemd-sysupdate.timer
+      enabled: true
+    - name: systemd-sysupdate.service
+      dropins:
+        - name: wasmedge.conf
+          contents: |
+            [Service]
+            ExecStartPre=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/wasmedge.raw > /tmp/wasmedge"
+            ExecStartPre=/usr/lib/systemd/systemd-sysupdate -C wasmedge update
+            ExecStartPost=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/wasmedge.raw > /tmp/wasmedge-new"
+            ExecStartPost=/usr/bin/sh -c "if ! cmp --silent /tmp/wasmedge /tmp/wasmedge-new; then touch /run/reboot-required; fi"
+        - name: llamaedge.conf
+          contents: |
+            [Service]
+            ExecStartPre=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/llamaedge.raw > /tmp/llamaedge"
+            ExecStartPre=/usr/lib/systemd/systemd-sysupdate -C llamaedge update
+            ExecStartPost=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/llamaedge.raw > /tmp/llamaedge-new"
+            ExecStartPost=/usr/bin/sh -c "if ! cmp --silent /tmp/llamaedge /tmp/llamaedge-new; then touch /run/reboot-required; fi"
+```

--- a/docs/nvidia_runtime.md
+++ b/docs/nvidia_runtime.md
@@ -1,0 +1,51 @@
+# NVIDIA runtime sysext
+
+This sysext ships the NVIDIA runtime environment and related tools.
+It does _not_ include the kernel module.
+Please refer to the [NVIDIA customisation guide](https://www.flatcar.org/docs/latest/setup/customization/using-nvidia/)
+for information and configuration snippets to deploy the kernel module on Flatcar.
+
+## Usage
+
+Download and merge the sysext at provisioning time using the below butane snippet.
+
+The snippet includes automated updates via systemd-sysupdate.
+Sysupdate will stage updates and request a reboot by creating a flag file at `/run/reboot-required`.
+
+You can deactivate updates by changing `enabled: true` to `enabled: false` in `systemd-sysupdate.timer`.
+Note that the snippet is for the x86-64 version of the NVIDIA runtime version v1.16.2.
+
+```yaml
+variant: flatcar
+version: 1.0.0
+
+storage:
+  files:
+    - path: /opt/extensions/nvidia_runtime/nvidia_runtime-v1.16.2-x86-64.raw
+      mode: 0644
+      contents:
+        source: https://github.com/flatcar/sysext-bakery/releases/download/latest/nvidia_runtime-v1.16.2-x86-64.raw
+    - path: /etc/sysupdate.nvidia_runtime.d/nvidia_runtime.conf
+      contents:
+        source: https://github.com/flatcar/sysext-bakery/releases/download/latest/nvidia_runtime.conf
+    - path: /etc/sysupdate.d/noop.conf
+      contents:
+        source: https://github.com/flatcar/sysext-bakery/releases/download/latest/noop.conf
+  links:
+    - target: /opt/extensions/nvidia_runtime/nvidia_runtime-v1.16.2-x86-64.raw
+      path: /etc/extensions/nvidia_runtime.raw
+      hard: false
+systemd:
+  units:
+    - name: systemd-sysupdate.timer
+      enabled: true
+    - name: systemd-sysupdate.service
+      dropins:
+        - name: nvidia_runtime.conf
+          contents: |
+            [Service]
+            ExecStartPre=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/nvidia_runtime.raw > /tmp/nvidia_runtime"
+            ExecStartPre=/usr/lib/systemd/systemd-sysupdate -C nvidia_runtime update
+            ExecStartPost=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/nvidia_runtime.raw > /tmp/nvidia_runtime-new"
+            ExecStartPost=/usr/bin/sh -c "if ! cmp --silent /tmp/nvidia_runtime /tmp/nvidia_runtime-new; then touch /run/reboot-required; fi"
+```

--- a/docs/ollama.md
+++ b/docs/ollama.md
@@ -1,0 +1,66 @@
+# Ollama sysext
+
+This sysext ships [Ollama](https://github.com/ollama/ollama).
+
+The sysext includes a service unit file to start Ollama at boot as well as a basic configuration.
+
+## Usage
+
+Download and merge the sysext at provisioning time using the below butane snippet.
+Ollma's configuration is customized in terms of where Ollama stores its models, configuration and runtime libraries.
+It can be changed via the `HOME`, `OLLAMA_MODELS` and `OLLAMA_RUNNERS_DIR` environment variables.
+Please refer to the [Ollama documentation for more information](https://github.com/ollama/ollama/tree/main/docs).
+
+The snippet includes automated updates via systemd-sysupdate.
+Sysupdate will stage updates and request a reboot by creating a flag file at `/run/reboot-required`.
+You can deactivate updates by changing `enabled: true` to `enabled: false` in `systemd-sysupdate.timer`.
+
+The snippet below deploys the x86-64 version of Ollama 0.3.9.
+**NOTE** in the default configuration, the Ollama API will be **publicly accessible**.
+Please update `OLLAMA_HOST` before deployment if you want to change that.
+
+```yaml
+variant: flatcar
+version: 1.0.0
+
+storage:
+  files:
+    - path: /opt/extensions/ollama/ollama-0.3.9-x86-64.raw
+      contents:
+        source: https://github.com/flatcar/sysext-bakery/releases/download/latest/ollama-0.3.9-x86-64.raw
+    - path: /etc/sysupdate.ollama.d/ollama.conf
+      contents:
+        source: https://github.com/flatcar/sysext-bakery/releases/download/latest/ollama.conf
+    - path: /etc/sysupdate.d/noop.conf
+      contents:
+        source: https://github.com/flatcar/sysext-bakery/releases/download/latest/noop.conf
+  links:
+    - target: /opt/extensions/ollama/ollama-0.3.9-x86-64.raw
+      path: /etc/extensions/ollama.raw
+      hard: false
+
+systemd:
+  units:
+    - name: ollama.service
+      enabled: true
+      dropins:
+        - name: 10-ollama-env-override.conf
+          contents: |
+            [Service]
+            Environment=HOME="/var/lib/ollama"
+            Environment=OLLAMA_MODELS="/var/lib/ollama/models"
+            Environment=OLLAMA_RUNNERS_DIR="/var/lib/ollama/runners"
+            Environment=OLLAMA_HOST="0.0.0.0:11434"
+    - name: systemd-sysupdate.timer
+      enabled: true
+    - name: systemd-sysupdate.service
+      dropins:
+        - name: ollama.conf
+          contents: |
+            [Service]
+            ExecStartPre=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/ollama.raw > /tmp/ollama"
+            ExecStartPre=/usr/lib/systemd/systemd-sysupdate -C ollama update
+            ExecStartPost=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/ollama.raw > /tmp/ollama-new"
+            ExecStartPost=/usr/bin/sh -c "if ! cmp --silent /tmp/ollama /tmp/ollama-new; then touch /run/reboot-required; fi"
+```
+```

--- a/docs/rke2.md
+++ b/docs/rke2.md
@@ -1,0 +1,80 @@
+# rke2 sysext
+
+This sysext ships [RKE2](https://docs.rke2.io/),
+Rancher's next-generation Kubernetes distribution.
+
+The sysext includes service unit files for both server and agent.
+No service is active by default; it is up to the node provisioning configuration to pick which one to start.
+See "Usage" below for details.
+
+## Usage
+
+Download and merge the sysext at provisioning time using the below butane snippet.
+
+The snippet includes automated updates via systemd-sysupdate.
+Sysupdate will stage updates and request a reboot by creating a flag file at `/run/reboot-required`.
+You can deactivate updates by changing `enabled: true` to `enabled: false` in `systemd-sysupdate.timer`.
+Updates are only supported within the same minor release, e.g. v1.31.2 -> v1.31.3; _never_ across releases (v1.31.x -> v1.32.x).
+This is because upstream Kubernetes does not support unattended automated upgrades across minor releases.
+
+Note that the snippet is for the x86-64 version of rke2 v1.31.1.
+
+Generic configuration for both Server (control plane) and Agent (worker):
+
+```yaml
+variant: flatcar
+version: 1.0.0
+
+storage:
+  files:
+    - path: /etc/extensions/rke2.raw
+      contents:
+        source: https://github.com/flatcar/sysext-bakery/releases/download/latest/rke2-v1.31.1+rke2r1-x86-64.raw
+    - path: /etc/sysupdate.rke2.d/rke2-v1.31.conf
+      contents:
+        source: https://github.com/flatcar/sysext-bakery/releases/download/latest/rke2.conf
+    - path: /etc/sysupdate.d/noop.conf
+      contents:
+        source: https://github.com/flatcar/sysext-bakery/releases/download/latest/noop.conf
+  links:
+    - target: /opt/extensions/rke2/rke2-v1.31.3+k3s1-x86-64.raw
+      path: /etc/extensions/k3s.raw
+      hard: false
+
+systemd:
+  units:
+    - name: systemd-sysupdate.timer
+      enabled: true
+    - name: systemd-sysupdate.service
+      dropins:
+        - name: rke2.conf
+          contents: |
+            [Service]
+            ExecStartPre=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/rke2.raw > /tmp/rke2"
+            ExecStartPre=/usr/lib/systemd/systemd-sysupdate -C rke2-v1.31 update
+            ExecStartPost=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/rke2.raw > /tmp/rke2-new"
+            ExecStartPost=/usr/bin/sh -c "if ! cmp --silent /tmp/rke2 /tmp/rke2-new; then touch /run/reboot-required; fi"
+```
+
+For a rke2 server (control plane) node, add to the section
+```yaml
+storage:
+  links:
+```
+the following:
+```yaml
+    - path: /etc/systemd/system/multi-user.target.wants/rke2-server.service
+      target: /usr/local/lib/systemd/system/rke2-server.service
+      overwrite: true
+```
+
+For a rke2 agent (worker node), add this instead:
+```yaml
+    - path: /etc/systemd/system/multi-user.target.wants/rke2-agent.service
+      target: /usr/local/lib/systemd/system/rke2-agent.service
+      overwrite: true
+```
+
+to start either Server or Agent services at boot, respectively.
+
+Note that any configuration you might need (security tokens or config.yaml files) can be deployed in the same fashion, via Butane/Ignition.

--- a/docs/tailscale.md
+++ b/docs/tailscale.md
@@ -1,0 +1,55 @@
+# Tailscale sysext
+
+This sysext ships [Tailscale](https://tailscale.com/).
+
+
+The Tailscale sysext includes a service unit but doesn't pre-enable it.
+The unit can be enabled via Butane in order to start tailscale at boot.
+
+## Usage
+
+Download and merge the sysext at provisioning time using the below butane snippet.
+
+The snippet includes automated updates via systemd-sysupdate.
+Sysupdate will stage updates and request a reboot by creating a flag file at `/run/reboot-required`.
+You can deactivate updates by changing `enabled: true` to `enabled: false` in `systemd-sysupdate.timer`.
+
+Note that the snippet is for the x86-64 version of tailscale 1.76.6.
+
+```yaml
+variant: flatcar
+version: 1.0.0
+
+storage:
+  files:
+    - path: /opt/extensions/tailscale/tailscale-1.76.6-x86-64.raw
+      mode: 0644
+      contents:
+        source: https://github.com/flatcar/sysext-bakery/releases/download/latest/tailscale-1.76.6-x86-64.raw
+    - path: /etc/sysupdate.tailscale.d/tailscale.conf
+      contents:
+        source: https://github.com/flatcar/sysext-bakery/releases/download/latest/tailscale.conf
+    - path: /etc/sysupdate.d/noop.conf
+      contents:
+        source: https://github.com/flatcar/sysext-bakery/releases/download/latest/noop.conf
+  links:
+    - path: /etc/systemd/system/multi-user.target.wants/tailscaled.service
+      target: /usr/local/lib/systemd/system/tailscaled.service
+      overwrite: true
+    - target: /opt/extensions/tailscale/tailscale-1.76.6-x86-64.raw
+      path: /etc/extensions/tailscale.raw
+      hard: false
+systemd:
+  units:
+    - name: systemd-sysupdate.timer
+      enabled: true
+    - name: systemd-sysupdate.service
+      dropins:
+        - name: tailscale.conf
+          contents: |
+            [Service]
+            ExecStartPre=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/tailscale.raw > /tmp/tailscale"
+            ExecStartPre=/usr/lib/systemd/systemd-sysupdate -C tailscale update
+            ExecStartPost=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/tailscale.raw > /tmp/tailscale-new"
+            ExecStartPost=/usr/bin/sh -c "if ! cmp --silent /tmp/tailscale /tmp/tailscale-new; then touch /run/reboot-required; fi"
+```

--- a/docs/wasmcloud.md
+++ b/docs/wasmcloud.md
@@ -1,0 +1,102 @@
+# Wasmcloud sysext
+
+This sysext ships [wasmcloud](https://wasmcloud.com/).
+
+The sysext includes a service unit file to start the `wasmcloud` and `nats` services at boot.
+Basic customisation options are discussed in the "Usage" section below.
+
+## Usage
+
+Download and merge the sysext at provisioning time using the below butane snippet.
+
+The snippet includes automated updates via systemd-sysupdate.
+Sysupdate will **merge the new sysext immediately after successful download**.
+You can deactivate updates by changing `enabled: true` to `enabled: false` in `systemd-sysupdate.timer`.
+
+Note that the snippet is for the x86-64 version of wasmcloud 1.2.1.
+
+
+The following customisations have been made (see comments in the config snippet)
+
+1. Provide a different configuration to setup the nats-server to act as a leaf node to a pre-existing wasmCloud deployment (`/etc/nats-server.conf`).
+2. Provide a set of credentials for the nats-server leaf node to connect with (`/etc/nats.creds`).
+3. Override the bundled `NATS_CONFIG` environment variable to point it to the newly created configuration (`NATS_CONFIG=/etc/nats-server.conf`).
+4. Override the lattice the wasmCloud host is configured to connect (`WASMCLOUD_LATTICE=<redacted>`).
+
+```yaml
+variant: flatcar
+version: 1.0.0
+
+storage:
+  links:
+    - target: /opt/extensions/wasmcloud/wasmcloud-1.2.1-x86-64.raw
+      path: /etc/extensions/wasmcloud.raw
+      hard: false
+  files:
+    - path: /opt/extensions/wasmcloud/wasmcloud-1.2.1-x86-64.raw
+      contents:
+        source: https://github.com/flatcar/sysext-bakery/releases/download/latest/wasmcloud-1.2.1-x86-64.raw
+    - path: /etc/sysupdate.wasmcloud.d/wasmcloud.conf
+      contents:
+        source: https://github.com/flatcar/sysext-bakery/releases/download/latest/wasmcloud.conf
+    - path: /etc/sysupdate.d/noop.conf
+      contents:
+      source: https://github.com/flatcar/sysext-bakery/releases/download/latest/noop.conf
+  #
+  # Custom WasmCloud Config
+  #
+  files:
+    - path: /etc/nats-server.conf
+      # NATS server leaf node config
+      contents:
+        inline: |
+          jetstream {
+            domain: default
+          }
+          leafnodes {
+              remotes = [
+                  {
+                      url: "tls://connect.cosmonic.sh"
+                      credentials: "/etc/nats.creds"
+                  }
+              ]
+          }
+    - path: /etc/nats.creds
+      # NATS server cretentials. TODO: actually add the credentials.
+      contents:
+        inline: |
+          <redacted>
+systemd:
+  units:
+    - name: systemd-sysupdate.timer
+      enabled: true
+    - name: systemd-sysupdate.service
+      dropins:
+        - name: wasmcloud.conf
+          contents: |
+            [Service]
+            ExecStartPre=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/wasmcloud.raw > /tmp/wasmcloud"
+            ExecStartPre=/usr/lib/systemd/systemd-sysupdate -C wasmcloud update
+            ExecStartPost=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/wasmcloud.raw > /tmp/wasmcloud-new"
+            ExecStartPost=/usr/bin/sh -c "if ! cmp --silent /tmp/wasmcloud /tmp/wasmcloud-new; then systemd-sysext refresh; fi"
+
+    #
+    # Custom WasmCloud Config
+    #
+    - name: nats.service
+      enabled: true
+      dropins:
+        - name: 10-nats-env-override.conf
+          contents: |
+            [Service]
+            Environment=NATS_CONFIG=/etc/nats-server.conf
+    - name: wasmcloud.service
+      # Wasmcloud env override. TODO: add lattice.
+      enabled: true
+      dropins:
+        - name: 10-wasmcloud-env-override.conf
+          contents: |
+            [Service]
+            Environment=WASMCLOUD_LATTICE=<redacted>
+```
+

--- a/docs/wasmedge.md
+++ b/docs/wasmedge.md
@@ -1,0 +1,48 @@
+# Wasmedge sysext
+
+This sysext ships [wasmedge](https://wasmedge.org/).
+
+The wasmedge sysext does not ship a systemd service unit at this point.
+In order to run it at boot users would need to add a custom service file in the config below.
+
+# Usage
+
+The wasmedge sysext can be configured by using the following snippet.
+The snippet includes automated updates via systemd-sysupdate.
+Sysupdate will **merge the new sysext immediately after successful download**.
+You can deactivate updates by changing `enabled: true` to `enabled: false` in `systemd-sysupdate.timer`.
+
+Note that the snippet is for the x86-64 version of wasmedge 0.14.1.
+
+```yaml
+variant: flatcar
+version: 1.0.0
+
+storage:
+  files:
+    - path: /opt/extensions/wasmedge-0.14.1-x86-64.raw
+      mode: 0420
+      contents:
+        source: https://github.com/flatcar/sysext-bakery/releases/download/wasmedge-0.14.1-x86-64.raw
+    - path: /etc/sysupdate.wasmedge.d/wasmedge.conf
+      contents:
+        source: https://github.com/flatcar/sysext-bakery/releases/download/latest/wasmedge.conf
+  links:
+    - target: /opt/extensions/wasmedge-0.14.1-x86-64.raw
+      path: /etc/extensions/wasmedge.raw
+      hard: false
+
+systemd:
+  units:
+    - name: systemd-sysupdate.timer
+      enabled: true
+    - name: systemd-sysupdate.service
+      dropins:
+        - name: wasmedge.conf
+          contents: |
+            [Service]
+            ExecStartPre=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/wasmedge.raw > /tmp/wasmedge"
+            ExecStartPre=/usr/lib/systemd/systemd-sysupdate -C wasmedge update
+            ExecStartPost=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/wasmedge.raw > /tmp/wasmedge-new"
+            ExecStartPost=/usr/bin/sh -c "if ! cmp --silent /tmp/wasmedge /tmp/wasmedge-new; then systemd-sysext refresh; fi"
+```

--- a/docs/wasmtime.md
+++ b/docs/wasmtime.md
@@ -1,0 +1,51 @@
+# Wasmtime sysext
+
+This extension ships [wasmtime](https://wasmtime.dev/).
+
+The wasmtime sysext does not ship a systemd service unit at this point.
+In order to start WASM workloads at boot, users need to supply custom unit files via Butane / Ignition.
+
+# Usage
+
+Download and merge the sysext at provisioning time using the below butane snippet.
+
+The snippet includes automated updates via systemd-sysupdate.
+Sysupdate will **merge the new sysext immediately after successful download**.
+You can deactivate updates by changing `enabled: true` to `enabled: false` in `systemd-sysupdate.timer`.
+
+Note that the snippet is for the x86-64 version of wasmtime 24.0.0.
+
+```yaml
+variant: flatcar
+version: 1.0.0
+
+storage:
+  links:
+    - target: /opt/extensions/wasmtime/wasmtime-24.0.0-x86-64.raw
+      path: /etc/extensions/wasmtime.raw
+      hard: false
+  files:
+    - path: /opt/extensions/wasmtime/wasmtime-24.0.0-x86-64.raw
+      contents:
+        source: https://github.com/flatcar/sysext-bakery/releases/download/latest/wasmtime-24.0.0-x86-64.raw
+    - path: /etc/sysupdate.wasmtime.d/wasmtime.conf
+      contents:
+        source: https://github.com/flatcar/sysext-bakery/releases/download/latest/wasmtime.conf
+    - path: /etc/sysupdate.d/noop.conf
+      contents:
+      source: https://github.com/flatcar/sysext-bakery/releases/download/latest/noop.conf
+ 
+systemd:
+  units:
+    - name: systemd-sysupdate.timer
+      enabled: true
+    - name: systemd-sysupdate.service
+      dropins:
+        - name: wasmtime.conf
+          contents: |
+            [Service]
+            ExecStartPre=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/wasmtime.raw > /tmp/wasmtime"
+            ExecStartPre=/usr/lib/systemd/systemd-sysupdate -C wasmtime update
+            ExecStartPost=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/wasmtime.raw > /tmp/wasmtime-new"
+            ExecStartPost=/usr/bin/sh -c "if ! cmp --silent /tmp/wasmtime /tmp/wasmtime-new; then systemd-sysext refresh; fi"
+```


### PR DESCRIPTION
This change is a thorough documentation overhaul.

The main README has been refactored to provide a top-down, user-centric view of the Bakery. All specific sysexts are discussed in separate files. All sysexts now come with full-blown ready-to-use example configurations.