### PR TITLE
Fix filename in Docker Compose docs

### DIFF
--- a/docs/docker_compose.md
+++ b/docs/docker_compose.md
@@ -18,19 +18,19 @@ version: 1.0.0
 
 storage:
   files:
-    - path: /opt/extensions/docker-compose/docker-compose-2.24.5-x86-64.raw
+    - path: /opt/extensions/docker_compose/docker_compose-2.24.5-x86-64.raw
       mode: 0644
       contents:
-        source: https://github.com/flatcar/sysext-bakery/releases/download/latest/docker-compose-2.24.5-x86-64.raw
-    - path: /etc/sysupdate.docker-compose.d/docker-compose.conf
+        source: https://github.com/flatcar/sysext-bakery/releases/download/latest/docker_compose-2.24.5-x86-64.raw
+    - path: /etc/sysupdate.docker_compose.d/docker_compose.conf
       contents:
-        source: https://github.com/flatcar/sysext-bakery/releases/download/latest/docker-compose.conf
+        source: https://github.com/flatcar/sysext-bakery/releases/download/latest/docker_compose.conf
     - path: /etc/sysupdate.d/noop.conf
       contents:
         source: https://github.com/flatcar/sysext-bakery/releases/download/latest/noop.conf
   links:
-    - target: /opt/extensions/docker-compose/docker-compose-2.24.5-x86-64.raw
-      path: /etc/extensions/docker-compose.raw
+    - target: /opt/extensions/docker_compose/docker_compose-2.24.5-x86-64.raw
+      path: /etc/extensions/docker_compose.raw
       hard: false
 systemd:
   units:
@@ -38,12 +38,12 @@ systemd:
       enabled: true
     - name: systemd-sysupdate.service
       dropins:
-        - name: docker-compose.conf
+        - name: docker_compose.conf
           contents: |
             [Service]
-            ExecStartPre=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/docker-compose.raw > /tmp/docker-compose"
-            ExecStartPre=/usr/lib/systemd/systemd-sysupdate -C docker-compose update
-            ExecStartPost=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/docker-compose.raw > /tmp/docker-compose-new"
-            ExecStartPost=/usr/bin/sh -c "if ! cmp --silent /tmp/docker-compose /tmp/docker-compose-new; then touch /run/reboot-required; fi"
+            ExecStartPre=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/docker_compose.raw > /tmp/docker_compose"
+            ExecStartPre=/usr/lib/systemd/systemd-sysupdate -C docker_compose update
+            ExecStartPost=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/docker_compose.raw > /tmp/docker_compose-new"
+            ExecStartPost=/usr/bin/sh -c "if ! cmp --silent /tmp/docker_compose /tmp/docker_compose-new; then touch /run/reboot-required; fi"
 ```
 


### PR DESCRIPTION
# Fix filename in Docker Compose docs

This pull request fixes the filename in the Docker Compose docs. The proper filename has an underscore (`_`) rather than a dash (`-`).

## How to use

Transpile and use.

## Testing done

1. `cat cl.yaml | docker run --rm -i quay.io/coreos/butane:latest > ignition.json`
2. `./flatcar_production_qemu.sh -i ignition.json`

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
