### PR TITLE
lib/, release_meta.sh: address corner cases, qol improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,9 +132,14 @@ Have a look at other extension builds for inspiration;
 
 # Hosting your own bakery
 
-Just fork the Bakery, update `lib/sysupdate.conf.tmpl` to point to the correct URL, and start building and publishing!
+Just fork the Bakery, update
+[`lib/sysupdate.conf.tmpl`](lib/sysupdate.conf.tmpl)
+and
+[`lib/libbakery.sh`](lib/libbakery.sh)
+to use the new home, and start building and publishing!
 
 In general, the extension images can be consumed straight from the respective GitHub releases download sections.
+However, making systemd-sysupdate work requires extra steps - see below.
 
 ## Releases structure in the bakery
 
@@ -156,7 +161,7 @@ The bakery hosts extensions' individual releases, a per-extension metadata relea
 * **Global Metadata release**:
   Version information metadata for all extensions.
   Global metadata releases ship one single SHA256SUMS file with all extensions' versions.
-  This release can be seen as the inventory of the Bakery.
+  This release can be seen as the global inventory of the whole Bakery.
   * The release is named `SHA256SUMS`.
 
 

--- a/_skel.sysext/create.sh
+++ b/_skel.sysext/create.sh
@@ -16,9 +16,16 @@
 #  for `multi-user.target` in the "files/..." directory of this extension.
 RELOAD_SERVICES_ON_MERGE="true"
 
+# If your extension publishes custom versions other than
+# "<extension>-v1.2.3" or "<extension>-1.2.3" please provide a regex match
+# pattern. Will be used by "bakery.sh list-bakery <extension>" and
+# by the release scripts.
+# EXTENSION_VERSION_MATCH_PATTERN='[.v0-9]+'
+
 # If you need to run curl calls to api.github.com consider using
-# 'curl_wrapper' (from lib/helpers.sh). The wrapper will use GH_TOKEN
-# if set to prevent throttling of unathenticated calls.
+# 'curl_api_wrapper' (from lib/helpers.sh). The wrapper will use GH_TOKEN
+# if set to prevent throttling of unathenticated calls, and handle pagination
+# etc.
 
 # Fetch and print a list of available versions.
 # Called by 'bakery.sh list <sysext>.

--- a/k3s.sysext/create.sh
+++ b/k3s.sysext/create.sh
@@ -5,6 +5,7 @@
 #
 
 RELOAD_SERVICES_ON_MERGE="true"
+EXTENSION_VERSION_MATCH_PATTERN='[.v0-9]+\+k3s[0-9]+'
 
 function list_available_versions() {
   list_github_releases "k3s-io" "k3s"

--- a/kubernetes.sysext/create.sh
+++ b/kubernetes.sysext/create.sh
@@ -42,9 +42,11 @@ function populate_sysext_root() {
   local rel_arch="$(arch_transform "x86-64" "amd64" "$arch")"
 
   if [[ -z ${cni_version} ]] ; then
-    cni_version="$(curl_wrapper https://api.github.com/repos/containernetworking/plugins/releases/latest \
+    cni_version="$(curl_api_wrapper https://api.github.com/repos/containernetworking/plugins/releases/latest \
                    | jq -r .tag_name)"
   fi
+
+  announce "Using CNI version '${version}'"
 
   mkdir -p "${sysextroot}/usr/bin"
 

--- a/lib/list.sh
+++ b/lib/list.sh
@@ -90,10 +90,19 @@ function _list_sysext_versions() {
 
 function _list_bakery_releases() {
   local extname="$(extension_name "$(get_positional_param 1 "${@}")")"
+  local extscript="${scriptroot}/${extname}.sysext/create.sh"
 
-  list_github_releases "${bakery%/*}" "${bakery#*/}" \
-    | sed --quiet "s/^${extname}-\\([^-]\\+\\)/\\1/p" \
-    | uniq
+ (
+    EXTENSION_VERSION_MATCH_PATTERN='[.v0-9]+'
+
+    if [[ -f "${extscript}" ]] ; then
+      source "${extscript}"
+    fi
+
+    list_github_releases "${bakery%/*}" "${bakery#*/}" \
+      | sed --quiet -r "s/^${extname}-(${EXTENSION_VERSION_MATCH_PATTERN})$/\\1/p" \
+      | uniq
+ )
 }
 # --
 

--- a/rke2.sysext/create.sh
+++ b/rke2.sysext/create.sh
@@ -5,6 +5,7 @@
 #
 
 RELOAD_SERVICES_ON_MERGE="true"
+EXTENSION_VERSION_MATCH_PATTERN='[.v0-9]+\+rke2r[0-9]+'
 
 function list_available_versions() {
   list_github_releases "rancher" "rke2"

--- a/wasmcloud.sysext/create.sh
+++ b/wasmcloud.sysext/create.sh
@@ -21,7 +21,7 @@ function populate_sysext_root() {
 
   local nats="$(get_optional_param "nats" "latest" "${@}")"
   if [[ $nats == latest ]] ; then
-    nats="$(curl_wrapper https://api.github.com/repos/nats-io/nats-server/releases/latest | jq -r .tag_name)"
+    nats="$(curl_api_wrapper https://api.github.com/repos/nats-io/nats-server/releases/latest | jq -r .tag_name)"
   fi
 
   echo "Using NATS server version '$nats'"


### PR DESCRIPTION
This change addresses some corner cases in extension version detection and adds a few quality of life improvements:

- For listing bakery extension releases we now support a per-extension EXTENSION_VERSION_MATCH_PATTERN to address unusual versioning. This is helpful for e.g. versions like "rke2-v1.31.3+rke2r1".
- Stricter versioning match: bakery extension release versions use a stricter match pattern. This prevents false positive substring matches, e.g. "docker-compose" matched as a release version of "docker".
- The curl wrapper now supports github API response pagination. It has aptly been renamed to curl_api_wrapper.