### PR TITLE
Fix CI workflow when creating the first release

### DIFF
--- a/release_build.sh
+++ b/release_build.sh
@@ -59,10 +59,10 @@ function fetch_releases {
 echo
 echo "Fetching previous 'latest' release sysexts"
 echo "=========================================="
-curl -fsSL --retry-delay 1 --retry 60 --retry-connrefused \
+{ curl -fsSL --retry-delay 1 --retry 60 --retry-connrefused \
          --retry-max-time 60 --connect-timeout 20  \
          https://api.github.com/repos/"${REPO}"/releases/latest \
-    | jq -r '.assets[] | "\(.name)\t\(.browser_download_url)"' | { grep -E '\.raw$' || true; } | tee prev_release_sysexts.txt
+    | jq -r '.assets[] | "\(.name)\t\(.browser_download_url)"' | grep -E '\.raw$' || true; } | tee prev_release_sysexts.txt
 
 while IFS=$'\t' read -r name url; do
     echo


### PR DESCRIPTION
The build script tries to fetch previous "latest" release sysexts. The `curl` command fails when the release "latest" does not exist. This is inconvenient when users want to test the pipeline in their own forks before opening PRs. 

## How to use

This should be trivial to review, I guess?

## Testing done

With this change introduced, I successfully ran the pipeline in my fork with no existing release.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
