### PR TITLE
GitHub release builds: build log in files, add dates

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -91,6 +91,7 @@ jobs:
             bakery/SHA256SUMS
             bakery/*.raw
             bakery/*.conf
+            bakery/*-build.log
 
   update-extension-metadata:
     needs: [ list-builds, create-release ]

--- a/release.sh
+++ b/release.sh
@@ -24,11 +24,13 @@ function out() {
 out ""
 out "New ${extension} extension release ${version}"
 out ""
+out "Built $(date --rfc-3339 seconds)"
 
 for arch in x86-64 arm64; do
   target="${extension}-${version}-${arch}"
   out "## \`${target}.raw\`"
-  ./bakery.sh create "${extension}" "${version}" --arch "${arch}" --sysupdate true --output-file "${target}"
+  ./bakery.sh create "${extension}" "${version}" --arch "${arch}" --sysupdate true --output-file "${target}" 2>&1 \
+    | tee "${extension}-${version}-${arch}-build.log"
   cat SHA256SUMS."${extension}" >> SHA256SUMS
 done
 

--- a/release_meta.sh
+++ b/release_meta.sh
@@ -65,6 +65,8 @@ function fetch_extension_metadata() {
 if [[ -n $extension ]] ; then
 
   out "# Extension ${extension} metadata release."
+  out ""
+  out "Updated $(date --rfc-3339 seconds)"
 
   fetch_extension_metadata "$extension"
   if [[ ! -f SHA256SUMS ]] ; then
@@ -81,6 +83,7 @@ else
 
   out "# Global SHA256SUMS metadata release."
   out ""
+  out "Updated $(date --rfc-3339 seconds)"
 
   for extension in $(./bakery.sh list --plain true); do
     echo
@@ -102,15 +105,6 @@ else
   fi
 fi
 # --
-
-if [[ -f SHA256SUMS ]] ; then
-  out ""
-  out "# SHA256SUMS:"
-  out '```'
-  cat SHA256SUMS | tee -a Release.md
-  out '```'
-fi
-
 
 git tag -f "${tag}" --force
 git push origin "${tag}" --force


### PR DESCRIPTION
This change re-adds build logs to releases but uses separate files instead of adding the log to Release.md.

This addresses a corner case where Release.md grew too large to be used as release text (see
https://github.com/flatcar/sysext-bakery/pull/138#issuecomment-2771519319).

Also, the PR adds build timestamps to release texts as well as removes the contents of SHA256SUMS from the SHA256SUMS metadata Release.md to avoid potential issues in the future as our release count grows. The SHA256SUMS file is part of that release, no need to repeat it in Release.md