### PR TITLE
[FEATURE] Add support for custom bakery url

### DIFF
--- a/bakery.sh
+++ b/bakery.sh
@@ -45,7 +45,7 @@ function _create_sysext_help() {
   echo " --arch <arch>:  Architecture supported by the sysext."
   echo "                    Either x86-64 (the default)  or arm64."
   echo " --bakery <url>: URL for the bakery."
-  echo "                    Default is: extensions.flatcar.org"
+  echo "                    Default is: 'https://extensions.flatcar.org/extensions'."
   _generate_sysext_options
   if [[ $(type -t populate_sysext_root_options ) == function ]] ; then
     echo "Sysext specific optional parameters:"

--- a/bakery.sh
+++ b/bakery.sh
@@ -44,6 +44,8 @@ function _create_sysext_help() {
   echo "Optional arguments:"
   echo " --arch <arch>:  Architecture supported by the sysext."
   echo "                    Either x86-64 (the default)  or arm64."
+  echo " --bakery <url>: URL for the bakery."
+  echo "                    Default is: extensions.flatcar.org"
   _generate_sysext_options
   if [[ $(type -t populate_sysext_root_options ) == function ]] ; then
     echo "Sysext specific optional parameters:"

--- a/lib/generate.sh
+++ b/lib/generate.sh
@@ -85,13 +85,13 @@ function _create_sysupdate() {
   local match_pattern="${2:-${extname}-@v-%a.raw}"
   local source_rel="${3:-${extname}}"
   local target_file="${4:-${source_rel}}"
-  local bakery_url=$(get_optional_param 'bakery' "${bakery_hub}" "${@}")
+  local bakery_base_url=$(get_optional_param 'bakery' "${bakery_base_url}" "${@}")
 
   sed -e "s/{EXTNAME}/${extname}/g" \
       -e "s/{MATCH_PATTERN}/${match_pattern}/g" \
       -e "s,{SOURCE_REL},${source_rel},g" \
       -e "s,{TARGET_FILE},${target_file},g" \
-      -e "s,{BAKERY_URL},${bakery_url},g" \
+      -e "s,{BAKERY_URL},${bakery_base_url},g" \
       "${libroot}/sysupdate.conf.tmpl" \
     >"${extname}.conf"
 
@@ -153,6 +153,8 @@ function _generate_sysext_options() {
   echo " --epoch <epoch>:      Set SOURCE_DATE_EPOCH (defaults to "0") for reproducible builds."
   echo "                       See https://reproducible-builds.org/docs/source-date-epoch/"
   echo "                       for more information."
+  echo " --bakery <url>        URL for bakery to fetch sysexts from."
+  echo "                       Defaults to 'https://extensions.flatcar.org/extensions'."
 }
 # --
 

--- a/lib/generate.sh
+++ b/lib/generate.sh
@@ -85,11 +85,13 @@ function _create_sysupdate() {
   local match_pattern="${2:-${extname}-@v-%a.raw}"
   local source_rel="${3:-${extname}}"
   local target_file="${4:-${source_rel}}"
+  local bakery_url=$(get_optional_param 'bakery' "${bakery_hub}" "${@}")
 
   sed -e "s/{EXTNAME}/${extname}/g" \
       -e "s/{MATCH_PATTERN}/${match_pattern}/g" \
       -e "s,{SOURCE_REL},${source_rel},g" \
       -e "s,{TARGET_FILE},${target_file},g" \
+      -e "s,{BAKERY_URL},${bakery_url},g" \
       "${libroot}/sysupdate.conf.tmpl" \
     >"${extname}.conf"
 

--- a/lib/generate.sh
+++ b/lib/generate.sh
@@ -91,7 +91,7 @@ function _create_sysupdate() {
       -e "s/{MATCH_PATTERN}/${match_pattern}/g" \
       -e "s,{SOURCE_REL},${source_rel},g" \
       -e "s,{TARGET_FILE},${target_file},g" \
-      -e "s,{BAKERY_URL},${bakery_base_url},g" \
+      -e "s,{BAKERY_BASE_URL},${bakery_base_url},g" \
       "${libroot}/sysupdate.conf.tmpl" \
     >"${extname}.conf"
 

--- a/lib/libbakery.sh
+++ b/lib/libbakery.sh
@@ -11,7 +11,7 @@ libroot="$(dirname "${BASH_SOURCE[0]}")"
 scriptroot="$(cd "$(dirname "${BASH_SOURCE[0]}")/../"; pwd)"
 
 bakery="flatcar/sysext-bakery"
-bakery_hub="extensions.flatcar.org"
+bakery_base_url="https://extensions.flatcar.org/extensions"
 
 # Add new library function scripts here:
 source "${libroot}/helpers.sh"

--- a/lib/sysupdate.conf.tmpl
+++ b/lib/sysupdate.conf.tmpl
@@ -3,7 +3,7 @@ Verify=false
 
 [Source]
 Type=url-file
-Path={BAKERY_URL}/{SOURCE_REL}/
+Path={BAKERY_BASE_URL}/{SOURCE_REL}/
 MatchPattern={MATCH_PATTERN}
 
 [Target]

--- a/lib/sysupdate.conf.tmpl
+++ b/lib/sysupdate.conf.tmpl
@@ -3,7 +3,7 @@ Verify=false
 
 [Source]
 Type=url-file
-Path=https://{BAKERY_URL}/extensions/{SOURCE_REL}/
+Path={BAKERY_URL}/{SOURCE_REL}/
 MatchPattern={MATCH_PATTERN}
 
 [Target]

--- a/lib/sysupdate.conf.tmpl
+++ b/lib/sysupdate.conf.tmpl
@@ -3,7 +3,7 @@ Verify=false
 
 [Source]
 Type=url-file
-Path=https://extensions.flatcar.org/extensions/{SOURCE_REL}/
+Path=https://{BAKERY_URL}/extensions/{SOURCE_REL}/
 MatchPattern={MATCH_PATTERN}
 
 [Target]

--- a/tools/bake_flatcar_image.sh
+++ b/tools/bake_flatcar_image.sh
@@ -56,6 +56,8 @@ function print_help() {
     echo "       --install_to      <partition:install-root> Partition and installation directory of sysexts"
     echo "                            in the OS image. Partition can be 'root' and 'oem'."
     echo "                            Defaults to '${install_to}'"
+    echo "       --bakery <url>    URL for bakery to fetch sysexts from."
+    echo "                            Defaults to 'https://extensions.flatcar.org/extensions'."
     echo
 }
 # --
@@ -260,11 +262,12 @@ declare -a sysexts
 
 while [ $# -gt 0 ]; do
     case "$1" in
-        "--fetch")      fetch="yes";     shift;;
-        "--vendor")     vendor="$2";     shift 2;;
-        "--arch")       arch="$2";       shift 2;;
-        "--release")    release="$2";    shift 2;;
-        "--install_to") install_to="$2"; shift 2;;
+        "--fetch")      fetch="yes";         shift;;
+        "--vendor")     vendor="$2";         shift 2;;
+        "--arch")       arch="$2";           shift 2;;
+        "--release")    release="$2";        shift 2;;
+        "--install_to") install_to="$2";     shift 2;;
+        "--bakery")     bakery_base_url="$2" shift 2;;
         --help) print_help; exit;;
         -h)  print_help; exit;;
         --*) echo -e "\nUnknown option '$1'\n"


### PR DESCRIPTION
# [FEATURE] Add support for custom bakery url

Currently hardcoded to extensions.flatcar.org/extensions/, though forks and individual bakerys would need to edit files directly to use their own.

## How to use

Add `--bakery <url>` to `bakery.sh` during build time or `--bakery <url>` to `tools/bake_flatcar_image.sh `. This makes it easier for forks and other "bakerys" to specify their url instead of editing the files directly.