### PR TITLE
release_dispatcher.sh: fix version array

### DIFF
--- a/release_dispatcher.sh
+++ b/release_dispatcher.sh
@@ -26,6 +26,7 @@ for image in "${images[@]}"; do
   version="${image#* }"
 
   if [ "${version}" = "latest" ] ; then
+    unset version
     mapfile -t version < <( ./bakery.sh list "${extension}" --latest true )
   fi
 
@@ -38,14 +39,19 @@ for image in "${images[@]}"; do
       continue
     fi
 
-    echo "Build required. "
-    build_required="true"
-    builds+=( "${extension}:${v}" )
+    if [[ " ${builds[@]} " != *" ${extension}:${v} "* ]] ; then
+      echo "Build required. "
+      build_required="true"
+      builds+=( "${extension}:${v}" )
+    else
+      echo "Build already scheduled. "
+    fi
   done
 
   if [[ $build_required == true && " ${extensions[@]} " != *" ${extension} "* ]] ; then
     extensions+=( "${extension}" )
   fi
+  unset version
 done
 
 cat >> "${output}" <<EOF


### PR DESCRIPTION
The version variable is used as both an array and a scalar type in release_dispatcher.sh. When being set to a scalar value and previously being used as array, only the first array member is overwritten. This leads to erroneous build dispatches because versions are mixed up.

We explicitly un-set the variable at the end of the version loop

We also check the presence of <extension>:<version> pairs in the build array before adding new ones to prevent cases where "latest" and a pinned version are identical