### PR TITLE
nvidia-runtime: create symlinks dynamically

### DIFF
--- a/nvidia-runtime.sysext/create.sh
+++ b/nvidia-runtime.sysext/create.sh
@@ -53,6 +53,5 @@ function populate_sysext_root() {
   cp -aR out/usr/lib/*-linux-gnu/* "${sysextroot}/usr/lib/"
 
   ln -s /opt/nvidia "${sysextroot}/usr/local/nvidia"
-  ln -s /opt/bin/nvidia-smi "${sysextroot}/usr/bin/nvidia-smi"
 }
 # --

--- a/nvidia-runtime.sysext/files/usr/lib/systemd/system/nvidia.service.d/10-persistenced.conf
+++ b/nvidia-runtime.sysext/files/usr/lib/systemd/system/nvidia.service.d/10-persistenced.conf
@@ -1,8 +1,4 @@
 [Service]
-ExecStartPre=-/bin/sh -c "rm /run/extensions/nvidia-driver && systemctl restart systemd-sysext"
-ExecStartPost=-/opt/bin/nvidia-persistenced
-ExecStartPost=-/bin/sh -c "chcon -R -t container_file_t /dev/nvidia*"
-ExecStartPost=mkdir -p /run/extensions
-ExecStartPost=ln -sf /opt/nvidia/current /run/extensions/nvidia-driver
-ExecStartPost=systemctl restart systemd-sysext
+ExecStartPre=/usr/local/bin/_nvidia-runtime-helper pre
+ExecStartPost=/usr/local/bin/_nvidia-runtime-helper post
 ExecStopPost=rmmod nvidia_uvm nvidia_modeset nvidia

--- a/nvidia-runtime.sysext/files/usr/local/bin/_nvidia-runtime-helper
+++ b/nvidia-runtime.sysext/files/usr/local/bin/_nvidia-runtime-helper
@@ -1,0 +1,43 @@
+#!/bin/bash
+set -euo pipefail
+
+SYSEXT_MODE=0
+if systemd-sysext list 2>&1 | grep -q flatcar-nvidia-drivers; then
+  SYSEXT_MODE=1
+fi
+
+_pre() {
+  if [ "$SYSEXT_MODE" -eq 0 ]; then
+    rm /run/extensions/nvidia-driver && systemctl restart systemd-sysext || true
+  fi
+}
+
+_post() {
+  chcon -R -t container_file_t /dev/nvidia* || true
+
+  if [ "$SYSEXT_MODE" -eq 0 ]; then
+    mkdir -p /run/extensions
+    # /opt/nvidia/current gets mounted as an overlay on root filesystem
+    mkdir -p /opt/nvidia/current/usr/bin && ln -sf /opt/bin/nvidia-smi /opt/nvidia/current/usr/bin/nvidia-smi
+    ln -sf /opt/nvidia/current /run/extensions/nvidia-driver
+    systemctl restart systemd-sysext
+  fi
+}
+
+if [ ! "$#" -eq 1 ]; then
+  echo "You need to specify action"
+  exit 1
+fi
+
+case "$1" in
+  pre)
+    _pre
+    ;;
+  post)
+    _post
+    ;;
+  *)
+    echo "Wrong action"
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
The sysext contains /opt/bin/nvidia-smi -> /usr/bin/nvidia-smi symlink. This does not play well with the prebuilt sysext, as it already ships the binaries in /usr/bin. Create the symlink dynamically, only when the prebuilt sysext is not loaded.

