### PR TITLE
release_build_versions.txt: use correct version strings

### DIFF
--- a/_skel.sysext/create.sh
+++ b/_skel.sysext/create.sh
@@ -16,6 +16,10 @@
 #  for `multi-user.target` in the "files/..." directory of this extension.
 RELOAD_SERVICES_ON_MERGE="true"
 
+# If you need to run curl calls to api.github.com consider using
+# 'curl_wrapper' (from lib/helpers.sh). The wrapper will use GH_TOKEN
+# if set to prevent throttling of unathenticated calls.
+
 # Fetch and print a list of available versions.
 # Called by 'bakery.sh list <sysext>.
 function list_available_versions() {

--- a/kubernetes.sysext/create.sh
+++ b/kubernetes.sysext/create.sh
@@ -42,7 +42,7 @@ function populate_sysext_root() {
   local rel_arch="$(arch_transform "x86-64" "amd64" "$arch")"
 
   if [[ -z ${cni_version} ]] ; then
-    cni_version="$(curl -fsSL https://api.github.com/repos/containernetworking/plugins/releases/latest \
+    cni_version="$(curl_wrapper https://api.github.com/repos/containernetworking/plugins/releases/latest \
                    | jq -r .tag_name)"
   fi
 

--- a/release_build_versions.txt
+++ b/release_build_versions.txt
@@ -43,7 +43,7 @@ kubernetes latest
 
 # TODO: llamaedge sysext depends on wasmedge sysext version, so we can't automatically build it :-/
 
-nebula 1.9.5
+nebula v1.9.5
 nebula latest
 
 nerdctl latest
@@ -51,23 +51,23 @@ nerdctl latest
 nvidia-runtime v1.16.2
 nvidia-runtime latest
 
-ollama 0.3.9
+ollama v0.3.9
 ollama latest
 
 rke2 latest
 
-tailscale 1.76.6
+tailscale v1.76.6
 tailscale latest
 
-wasmcloud 1.0.0
-wasmcloud 1.1.1
-wasmcloud 1.2.1
+wasmcloud v1.0.0
+wasmcloud v1.1.1
+wasmcloud v1.2.1
 wasmcloud latest
 
-wasmedge 0.14.1
+wasmedge 0.15.1
 wasmedge latest
 
-wasmtime 12.0.0
-wasmtime 13.0.0 # Used in Flatcar wasm OS demo
-wasmtime 24.0.0 # Used in README.md. Update readme when version changes.
+wasmtime v12.0.0
+wasmtime v13.0.0 # Used in Flatcar wasm OS demo
+wasmtime v24.0.0 # Used in README.md. Update readme when version changes.
 wasmtime latest

--- a/wasmcloud.sysext/create.sh
+++ b/wasmcloud.sysext/create.sh
@@ -21,7 +21,7 @@ function populate_sysext_root() {
 
   local nats="$(get_optional_param "nats" "latest" "${@}")"
   if [[ $nats == latest ]] ; then
-    nats="$(curl -fsSL https://api.github.com/repos/nats-io/nats-server/releases/latest | jq -r .tag_name)"
+    nats="$(curl_wrapper https://api.github.com/repos/nats-io/nats-server/releases/latest | jq -r .tag_name)"
   fi
 
   echo "Using NATS server version '$nats'"


### PR DESCRIPTION
This change updates release_build_versions.txt to use the correct version strings as reported by ./bakery.sh list <extension>. It also uses curl_wrapper in extensions' create.sh scripts for accessing api.github.com to avoud throttling (curl_wrapper uses GH_TOKEN for authentication if set).
