### PR TITLE
docs: fix configuration examples extension versions

### DIFF
--- a/docs/containerd.md
+++ b/docs/containerd.md
@@ -14,7 +14,9 @@ The snippet includes automated updates via systemd-sysupdate.
 Sysupdate will stage updates and request a reboot by creating a flag file at `/run/reboot-required`.
 You can deactivate updates by changing `enabled: true` to `enabled: false` in `systemd-sysupdate.timer`.
 
-Note that the snippet is for the x86-64 version of containerd 2.0.0.
+Note that the snippet is for the x86-64 version of containerd 2.0.4.
+
+Check out the metadata release at https://github.com/flatcar/sysext-bakery/releases/tag/containerd for a list of all versions available in the bakery.
 
 ```yaml
 variant: flatcar
@@ -22,10 +24,10 @@ version: 1.0.0
 
 storage:
   files:
-    - path: /opt/extensions/containerd/containerd-2.0.0-x86-64.raw
+    - path: /opt/extensions/containerd/containerd-2.0.4-x86-64.raw
       mode: 0644
       contents:
-        source: https://extensions.flatcar.org/extensions/containerd-2.0.0-x86-64.raw
+        source: https://extensions.flatcar.org/extensions/containerd-2.0.4-x86-64.raw
     - path: /etc/sysupdate.containerd.d/containerd.conf
       contents:
         source: https://extensions.flatcar.org/extensions/containerd.conf
@@ -33,7 +35,7 @@ storage:
       contents:
         source: https://extensions.flatcar.org/extensions/noop.conf
   links:
-    - target: /opt/extensions/containerd/containerd-2.0.0-x86-64.raw
+    - target: /opt/extensions/containerd/containerd-2.0.4-x86-64.raw
       path: /etc/extensions/containerd.raw
       hard: false
     - path: /etc/extensions/containerd-flatcar.raw

--- a/docs/crio.md
+++ b/docs/crio.md
@@ -17,7 +17,9 @@ The snippet includes automated updates via systemd-sysupdate.
 Sysupdate will stage updates and request a reboot by creating a flag file at `/run/reboot-required`.
 You can deactivate updates by changing `enabled: true` to `enabled: false` in `systemd-sysupdate.timer`.
 
-Note that the snippet is for the x86-64 version of cri-o v1.31.3.
+Note that the snippet is for the x86-64 version of cri-o v1.32.2.
+
+Check out the metadata release at https://github.com/flatcar/sysext-bakery/releases/tag/crio for a list of all versions available in the bakery.
 
 ```yaml
 variant: flatcar
@@ -25,10 +27,10 @@ version: 1.0.0
 
 storage:
   files:
-    - path: /opt/extensions/crio/crio-v1.31.3-x86-64.raw
+    - path: /opt/extensions/crio/crio-v1.32.2-x86-64.raw
       mode: 0644
       contents:
-        source: https://extensions.flatcar.org/extensions/crio-v1.31.3-x86-64.raw
+        source: https://extensions.flatcar.org/extensions/crio-v1.32.2-x86-64.raw
     - path: /etc/sysupdate.crio.d/crio.conf
       contents:
         source: https://extensions.flatcar.org/extensions/crio.conf
@@ -36,7 +38,7 @@ storage:
       contents:
         source: https://extensions.flatcar.org/extensions/noop.conf
   links:
-    - target: /opt/extensions/crio/crio-v1.31.3-x86-64.raw
+    - target: /opt/extensions/crio/crio-v1.32.2-x86-64.raw
       path: /etc/extensions/crio.raw
       hard: false
 systemd:

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -15,7 +15,9 @@ The snippet includes automated updates via systemd-sysupdate.
 Sysupdate will stage updates and request a reboot by creating a flag file at `/run/reboot-required`.
 You can deactivate updates by changing `enabled: true` to `enabled: false` in `systemd-sysupdate.timer`.
 
