### PR TITLE
Fix list of extensions in docs, continue GH action on build errors

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,6 +49,12 @@ jobs:
     strategy:
       matrix:
         release: ${{ fromJson(needs.list-builds.outputs.builds) }}
+    # Try to finish all jobs even if one fails.
+    # Job fails can be transient and will be re-tried every time this action runs.
+    # NOTE that this will cause succeeding jobs (update metadata) to run even if the whole matrix fails.
+    #      This is intended and should not cause any issues[tm].
+    continue-on-error: true 
+
     runs-on: ubuntu-24.04
     permissions:
       # allow the action to create a release

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,13 +61,16 @@ Check out documentation on specific extensions at the navigation menu on the lef
 |    Extension     | Availability | Versions available |
 | ---------------- | ------------ | ------------- |
 | `cilium`         |  released    | [cilium versions](https://github.com/flatcar/sysext-bakery/releases/tag/cilium) |
+| `containerd`     |  released    | [containerd versions](https://github.com/flatcar/sysext-bakery/releases/tag/containerd) |
 | `crio`           |  released    | [crio versions](https://github.com/flatcar/sysext-bakery/releases/tag/crio) |
-| `docker`         |  released    | [docker versions](https://github.com/flatcar/sysext-bakery/releases/tag/docker) |
 | `docker-compose` |  released    | [docker-compose versions](https://github.com/flatcar/sysext-bakery/releases/tag/docker-compose) |
+| `docker`         |  released    | [docker versions](https://github.com/flatcar/sysext-bakery/releases/tag/docker) |
 | `falco`          |  released    | [falco versions](https://github.com/flatcar/sysext-bakery/releases/tag/falco) |
 | `k3s`            |  released    | [k3s versions](https://github.com/flatcar/sysext-bakery/releases/tag/k3s) |
 | `keepalived`     |  released    | [keepalived versions](https://github.com/flatcar/sysext-bakery/releases/tag/keepalived) |
 | `kubernetes`     |  released    | [kubernetes versions](https://github.com/flatcar/sysext-bakery/releases/tag/kubernetes) |
+| `llamaedge`      |  released    | [llamaedge versions](https://github.com/flatcar/sysext-bakery/releases/tag/llamaedge) |
+| `nebula`         |  released    | [nebula versions](https://github.com/flatcar/sysext-bakery/releases/tag/nebula) |
 | `nerdctl`        |  released    | [nerdctl versions](https://github.com/flatcar/sysext-bakery/releases/tag/nerdctl) |
 | `nvidia-runtime` |  released    | [nvidia-runtime versions](https://github.com/flatcar/sysext-bakery/releases/tag/nvidia-runtime) |
 | `ollama`         |  released    | [ollama versions](https://github.com/flatcar/sysext-bakery/releases/tag/ollama) |


### PR DESCRIPTION
This change addresses an issue with the GitHub actions automated builds where all extension builds fail if only one extension fails to build. The issue can prevent extension updates from being released even if that particular extension builds successfully.

The change also updates the list of extensions in docs/index.md and adds extensions present in the repository but missing from the list.

Concrete manifestation of the build issue is e.g. here: https://github.com/flatcar/sysext-bakery/actions/runs/15408902919/job/43356903558 and effectively blocks **all** extensions from being updated.

The tailscale buid failure in the action above is caused by Taiulscale [release v1.8.1](https://github.com/tailscale/tailscale/releases/tag/v1.84.1) _only_ shipping Android and MacOS binaries: https://pkgs.tailscale.com/stable/?v=1.84.1. The failure is expected to resolve itself as soon as tailscale publishes a new version for all platforms.

With the fix, the action continues and publishes extensions that have successful builds: https://github.com/flatcar/sysext-bakery/actions/runs/15441086065/job/43458950912