### PR TITLE
Add opkssh sysext

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -71,6 +71,7 @@ Check out documentation on specific extensions at the navigation menu on the lef
 | `nerdctl`        |  released    | [nerdctl versions](https://github.com/flatcar/sysext-bakery/releases/tag/nerdctl) |
 | `nvidia-runtime` |  released    | [nvidia-runtime versions](https://github.com/flatcar/sysext-bakery/releases/tag/nvidia-runtime) |
 | `ollama`         |  released    | [ollama versions](https://github.com/flatcar/sysext-bakery/releases/tag/ollama) |
+| `opkssh`         |  released    | [opkssh versions](https://github.com/flatcar/sysext-bakery/releases/tag/opkssh) |
 | `rke2`           |  released    | [rke2 versions](https://github.com/flatcar/sysext-bakery/releases/tag/rke2) |
 | `tailscale`      |  released    | [tailscale versions](https://github.com/flatcar/sysext-bakery/releases/tag/tailscale) |
 | `wasmcloud`      |  released    | [wasmcloud versions](https://github.com/flatcar/sysext-bakery/releases/tag/wasmcloud) |

--- a/docs/opkssh.md
+++ b/docs/opkssh.md
@@ -1,0 +1,97 @@
+# opkssh sysext
+
+This sysext ships [opkssh](https://github.com/openpubkey/opkssh/),
+
+opkssh is a tool which enables ssh to be used with OpenID Connect allowing SSH access to be managed via identities like alice@example.com instead of long-lived SSH keys. It does not replace SSH, but instead generates SSH public keys containing PK Tokens and configures sshd to verify them. These PK Tokens contain standard OpenID Connect ID Tokens. This protocol builds on the OpenPubkey which adds user public keys to OpenID Connect without breaking compatibility with existing OpenID Provider.
+
+## Usage
+
+Download and merge the sysext at provisioning time using the below butane snippet.
+
+The snippet includes automated updates via systemd-sysupdate.
+You can deactivate updates by changing `enabled: true` to `enabled: false` in `systemd-sysupdate.timer`.
+
+Note that the snippet is for the arm-64 version of opkssh v0.5.1.
+
+Check out the metadata release at https://github.com/flatcar/sysext-bakery/releases/tag/opkssh for a list of all versions available in the bakery.
+
+Generic configuration for both Server (control plane) and Agent (worker):
+
+```yaml
+variant: flatcar
+version: 1.0.0
+
+passwd:
+  users:
+    - name: opksshuser
+      no_create_home: true
+      shell: /sbin/nologin
+      uid: 999
+      primary_group: opksshuser
+      no_user_group: true
+  groups:
+    - name: opksshuser
+      gid: 999
+      system: true
+
+
+storage:
+  files:
+    - path: /opt/extensions/opkssh/opkssh-v0.5.1-arm64.raw
+      contents:
+        source: https://extensions.flatcar.org/extensions/opkssh-v0.5.1-arm64.raw
+    - path: /etc/sysupdate.opkssh.d/opkssh-v0.5.1.conf
+      contents:
+        source: https://extensions.flatcar.org/extensions/opkssh/opkssh-v0.5.1.conf
+    - path: /etc/sysupdate.d/noop.conf
+      contents:
+        source: https://extensions.flatcar.org/extensions/noop.conf
+    - path: /etc/opk/providers
+      mode: 0640
+      group:
+        id: 999
+      contents:
+        inline: |
+          # Issuer Client-ID expiration-policy
+          https://accounts.google.com 206584157355-7cbe4s640tvm7naoludob4ut1emii7sf.apps.googleusercontent.com 24h
+    - path: /etc/opk/auth_id
+      mode: 0640
+      group:
+        id: 999
+      contents:
+        inline: |
+          core my.email@gmail.com https://accounts.google.com
+    - path: /var/log/opkssh.log
+      mode: 0660
+      group:
+        id: 999
+      contents:
+        inline: ''
+    - path: /etc/sudoers.d/okpsshuser
+      contents:
+        inline: |
+          opksshuser ALL=(ALL) NOPASSWD: /usr/local/bin/opkssh readhome *
+    - path: /etc/ssh/sshd_config.d/99-opkssh.conf
+      contents:
+        inline: |
+          AuthorizedKeysCommand /usr/local/bin/opkssh verify %u %k %t
+          AuthorizedKeysCommandUser opksshuser
+  links:
+    - target: /opt/extensions/opkssh/opkssh-v0.5.1-arm64.raw
+      path: /etc/extensions/opkssh.raw
+      hard: false
+
+systemd:
+  units:
+    - name: systemd-sysupdate.timer
+      enabled: true
+    - name: systemd-sysupdate.service
+      dropins:
+        - name: opkssh.conf
+          contents: |
+            [Service]
+            ExecStartPre=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/opkssh.raw > /tmp/opkssh"
+            ExecStartPre=/usr/lib/systemd/systemd-sysupdate -C opkssh update
+            ExecStartPost=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/opkssh.raw > /tmp/opkssh-new"
+            ExecStartPost=/usr/bin/sh -c "if ! cmp --silent /tmp/opkssh /tmp/opkssh-new; then systemd-sysext refresh; fi"
+```

--- a/opkssh.sysext/create.sh
+++ b/opkssh.sysext/create.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# vim: et ts=2 syn=bash
+#
+# opkssh extension.
+#
+
+RELOAD_SERVICES_ON_MERGE="false"
+
+function list_available_versions() {
+  list_github_releases "openpubkey" "opkssh"
+}
+# --
+
+function populate_sysext_root() {
+  local sysextroot="$1"
+  local arch="$2"
+  local version="$3"
+
+  local rel_arch="$(arch_transform "x86-64" "amd64" "$arch")"
+  curl --parallel --fail --silent --show-error --location \
+        --remote-name "https://github.com/openpubkey/opkssh/releases/download/${version}/opkssh-linux-${rel_arch}"
+
+  mkdir -p "${sysextroot}/usr/local/bin"
+
+  cp opkssh-linux-${rel_arch} "${sysextroot}/usr/local/bin/opkssh"
+  chmod 755 "${sysextroot}/usr/local/bin/opkssh"
+}
+# --


### PR DESCRIPTION
# Add opkssh sysext

opkssh is a tool which enables ssh to be used with OpenID Connect allowing SSH access to be managed via identities like alice@example.com instead of long-lived SSH keys. It does not replace SSH, but instead generates SSH public keys containing PK Tokens and configures sshd to verify them. These PK Tokens contain standard [OpenID Connect ID Tokens](https://openid.net/specs/openid-connect-core-1_0.html). This protocol builds on the [OpenPubkey](https://github.com/openpubkey/openpubkey/blob/main/README.md) which adds user public keys to OpenID Connect without breaking compatibility with existing OpenID Provider.

https://github.com/openpubkey/opkssh

## How to use

1. Add sysext as per doc  (ensuring you change `my.email@gmail.com` to your actual gmail address
2. Run `opkssh login google` to generate private key and certificate
3. Login to host `ssh -o "IdentitiesOnly=yes" -i ~/.ssh/id_ecdsa.pub -i ~/.ssh/id_ecdsa core@my.flatcar.host`

## Testing done

Tested on Raspberry Pi 4 using instructions above