-Note that the snippet is for the x86-64 version of docker 25.0.3.
+Note that the snippet is for the x86-64 version of docker 28.0.4.
+
+Check out the metadata release at https://github.com/flatcar/sysext-bakery/releases/tag/docker for a list of all versions available in the bakery.
 
 ```yaml
 variant: flatcar
@@ -23,10 +25,10 @@ version: 1.0.0
 
 storage:
   files:
-    - path: /opt/extensions/docker/docker-25.0.3-x86-64.raw
+    - path: /opt/extensions/docker/docker-28.0.4-x86-64.raw
       mode: 0644
       contents:
-        source: https://extensions.flatcar.org/extensions/docker-25.0.3-x86-64.raw
+        source: https://extensions.flatcar.org/extensions/docker-28.0.4-x86-64.raw
     - path: /etc/sysupdate.docker.d/docker.conf
       contents:
         source: https://extensions.flatcar.org/extensions/docker.conf
@@ -34,7 +36,7 @@ storage:
       contents:
         source: https://extensions.flatcar.org/extensions/noop.conf
   links:
-    - target: /opt/extensions/docker/docker-25.0.3-x86-64.raw
+    - target: /opt/extensions/docker/docker-28.0.4-x86-64.raw
       path: /etc/extensions/docker.raw
       hard: false
     - path: /etc/extensions/docker-flatcar.raw

--- a/docs/docker_compose.md
+++ b/docs/docker_compose.md
@@ -10,7 +10,9 @@ The snippet includes automated updates via systemd-sysupdate.
 Sysupdate will stage updates and request a reboot by creating a flag file at `/run/reboot-required`.
 You can deactivate updates by changing `enabled: true` to `enabled: false` in `systemd-sysupdate.timer`.
 
-Note that the snippet is for the x86-64 version of docker-compose 2.24.5.
+Note that the snippet is for the x86-64 version of docker-compose 2.34.0.
+
+Check out the metadata release at https://github.com/flatcar/sysext-bakery/releases/tag/docker-compose for a list of all versions available in the bakery.
 
 ```yaml
 variant: flatcar
@@ -18,10 +20,10 @@ version: 1.0.0
 
 storage:
   files:
-    - path: /opt/extensions/docker-compose/docker-compose-2.24.5-x86-64.raw
+    - path: /opt/extensions/docker-compose/docker-compose-2.34.0-x86-64.raw
       mode: 0644
       contents:
-        source: https://extensions.flatcar.org/extensions/docker-compose-2.24.5-x86-64.raw
+        source: https://extensions.flatcar.org/extensions/docker-compose-2.34.0-x86-64.raw
     - path: /etc/sysupdate.docker-compose.d/docker-compose.conf
       contents:
         source: https://extensions.flatcar.org/extensions/docker-compose.conf
@@ -29,7 +31,7 @@ storage:
       contents:
         source: https://extensions.flatcar.org/extensions/noop.conf
   links:
-    - target: /opt/extensions/docker-compose/docker-compose-2.24.5-x86-64.raw
+    - target: /opt/extensions/docker-compose/docker-compose-2.34.0-x86-64.raw
       path: /etc/extensions/docker-compose.raw
       hard: false
 systemd:

--- a/docs/falco.md
+++ b/docs/falco.md
@@ -25,7 +25,9 @@ The snippet includes automated updates via systemd-sysupdate.
 Sysupdate will stage updates and request a reboot by creating a flag file at `/run/reboot-required`.
 You can deactivate updates by changing `enabled: true` to `enabled: false` in `systemd-sysupdate.timer`.
 
-Note that the snippet is for the x86-64 version of falco 0.39.1.
+Note that the snippet is for the x86-64 version of falco 0.40.0.
+
+Check out the metadata release at https://github.com/flatcar/sysext-bakery/releases/tag/falco for a list of all versions available in the bakery.
 
 ```yaml
 variant: flatcar
@@ -33,10 +35,10 @@ version: 1.0.0
 
 storage:
   files:
-    - path: /opt/extensions/falco/falco-0.39.1-x86-64.raw
+    - path: /opt/extensions/falco/falco-0.40.0-x86-64.raw
       mode: 0644
       contents:
-        source: https://extensions.flatcar.org/extensions/falco-0.39.1-x86-64.raw
+        source: https://extensions.flatcar.org/extensions/falco-0.40.0-x86-64.raw
     - path: /etc/sysupdate.falco.d/falco.conf
       contents:
         source: https://extensions.flatcar.org/extensions/falco.conf
@@ -44,7 +46,7 @@ storage:
       contents:
         source: https://extensions.flatcar.org/extensions/noop.conf
   links:
-    - target: /opt/extensions/falco/falco-0.39.1-x86-64.raw
+    - target: /opt/extensions/falco/falco-0.40.0-x86-64.raw
       path: /etc/extensions/falco.raw
       hard: false
 systemd:

--- a/docs/k3s.md
+++ b/docs/k3s.md
@@ -18,6 +18,8 @@ This is because upstream Kubernetes does not support unattended automated upgrad
 
 Note that the snippet is for the x86-64 version of k3s v1.32.2 w/ k3s1.
 
+Check out the metadata release at https://github.com/flatcar/sysext-bakery/releases/tag/k3s for a list of all versions available in the bakery.
+
 Any specific configuration required would need to be added to the below configuration,
 e.g. by providing a token for an agent or server to join or creating a `config.yaml` file.
 

--- a/docs/keepalived.md
+++ b/docs/keepalived.md
@@ -12,6 +12,8 @@ You can deactivate updates by changing `enabled: true` to `enabled: false` in `s
 
 Note that the snippet is for the x86-64 version of keepalived v2.3.1.
 
