### PR TITLE
URL rewrite: support explicit release versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,10 @@ Simplified, this looks like:
   The actual extension image.
 * `.../<extension>.conf` => `/releases/<extension>/<extension>.conf` - sysupdate configuration for that extension
 
+Lastly, for extensions that do not support unattended in-place updates across major releases (like Kubernetes, rke2, etc.)
+we support an additional `<release>` sub-path in the source URL to select a specific release and not have it deduced from the filename:
+* `.../<release>/<extension>.conf` => `/releases/<release>/<extension>.conf`
+
 This requires self-hosting, but is low traffic and low CPU load, as the only task this service has is to re-write HTTP URLs.
 Usually the smallest instance type of your favourite hoster suffices.
 Flatcar uses https://extensions.flatcar.org.

--- a/docs/k3s.md
+++ b/docs/k3s.md
@@ -13,10 +13,10 @@ Download and merge the sysext at provisioning time using the below butane snippe
 The snippet includes automated updates via systemd-sysupdate.
 Sysupdate will stage updates and request a reboot by creating a flag file at `/run/reboot-required`.
 You can deactivate updates by changing `enabled: true` to `enabled: false` in `systemd-sysupdate.timer`.
-Updates are only supported within the same minor release, e.g. v1.31.2 -> v1.31.3; _never_ across releases (v1.31.x -> v1.32.x).
-This is because upstream Kubernetes does not support unattended automated upgrades across minor releases.
+Updates are only supported within the same minor release, e.g. v1.32.2 -> v1.32.3; _never_ across releases (v1.31.x -> v1.32.x).
+This is because upstream Kubernetes does not support unattended automated upgrades across releases.
 
-Note that the snippet is for the x86-64 version of k3s v1.31.3 w/ k3s1.
+Note that the snippet is for the x86-64 version of k3s v1.32.2 w/ k3s1.
 
 Any specific configuration required would need to be added to the below configuration,
 e.g. by providing a token for an agent or server to join or creating a `config.yaml` file.
@@ -28,18 +28,18 @@ version: 1.0.0
 
 storage:
   files:
-    - path: /opt/extensions/k3s/k3s-v1.31.3+k3s1-x86-64.raw
+    - path: /opt/extensions/k3s/k3s-v1.32.2+k3s1-x86-64.raw
       mode: 0644
       contents:
-        source: https://extensions.flatcar.org/extensions/k3s-v1.31.3+k3s1-x86-64.raw
-    - path: /etc/sysupdate.k3s.d/k3s-v1.31.conf
+        source: https://extensions.flatcar.org/extensions/k3s-v1.32.2+k3s1-x86-64.raw
+    - path: /etc/sysupdate.k3s.d/k3s-v1.32.conf
       contents:
-        source: https://extensions.flatcar.org/extensions/k3s.conf
+        source: https://extensions.flatcar.org/extensions/k3s/k3s-v1.32.conf
     - path: /etc/sysupdate.d/noop.conf
       contents:
         source: https://extensions.flatcar.org/extensions/noop.conf
   links:
-    - target: /opt/extensions/k3s/k3s-v1.31.3+k3s1-x86-64.raw
+    - target: /opt/extensions/k3s/k3s-v1.32.2+k3s1-x86-64.raw
       path: /etc/extensions/k3s.raw
       hard: false
 systemd:
@@ -52,7 +52,7 @@ systemd:
           contents: |
             [Service]
             ExecStartPre=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/k3s.raw > /tmp/k3s"
