### PR TITLE
Allow creating sysext with 'latest' version

### DIFF
--- a/bakery.sh
+++ b/bakery.sh
@@ -116,6 +116,10 @@ function create_sysext() {
     return 1
   fi
 
+  if [[ ${version} == latest ]] ; then
+    version="$(list_sysext "$extname" --latest true)"
+  fi
+
   local workdir="$(mktemp -d)"
   local sysextroot_tmp="$(mktemp -d)"
   trap "rm -rf '${workdir}' '${sysextroot_tmp}'" EXIT


### PR DESCRIPTION
# Allow for building sysext without knowing the version

This allows you to run `./bakery.sh create <sysext> latest`.

## How to use

1. before patch
2. `./bakery.sh create k3s latest`
3. apply patch
4. `./bakery.sh create k3s latest`

## Testing done

Above steps

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