+Check out the metadata release at https://github.com/flatcar/sysext-bakery/releases/tag/keepalived for a list of all versions available in the bakery.
+
 ```yaml
 variant: flatcar
 version: 1.0.0

--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -14,8 +14,10 @@ Below are a few config snippets from that howto.
 We'll discuss 2 node types - control plane and worker nodes - with minor differences in their configuration.
 
 Note that the snippets are for the x86-64 version of Kubernetes v1.32.2.
-The snippet includes automated updates via systemd-sysupdate.
 
+Check out the metadata release at https://github.com/flatcar/sysext-bakery/releases/tag/kubernetes for a list of all versions available in the bakery.
+
+The snippet includes automated updates via systemd-sysupdate.
 Updates are only supported within the same minor release, e.g. v1.32.2 -> v1.32.3; _never_ across releases (v1.31.x -> v1.32.x).
 This is because upstream Kubernetes does not support unattended automated upgrades across releases.
 

--- a/docs/llamaedge.md
+++ b/docs/llamaedge.md
@@ -25,6 +25,8 @@ You can deactivate updates by changing `enabled: true` to `enabled: false` in `s
 
 Note that the snippet is for the x86-64 version of WasmEdge 0.14.1 and LlamaEdge 0.14.16.
 
+Check out the metadata release at https://github.com/flatcar/sysext-bakery/releases/tag/llamaedge for a list of all versions available in the bakery.
+
 ```yaml
 variant: flatcar
 version: 1.0.0
@@ -34,7 +36,7 @@ storage:
     - path: /opt/extensions/wasmedge-0.14.1-x86-64.raw
       mode: 0420
       contents:
-        source: https://extensions.flatcar.org/extensions/wasmaedge-0.14.1-x86-64.raw
+        source: https://extensions.flatcar.org/extensions/wasmedge-0.14.1-x86-64.raw
     - path: /opt/extensions/llamaedge-0.14.16-x86-64.raw
       mode: 0420
       contents:

--- a/docs/nebula.md
+++ b/docs/nebula.md
@@ -6,6 +6,8 @@ This sysext ships [Nebula](https://github.com/slackhq/nebula).
 
 Refer to the following Butane snippet that enables Nebula v1.9.5 for an x86-64 machine with automated updates using `systemd-sysupdate`.
 
+Check out the metadata release at https://github.com/flatcar/sysext-bakery/releases/tag/nebula for a list of all versions available in the bakery.
+
 Note that you will also need to supply a [Nebula config file](https://github.com/slackhq/nebula/blob/master/examples/config.yml) at `/etc/nebula/config.yaml`, as well as necessary key files. You can embed them into the `files` section of your Butane configuration.
 
 ```yaml

--- a/docs/nerdctl.md
+++ b/docs/nerdctl.md
@@ -8,19 +8,20 @@ If the plugins are not included, `nerdctl` can only operate in `--net host` mode
 
 # Usage
 
-The first (and simplest) example ships nerdctl (version 2.0.3) only; i.e. it uses containerd provided by the OS.
+The example ships nerdctl (version 2.0.4) only; i.e. it uses containerd provided by the OS.
 Please refer to the containerd and docker extension documentation referenced above to combine nerdctl with a custom containerd.
 
