### PR TITLE
lib/generate: fix URL in sysupdate conf

### DIFF
--- a/lib/generate.sh
+++ b/lib/generate.sh
@@ -83,8 +83,12 @@ function _create_metadata() {
 function _create_sysupdate() {
   local extname="$1"
   local match_pattern="${2:-${extname}-@v-%a.raw}"
-  local source_rel="${3:-${extname}}"
-  local target_file="${4:-${source_rel}}"
+  local source_rel="${3:-}"
+  local target_file="${4:-${extname}}"
+
+  if [[ -n $source_rel ]] ; then
+    source_rel="${source_rel%/}/"
+  fi
 
   sed -e "s/{EXTNAME}/${extname}/g" \
       -e "s/{MATCH_PATTERN}/${match_pattern}/g" \

--- a/lib/sysupdate.conf.tmpl
+++ b/lib/sysupdate.conf.tmpl
@@ -3,7 +3,7 @@ Verify=false
 
 [Source]
 Type=url-file
-Path=https://extensions.flatcar.org/extensions/{SOURCE_REL}/
+Path=https://extensions.flatcar.org/extensions/{SOURCE_REL}
 MatchPattern={MATCH_PATTERN}
 
 [Target]


### PR DESCRIPTION
510b5193ce659392efa51857b5e03e9b250f0287 added support for explicit release URLs for raw files but broke generic URLs as the version part of the URL was dropped.

This change updates sysupdate to use the plain extensions/ URL by default for SHA256SUMS and raw files, mitigating the issue.

Fixes #127.

TODO after merging: delete all affected releases (basically everything except kubernetes, rke, and k3s) to force a rebuild OR fix-up the .conf files manually and re-upload to affected releases.