-            ExecStartPre=/usr/lib/systemd/systemd-sysupdate -C k3s-v1.31 update
+            ExecStartPre=/usr/lib/systemd/systemd-sysupdate -C k3s-v1.32 update
             ExecStartPost=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/k3s.raw > /tmp/k3s-new"
             ExecStartPost=/usr/bin/sh -c "if ! cmp --silent /tmp/k3s /tmp/k3s-new; then touch /run/reboot-required; fi"
 ```

--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -13,8 +13,12 @@ As mentioned above, a full howto is available.
 Below are a few config snippets from that howto.
 We'll discuss 2 node types - control plane and worker nodes - with minor differences in their configuration.
 
-Note that the snippets are for the x86-64 version of Kubernetes v1.31.3.
+Note that the snippets are for the x86-64 version of Kubernetes v1.32.2.
 The snippet includes automated updates via systemd-sysupdate.
+
+Updates are only supported within the same minor release, e.g. v1.32.2 -> v1.32.3; _never_ across releases (v1.31.x -> v1.32.x).
+This is because upstream Kubernetes does not support unattended automated upgrades across releases.
+
 Sysupdate will stage updates and request a reboot by creating a flag file at `/run/reboot-required`.
 It is recommended to deploy [kured](https://kured.dev/) to the cluster to manage reboots.
 Alternatively, you can deactivate updates by changing `enabled: true` to `enabled: false` in `systemd-sysupdate.timer`.
@@ -25,19 +29,19 @@ version: 1.0.0
 
 storage:
   links:
-    - target: /opt/extensions/kubernetes/kubernetes-v1.31.3-x86-64.raw
+    - target: /opt/extensions/kubernetes/kubernetes-v1.32.2-x86-64.raw
       path: /etc/extensions/kubernetes.raw
       hard: false
   files:
-    - path: /etc/sysupdate.kubernetes.d/kubernetes-v1.31.conf
+    - path: /etc/sysupdate.kubernetes.d/kubernetes-v1.32.conf
       contents:
-        source: https://extensions.flatcar.org/extensions/kubernetes-v1.31.conf
+        source: https://extensions.flatcar.org/extensions/kubernetes/kubernetes-v1.32.conf
     - path: /etc/sysupdate.d/noop.conf
       contents:
         source: https://extensions.flatcar.org/extensions/noop.conf
-    - path: /opt/extensions/kubernetes/kubernetes-v1.31.3-x86-64.raw
+    - path: /opt/extensions/kubernetes/kubernetes-v1.32.2-x86-64.raw
       contents:
-        source: https://extensions.flatcar.org/extensions/kubernetes-v1.31.3-x86-64.raw
+        source: https://extensions.flatcar.org/extensions/kubernetes-v1.32.2-x86-64.raw
 systemd:
   units:
     - name: systemd-sysupdate.timer
@@ -48,7 +52,7 @@ systemd:
           contents: |
             [Service]
             ExecStartPre=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/kubernetes.raw > /tmp/kubernetes"
-            ExecStartPre=/usr/lib/systemd/systemd-sysupdate -C kubernetes update
+            ExecStartPre=/usr/lib/systemd/systemd-sysupdate -C kubernetes-v1.32 update
             ExecStartPost=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/kubernetes.raw > /tmp/kubernetes-new"
             ExecStartPost=/usr/bin/sh -c "if ! cmp --silent /tmp/kubernetes /tmp/kubernetes-new; then touch /run/reboot-required; fi"
     - name: locksmithd.service

--- a/docs/rke2.md
+++ b/docs/rke2.md
@@ -14,10 +14,10 @@ Download and merge the sysext at provisioning time using the below butane snippe
 The snippet includes automated updates via systemd-sysupdate.
 Sysupdate will stage updates and request a reboot by creating a flag file at `/run/reboot-required`.
 You can deactivate updates by changing `enabled: true` to `enabled: false` in `systemd-sysupdate.timer`.
-Updates are only supported within the same minor release, e.g. v1.31.2 -> v1.31.3; _never_ across releases (v1.31.x -> v1.32.x).
+Updates are only supported within the same minor release, e.g. v1.32.2 -> v1.32.3; _never_ across releases (v1.31.x -> v1.32.x).
 This is because upstream Kubernetes does not support unattended automated upgrades across minor releases.
 
-Note that the snippet is for the x86-64 version of rke2 v1.31.1.
+Note that the snippet is for the x86-64 version of rke2 v1.32.2.
 
 Generic configuration for both Server (control plane) and Agent (worker):
 
@@ -29,15 +29,15 @@ storage:
   files:
     - path: /etc/extensions/rke2.raw
       contents:
-        source: https://extensions.flatcar.org/extensions/rke2-v1.31.1+rke2r1-x86-64.raw
-    - path: /etc/sysupdate.rke2.d/rke2-v1.31.conf
+        source: https://extensions.flatcar.org/extensions/rke2-v1.32.2+rke2r1-x86-64.raw
+    - path: /etc/sysupdate.rke2.d/rke2-v1.32.conf
       contents:
-        source: https://extensions.flatcar.org/extensions/rke2.conf
+        source: https://extensions.flatcar.org/extensions/rke2/rke2-v1.32.conf
     - path: /etc/sysupdate.d/noop.conf
       contents:
         source: https://extensions.flatcar.org/extensions/noop.conf
   links:
-    - target: /opt/extensions/rke2/rke2-v1.31.3+k3s1-x86-64.raw
+    - target: /opt/extensions/rke2/rke2-v1.32.2+k3s1-x86-64.raw
       path: /etc/extensions/k3s.raw
       hard: false
 
@@ -51,7 +51,7 @@ systemd:
           contents: |
             [Service]
             ExecStartPre=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/rke2.raw > /tmp/rke2"
-            ExecStartPre=/usr/lib/systemd/systemd-sysupdate -C rke2-v1.31 update
+            ExecStartPre=/usr/lib/systemd/systemd-sysupdate -C rke2-v1.32 update
             ExecStartPost=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/rke2.raw > /tmp/rke2-new"
             ExecStartPost=/usr/bin/sh -c "if ! cmp --silent /tmp/rke2 /tmp/rke2-new; then touch /run/reboot-required; fi"
 ```