+Check out the metadata release at https://github.com/flatcar/sysext-bakery/releases/tag/nerdctl for a list of all versions available in the bakery.
 ```yaml
 variant: flatcar
 version: 1.0.0
 
 storage:
   files:
-    - path: /opt/extensions/nerdctl-v2.0.3.raw
+    - path: /opt/extensions/nerdctl-v2.0.4.raw
       mode: 0420
       contents:
-        source: https://extensions.flatcar.org/extensions/nerdctl-v2.0.3.raw
+        source: https://extensions.flatcar.org/extensions/nerdctl-v2.0.4.raw
     - path: /etc/sysupdate.nerdctl.d/nerdctl.conf
       contents:
         source: https://extensions.flatcar.org/extensions/nerdctl.conf
@@ -28,7 +29,7 @@ storage:
       contents:
         source: https://extensions.flatcar.org/extensions/noop.conf
   links:
-    - target: /opt/extensions/nerdctl-v2.0.3.raw
+    - target: /opt/extensions/nerdctl-v2.0.4.raw
       path: /etc/extensions/nerdctl.raw
       hard: false
 

--- a/docs/nvidia_runtime.md
+++ b/docs/nvidia_runtime.md
@@ -13,7 +13,9 @@ The snippet includes automated updates via systemd-sysupdate.
 Sysupdate will stage updates and request a reboot by creating a flag file at `/run/reboot-required`.
 
 You can deactivate updates by changing `enabled: true` to `enabled: false` in `systemd-sysupdate.timer`.
-Note that the snippet is for the x86-64 version of the NVIDIA runtime version v1.16.2.
+Note that the snippet is for the x86-64 version of the NVIDIA runtime version v1.17.5.
+
+Check out the metadata release at https://github.com/flatcar/sysext-bakery/releases/tag/nvidia-runtime for a list of all versions available in the bakery.
 
 ```yaml
 variant: flatcar
@@ -21,10 +23,10 @@ version: 1.0.0
 
 storage:
   files:
-    - path: /opt/extensions/nvidia_runtime/nvidia_runtime-v1.16.2-x86-64.raw
+    - path: /opt/extensions/nvidia_runtime/nvidia_runtime-v1.17.5-x86-64.raw
       mode: 0644
       contents:
-        source: https://extensions.flatcar.org/extensions/nvidia_runtime-v1.16.2-x86-64.raw
+        source: https://extensions.flatcar.org/extensions/nvidia_runtime-v1.17.5-x86-64.raw
     - path: /etc/sysupdate.nvidia_runtime.d/nvidia_runtime.conf
       contents:
         source: https://extensions.flatcar.org/extensions/nvidia_runtime.conf
@@ -32,7 +34,7 @@ storage:
       contents:
         source: https://extensions.flatcar.org/extensions/noop.conf
   links:
-    - target: /opt/extensions/nvidia_runtime/nvidia_runtime-v1.16.2-x86-64.raw
+    - target: /opt/extensions/nvidia_runtime/nvidia_runtime-v1.17.5-x86-64.raw
       path: /etc/extensions/nvidia_runtime.raw
       hard: false
 systemd:

--- a/docs/ollama.md
+++ b/docs/ollama.md
@@ -15,7 +15,9 @@ The snippet includes automated updates via systemd-sysupdate.
 Sysupdate will stage updates and request a reboot by creating a flag file at `/run/reboot-required`.
 You can deactivate updates by changing `enabled: true` to `enabled: false` in `systemd-sysupdate.timer`.
 
-The snippet below deploys the x86-64 version of Ollama 0.3.9.
+The snippet below deploys the x86-64 version of Ollama 0.6.3.
+Check out the metadata release at https://github.com/flatcar/sysext-bakery/releases/tag/ollama for a list of all versions available in the bakery.
+
 **NOTE** in the default configuration, the Ollama API will be **publicly accessible**.
 Please update `OLLAMA_HOST` before deployment if you want to change that.
 
@@ -25,9 +27,9 @@ version: 1.0.0
 
 storage:
   files:
-    - path: /opt/extensions/ollama/ollama-v0.3.9-x86-64.raw
+    - path: /opt/extensions/ollama/ollama-v0.6.3-x86-64.raw
       contents:
-        source: https://extensions.flatcar.org/extensions/ollama-v0.3.9-x86-64.raw
+        source: https://extensions.flatcar.org/extensions/ollama-v0.6.3-x86-64.raw
     - path: /etc/sysupdate.ollama.d/ollama.conf
       contents:
         source: https://extensions.flatcar.org/extensions/ollama.conf
