### PR TITLE
keepalived: do not use /usr/sbin

### DIFF
--- a/keepalived.sysext/create.sh
+++ b/keepalived.sysext/create.sh
@@ -30,9 +30,13 @@ function populate_sysext_root() {
               -i \
               -v "$(pwd)":/install_root \
               --platform "linux/${img_arch}" \
-              alpine \
+              --pull always \
+              alpine:v3.21 \
                   /install_root/build.sh "${version}" "$user_group"
 
+  # /usr/sbin is a symlink to /usr/bin on Flatcar.
+  mv usr/sbin/keepalived usr/bin
+  rmdir usr/sbin
   cp -aR usr "${sysextroot}"/
 }
 # --


### PR DESCRIPTION
/usr/sbin is a symlink to /usr/bin on recent Flatcar releases. Sysexts shipping /usr/sbin would overwrite that symlink and sbin would contain only the contents that sysext ships.

We copy keepalived to /usr/bin and also pin the Alpine Linux release used for the build.

After merge we need to delete the keepalived releases to force a rebuild.

Fixes #131 