### PR TITLE
[FEATURE] Env file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+bakery="flatcar/sysext-bakery"
+bakery_hub="extensions.flatcar.org"

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ mnt*
 Release.md
 prev_release_sysexts.txt
 tags
+.env
+.env.backup

--- a/README.md
+++ b/README.md
@@ -132,11 +132,9 @@ Have a look at other extension builds for inspiration;
 
 # Hosting your own bakery
 
-Just fork the Bakery, update
-[`lib/sysupdate.conf.tmpl`](lib/sysupdate.conf.tmpl)
-and
-[`lib/libbakery.sh`](lib/libbakery.sh)
-to use the new home, and start building and publishing!
+Just fork the Bakery, rename
+[`.env.example`](.env.example)
+to `.env` and update the variables to their new home. Now you can start building and publishing!
 
 In general, the extension images can be consumed straight from the respective GitHub releases download sections.
 However, making systemd-sysupdate work requires extra steps - see below.

--- a/README.md
+++ b/README.md
@@ -136,6 +136,11 @@ Just fork the Bakery, rename
 [`.env.example`](.env.example)
 to `.env` and update the variables to their new home. Now you can start building and publishing!
 
+Note: By default `.env` is in .gitignore to prevent any sensitive information from being uploaded and `.env` could be extended in the future. One can run the following to push it to git:
+```sh
+git add --force .env
+```
+
 In general, the extension images can be consumed straight from the respective GitHub releases download sections.
 However, making systemd-sysupdate work requires extra steps - see below.
 

--- a/lib/generate.sh
+++ b/lib/generate.sh
@@ -89,6 +89,7 @@ function _create_sysupdate() {
 
   sed -e "s/{EXTNAME}/${extname}/g" \
       -e "s/{MATCH_PATTERN}/${match_pattern}/g" \
+      -e "s,{BAKERY_HUB},${bakery_hub},g" \
       -e "s,{SOURCE_REL},${source_rel},g" \
       -e "s,{TARGET_FILE},${target_file},g" \
       "${libroot}/sysupdate.conf.tmpl" \

--- a/lib/libbakery.sh
+++ b/lib/libbakery.sh
@@ -13,6 +13,10 @@ scriptroot="$(cd "$(dirname "${BASH_SOURCE[0]}")/../"; pwd)"
 bakery="flatcar/sysext-bakery"
 bakery_hub="extensions.flatcar.org"
 
+if [[ -s "${scriptroot}/.env" ]]; then
+  source "${scriptroot}/.env"
+fi
+
 # Add new library function scripts here:
 source "${libroot}/helpers.sh"
 source "${libroot}/generate.sh"

--- a/lib/sysupdate.conf.tmpl
+++ b/lib/sysupdate.conf.tmpl
@@ -3,7 +3,7 @@ Verify=false
 
 [Source]
 Type=url-file
-Path=https://extensions.flatcar.org/extensions/{SOURCE_REL}/
+Path=https://{BAKERY_HUB}/extensions/{SOURCE_REL}/
 MatchPattern={MATCH_PATTERN}
 
 [Target]


### PR DESCRIPTION
# .env file support

Currently bakery_hub and bakery are hard coded requiring manual intervention when forking. This allows for a .env file to override those values for better fork support.

I use `-s` as this will only source if file is there and is not empty.

## How to use

Move .env.example to .env and update bakery and bakery_hub values and build.

This all stems from https://github.com/flatcar/sysext-bakery/pull/135