@@ -35,7 +37,7 @@ storage:
       contents:
         source: https://extensions.flatcar.org/extensions/noop.conf
   links:
-    - target: /opt/extensions/ollama/ollama-v0.3.9-x86-64.raw
+    - target: /opt/extensions/ollama/ollama-v0.6.3-x86-64.raw
       path: /etc/extensions/ollama.raw
       hard: false
 

--- a/docs/rke2.md
+++ b/docs/rke2.md
@@ -19,6 +19,8 @@ This is because upstream Kubernetes does not support unattended automated upgrad
 
 Note that the snippet is for the x86-64 version of rke2 v1.32.2.
 
+Check out the metadata release at https://github.com/flatcar/sysext-bakery/releases/tag/rke2 for a list of all versions available in the bakery.
+
 Generic configuration for both Server (control plane) and Agent (worker):
 
 ```yaml

--- a/docs/tailscale.md
+++ b/docs/tailscale.md
@@ -17,7 +17,9 @@ The snippet includes automated updates via systemd-sysupdate.
 Sysupdate will stage updates and request a reboot by creating a flag file at `/run/reboot-required`.
 You can deactivate updates by changing `enabled: true` to `enabled: false` in `systemd-sysupdate.timer`.
 
-Note that the snippet is for the x86-64 version of tailscale 1.76.6.
+Note that the snippet is for the x86-64 version of tailscale 1.80.3.
+
+Check out the metadata release at https://github.com/flatcar/sysext-bakery/releases/tag/tailscale for a list of all versions available in the bakery.
 
 ```yaml
 variant: flatcar
@@ -25,10 +27,10 @@ version: 1.0.0
 
 storage:
   files:
-    - path: /opt/extensions/tailscale/tailscale-v1.76.6-x86-64.raw
+    - path: /opt/extensions/tailscale/tailscale-v1.80.3-x86-64.raw
       mode: 0644
       contents:
-        source: https://extensions.flatcar.org/extensions/tailscale-v1.76.6-x86-64.raw
+        source: https://extensions.flatcar.org/extensions/tailscale-v1.80.3-x86-64.raw
     - path: /etc/sysupdate.tailscale.d/tailscale.conf
       contents:
         source: https://extensions.flatcar.org/extensions/tailscale.conf
@@ -39,7 +41,7 @@ storage:
     - path: /etc/systemd/system/multi-user.target.wants/tailscaled.service
       target: /usr/local/lib/systemd/system/tailscaled.service
       overwrite: true
-    - target: /opt/extensions/tailscale/tailscale-v1.76.6-x86-64.raw
+    - target: /opt/extensions/tailscale/tailscale-v1.80.3-x86-64.raw
       path: /etc/extensions/tailscale.raw
       hard: false
 systemd:

--- a/docs/wasmcloud.md
+++ b/docs/wasmcloud.md
@@ -13,8 +13,9 @@ The snippet includes automated updates via systemd-sysupdate.
 Sysupdate will **merge the new sysext immediately after successful download**.
 You can deactivate updates by changing `enabled: true` to `enabled: false` in `systemd-sysupdate.timer`.
 
-Note that the snippet is for the x86-64 version of wasmcloud 1.2.1.
+Note that the snippet is for the x86-64 version of wasmcloud 1.7.0.
 
+Check out the metadata release at https://github.com/flatcar/sysext-bakery/releases/tag/wasmcloud for a list of all versions available in the bakery.
 
 The following customisations have been made (see comments in the config snippet)
 
@@ -29,13 +30,13 @@ version: 1.0.0
 
 storage:
   links:
-    - target: /opt/extensions/wasmcloud/wasmcloud-v1.2.1-x86-64.raw
+    - target: /opt/extensions/wasmcloud/wasmcloud-v1.7.0-x86-64.raw
       path: /etc/extensions/wasmcloud.raw
       hard: false
   files:
-    - path: /opt/extensions/wasmcloud/wasmcloud-v1.2.1-x86-64.raw
+    - path: /opt/extensions/wasmcloud/wasmcloud-v1.7.0-x86-64.raw
       contents:
-        source: https://extensions.flatcar.org/extensions/wasmcloud-v1.2.1-x86-64.raw
+        source: https://extensions.flatcar.org/extensions/wasmcloud-v1.7.0-x86-64.raw
     - path: /etc/sysupdate.wasmcloud.d/wasmcloud.conf
       contents:
         source: https://extensions.flatcar.org/extensions/wasmcloud.conf

