### PR TITLE
K3s: Fix path of transfer definition file in docs

### DIFF
--- a/docs/k3s.md
+++ b/docs/k3s.md
@@ -32,7 +32,7 @@ storage:
       mode: 0644
       contents:
         source: https://extensions.flatcar.org/extensions/k3s-v1.32.2+k3s1-x86-64.raw
-    - path: /etc/sysupdate.k3s.d/k3s-v1.32.conf
+    - path: /etc/sysupdate.k3s-v1.32.d/k3s-v1.32.conf
       contents:
         source: https://extensions.flatcar.org/extensions/k3s/k3s-v1.32.conf
     - path: /etc/sysupdate.d/noop.conf


### PR DESCRIPTION
Putting the transfer definition file under `/etc/sysupdate.k3s.d/` results in the following error: `No transfer definitions for component 'k3s-v1.32' found.`.

This can be fixed by either putting the file under `/etc/sysupdate.k3s-v1.32.d/` or by setting `ExecStartPre=/usr/lib/systemd/systemd-sysupdate -C k3s update` instead of `ExecStartPre=/usr/lib/systemd/systemd-sysupdate -C k3s-v1.32 update` in [docs/k3s.md](https://github.com/flatcar/sysext-bakery/blob/d548304e38ed7da8fe37ba436b988dc4005ce6a4/docs/k3s.md?plain=1#L55).

This PR updates the path to the file in [docs/k3s.md](https://github.com/flatcar/sysext-bakery/blob/d548304e38ed7da8fe37ba436b988dc4005ce6a4/docs/k3s.md?plain=1#L35).