### PR TITLE
[FEATURE] Add support for EROFS

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,7 +32,8 @@ jobs:
             curl \
             jq \
             squashfs-tools \
-            xz-utils
+            xz-utils \
+            erofs-utils
 
       - name: list
         id: list

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ If you want to build yourself, the following packages are required:
 
 - `curl`
 - `docker`
+- `erofs-utils`
 - `git`
 - `jq`
 - `squashfs-tools`

--- a/lib/generate.sh
+++ b/lib/generate.sh
@@ -19,12 +19,12 @@ function _check_format() {
   local fmt="$1"
 
   case "$fmt" in
-    squashfs|btrfs|ext4|ext2)
+    squashfs|btrfs|ext4|ext2|erofs)
         return 0;;
   esac
 
   echo "ERROR: unsupported sysext file system format '$fmt'."
-  echo "Supported file system formats are: squashfs, btrfs, ext4, or ext2."
+  echo "Supported file system formats are: squashfs, btrfs, ext4, ext2, or erofs."
 
   exit 1
 }
@@ -116,6 +116,9 @@ function _generate_sysext() {
       ;;
     squashfs)
       mksquashfs "${basedir}" "${fname}" -all-root -noappend -xattrs-exclude '^btrfs.'
+      ;;
+    erofs)
+      mkfs.erofs --mixed -z none --rootdir "${basedir}" "${fname}"
       ;;
 
   esac


### PR DESCRIPTION
# Add support for EROFS

Now that alpha support EROFS, add support in sysext-bakery to build sysexts in EROFS.

## How to use

Specify `$fmt` as `erofs`

## Testing done

Initial building on test machine seems to work and load but needs more testing to make sure no issues w/ Flatcar and EROFS sysexts.