--- a/docs/wasmedge.md
+++ b/docs/wasmedge.md
@@ -14,6 +14,8 @@ You can deactivate updates by changing `enabled: true` to `enabled: false` in `s
 
 Note that the snippet is for the x86-64 version of wasmedge 0.14.1.
 
+Check out the metadata release at https://github.com/flatcar/sysext-bakery/releases/tag/wasmedge for a list of all versions available in the bakery.
+
 ```yaml
 variant: flatcar
 version: 1.0.0

--- a/docs/wasmtime.md
+++ b/docs/wasmtime.md
@@ -13,7 +13,9 @@ The snippet includes automated updates via systemd-sysupdate.
 Sysupdate will **merge the new sysext immediately after successful download**.
 You can deactivate updates by changing `enabled: true` to `enabled: false` in `systemd-sysupdate.timer`.
 
-Note that the snippet is for the x86-64 version of wasmtime 24.0.0.
+Note that the snippet is for the x86-64 version of wasmtime 31.0.0.
+
+Check out the metadata release at https://github.com/flatcar/sysext-bakery/releases/tag/wasmtime for a list of all versions available in the bakery.
 
 ```yaml
 variant: flatcar
@@ -21,13 +23,13 @@ version: 1.0.0
 
 storage:
   links:
-    - target: /opt/extensions/wasmtime/wasmtime-v24.0.0-x86-64.raw
+    - target: /opt/extensions/wasmtime/wasmtime-v31.0.0-x86-64.raw
       path: /etc/extensions/wasmtime.raw
       hard: false
   files:
-    - path: /opt/extensions/wasmtime/wasmtime-v24.0.0-x86-64.raw
+    - path: /opt/extensions/wasmtime/wasmtime-v31.0.0-x86-64.raw
       contents:
-        source: https://extensions.flatcar.org/extensions/wasmtime-v24.0.0-x86-64.raw
+        source: https://extensions.flatcar.org/extensions/wasmtime-v31.0.0-x86-64.raw
     - path: /etc/sysupdate.wasmtime.d/wasmtime.conf
       contents:
         source: https://extensions.flatcar.org/extensions/wasmtime.conf

--- a/llamaedge.sysext/create.sh
+++ b/llamaedge.sysext/create.sh
@@ -32,7 +32,7 @@ function populate_sysext_root() {
        -fsSL "https://github.com/LlamaEdge/LlamaEdge/releases/download/${version}/llama-api-server.wasm"
 
   tar --force-local -xzf "WasmEdge-plugin.tar.gz"
-  mkdir -p "${sysextroot}"/usr/lib/wasmedge/wasm
+  mkdir -p "${sysextroot}"/usr/lib/wasmedge/wasm "${sysextroot}"/usr/share/llamaedge/
 
   cp -a libwasmedgePluginWasiNN.so "${sysextroot}"/usr/lib/wasmedge
   cp -a llama-api-server.wasm "${sysextroot}"/usr/lib/wasmedge/wasm

--- a/release_build_versions.txt
+++ b/release_build_versions.txt
@@ -26,8 +26,6 @@ docker-compose 2.22.0
 docker-compose 2.24.5
 docker-compose latest
 
-docker 24.0.9
-docker 25.0.3
 docker latest
 
 falco 0.39.1
@@ -42,7 +40,7 @@ kubernetes v1.28.5 # required for CAPO CI
 kubernetes v1.27.3 # required for CAPG CI
 kubernetes latest
 
-# TODO: llamaedge sysext depends on wasmedge sysext version, so we can't automatically build it :-/
+# TODO: llamaedge sysext depends on wasmedge sysext version (build parameter), so we can't automatically build it :-/
 
 nebula v1.9.5
 nebula latest
@@ -65,7 +63,7 @@ wasmcloud v1.1.1
 wasmcloud v1.2.1
 wasmcloud latest
 
-wasmedge 0.14.1
+wasmedge 0.14.1 # manually built llamaedge 0.14.16 uses this
 wasmedge latest
 
 wasmtime v12.0.0


### PR DESCRIPTION
Not all versions used in extensions' configuration snippets are available in the "new" bakery releases, and some were very outdated. This change updates configuration snippets to use more recent versions that actually exist in the bakery.