### PR TITLE
Add Nebula sysext

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Check out the README files of specific extensions for detailed usage instruction
 | `k3s`            |  released    | [k3s.md](docs/k3s.md) |
 | `keepalived`     | build script | [keepalived.md](docs/keepalived.md) |
 | `kubernetes`     |  released    | [kubernetes.md](docs/kubernetes.md) |
+| `nebula`         |  released    | [nebula.md](docs/nebula.md) |
 | `nvidia-runtime` |  released    | [nvidia-runtime.md](docs/nvidia-runtime.md) |
 | `ollama`         |  released    | [ollama.md](docs/ollama.md) |
 | `rke2`           |  released    | [rke2.md](docs/rke2.md) |

--- a/create_nebula_sysext.sh
+++ b/create_nebula_sysext.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export ARCH="${ARCH-x86-64}"
+SCRIPTFOLDER="$(dirname "$(readlink -f "$0")")"
+
+if [ $# -lt 2 ] || [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
+  echo "Usage: $0 VERSION SYSEXTNAME"
+  echo "The script will download nebula release binaries and create a sysext squashfs image with the name SYSEXTNAME.raw in the current folder."
+  echo "A temporary directory named SYSEXTNAME in the current folder will be created and deleted again."
+  echo "All files in the sysext image will be owned by root."
+  echo "To use arm64 pass 'ARCH=arm64' as environment variable (current value is '${ARCH}')."
+  "${SCRIPTFOLDER}"/bake.sh --help
+  exit 1
+fi
+
+VERSION="$1"
+SYSEXTNAME="$2"
+
+if [ "${ARCH}" = "x86_64" ] || [ "${ARCH}" = "x86-64" ]; then
+  ARCH="amd64"
+elif [ "${ARCH}" = "aarch64" ]; then
+  ARCH="arm64"
+fi
+
+VERSION="v${VERSION#v}"
+
+TARBALL="nebula-linux-${ARCH}.tar.gz"
+SHASUM="SHASUM256.txt"
+
+TARBALL_URL="https://github.com/slackhq/nebula/releases/download/${VERSION}/${TARBALL}"
+SHASUM_URL="https://github.com/slackhq/nebula/releases/download/${VERSION}/${SHASUM}"
+
+rm -rf "${SYSEXTNAME}"
+
+TMP_DIR="${SYSEXTNAME}/tmp"
+mkdir -p "${TMP_DIR}"
+
+curl --parallel --fail --silent --show-error --location \
+  --output "${TMP_DIR}/${TARBALL}" "${TARBALL_URL}" \
+  --output "${TMP_DIR}/${SHASUM}" "${SHASUM_URL}"
+
+pushd "${TMP_DIR}" > /dev/null
+grep "${TARBALL}$" "${SHASUM}" | sha256sum -c -
+popd  > /dev/null
+
+mkdir -p "${SYSEXTNAME}/usr/bin"
+
+tar --force-local -xf "${TMP_DIR}/${TARBALL}" -C "${SYSEXTNAME}/usr/bin"
+chmod +x "${SYSEXTNAME}/usr/bin/nebula"
+chmod +x "${SYSEXTNAME}/usr/bin/nebula-cert"
+
+mkdir -p "${SYSEXTNAME}/usr/lib/systemd/system"
+cat > "${SYSEXTNAME}/usr/lib/systemd/system/nebula.service" <<-'EOF'
+[Unit]
+Description=Nebula overlay networking tool
+Wants=basic.target network-online.target nss-lookup.target time-sync.target
+After=basic.target network.target network-online.target
+
+[Service]
+Type=notify
+NotifyAccess=main
+SyslogIdentifier=nebula
+ExecReload=/bin/kill -HUP $MAINPID
+ExecStart=/usr/bin/nebula -config /etc/nebula/config.yaml
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+mkdir -p "${SYSEXTNAME}"/usr/lib/systemd/system/multi-user.target.d
+{ echo "[Unit]"; echo "Upholds=nebula.service"; } > "${SYSEXTNAME}"/usr/lib/systemd/system/multi-user.target.d/10-nebula.conf
+
+rm -rf "${TMP_DIR}"
+
+RELOAD=1 "${SCRIPTFOLDER}"/bake.sh "${SYSEXTNAME}"
+rm -rf "${SYSEXTNAME}"

--- a/docs/nebula.md
+++ b/docs/nebula.md
@@ -1,0 +1,45 @@
+# Nebula sysext
+
+This sysext ships [Nebula](https://github.com/slackhq/nebula).
+
+## Usage
+
+Refer to the following Butane snippet that enables Nebula v1.9.5 for an x86-64 machine with automated updates using `systemd-sysupdate`.
+
+```yaml
+variant: flatcar
+version: 1.0.0
+
+storage:
+  files:
+    - path: /opt/extensions/nebula/nebula-v1.9.5-x86-64.raw
+      mode: 0644
+      contents:
+        source: https://github.com/flatcar/sysext-bakery/releases/download/latest/nebula-v1.9.5-x86-64.raw
+    - path: /etc/sysupdate.nebula.d/nebula.conf
+      contents:
+        source: https://github.com/flatcar/sysext-bakery/releases/download/latest/nebula.conf
+    - path: /etc/sysupdate.d/noop.conf
+      contents:
+        source: https://github.com/flatcar/sysext-bakery/releases/download/latest/noop.conf
+  links:
+    - path: /etc/systemd/system/multi-user.target.wants/nebula.service
+      target: /usr/lib/systemd/system/nebula.service
+      overwrite: true
+    - target: /opt/extensions/nebula/nebula-v1.9.5-x86-64.raw
+      path: /etc/extensions/nebula.raw
+      hard: false
+systemd:
+  units:
+    - name: systemd-sysupdate.timer
+      enabled: true
+    - name: systemd-sysupdate.service
+      dropins:
+        - name: nebula.conf
+          contents: |
+            [Service]
+            ExecStartPre=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/nebula.raw > /tmp/nebula"
+            ExecStartPre=/usr/lib/systemd/systemd-sysupdate -C nebula update
+            ExecStartPost=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/nebula.raw > /tmp/nebula-new"
+            ExecStartPost=/usr/bin/sh -c "if ! cmp --silent /tmp/nebula /tmp/nebula-new; then touch /run/reboot-required; fi"
+```

--- a/release_build_versions.txt
+++ b/release_build_versions.txt
@@ -25,6 +25,8 @@ wasmcloud-1.2.1
 
 tailscale-1.76.6
 
+nebula-1.9.5
+
 nvidia_runtime-v1.16.2
 
 ollama-0.3.9


### PR DESCRIPTION
# [Title: describe the change in one sentence]

This PR adds a [Nebula](https://github.com/slackhq/nebula) sysext, including the build script and documentation.

## How to use

Run `create_nebula_sysext.sh 1.9.5 nebula` to produce the squashfs image `nebula.raw`. Verify that it contains `usr/bin/nebula` and `/usr/bin/nebula-cert` and both should run.

## Testing done

I ran the CI pipeline in my fork and successfully produced correct squashfs images for amd64 and arm64, as well as the `.conf` file for sysupdate.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