--- a/tools/http-url-rewrite-server/Caddyfile
+++ b/tools/http-url-rewrite-server/Caddyfile
@@ -26,15 +26,22 @@ extensions.flatcar.org {
 	#     <extension>-<version>-<arch>.raw
 	#       ==>  https://[...]/releases/download/<extension>-<version>/<extension>-<version>-<arch>.raw
 	# Match groups: 1 - extension, 2 - version, 3 - arch
-	@raw path_regexp raw ^.*/extensions/*.*/([^/]+)-([^/]+)-(x86-64|arm64).raw$
+	@raw path_regexp raw ^.*/extensions/([^/]+)-([^/]+)-(x86-64|arm64).raw$
 	redir @raw {vars.base_dest_url}/{re.raw.1}-{re.raw.2}/{re.raw.1}-{re.raw.2}-{re.raw.3}.raw
 
 	# Sysupdate conf. This is only used by Ignition.
 	#     <extension>-<version>.conf
 	#       ==>  https://[...]/releases/download/<extension>-<version>/<extension>-<version>.conf
-	# Match groups: 1 - extension, 2 - version, 3 - arch
-	@conf path_regexp conf ^.*/extensions/*.*/([^/]+).conf$
+	# Match groups: 1 - extension, 2 - version
+	@conf path_regexp conf ^.*/extensions/([^/]+).conf$
 	redir @conf {vars.base_dest_url}/{re.conf.1}/{re.conf.1}.conf
+
+	# Sysupdate or extension image with explicit release sub-path.
+	#     /<release>/<extension-conf-or-raw>
+	#       ==>  https://[...]/releases/download/<release>/<extension-conf-or-raw>
+	# Match groups: 1 - release, 2 - filename, 3 - suffix
+	@expl path_regexp expl ^.*/extensions/([^/]+)/([^/]+).(conf|raw)$
+	redir @expl {vars.base_dest_url}/{re.expl.1}/{re.expl.2}.{re.expl.3}
 
 	# Extension specific SHA file with extension name in path (group 1)
 	#     <extension>/SHA256SUMS


### PR DESCRIPTION
Some extensions, e.g. Kubernetes, do not allow unattended in-place updates across major versions. These use the pattern `<extension>-<majorversion>.conf` for their sysupdate configurations.

The URL rewriter incorrectly redirects to
`.../releases/tags/<extension>-<majorversion>/<extension>-<majorversion>.conf`.

This change adds an explicit `.../<release>/<file>.(conf|raw)` to the URL rewriter and updates Kubernetes, rke2, and k3s documentation as well as the developer README.md .

Fixes #123 