### PR TITLE
release_dispatcher.sh: prune spaces after version, un-break builds

### DIFF
--- a/release_dispatcher.sh
+++ b/release_dispatcher.sh
@@ -16,7 +16,7 @@ echo "Checking for new extension images to be built"
 echo "============================================="
 echo
 
-mapfile -t images < <( sed -e 's:\s*#.*::' -e '/^$/d' release_build_versions.txt )
+mapfile -t images < <( sed -e 's:\s*#.*::' -e 's/[[:space:]]*$//' -e '/^$/d' release_build_versions.txt )
 
 builds=()
 extensions=()


### PR DESCRIPTION
release_dispatcher.sh stumbled over spaces after a version string in release_build_versions.txt and generated incorrect dispatch information ( "<version>:<version>" instead of "<sysext>:<version>" ). This was caused by incorrect handling of spaces after version strings; this change fixes that.

Tested locally.