### PR TITLE
docs/kubernetes: fix component name

### DIFF
--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -54,7 +54,7 @@ systemd:
           contents: |
             [Service]
             ExecStartPre=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/kubernetes.raw > /tmp/kubernetes"
-            ExecStartPre=/usr/lib/systemd/systemd-sysupdate -C kubernetes-v1.32 update
+            ExecStartPre=/usr/lib/systemd/systemd-sysupdate -C kubernetes update
             ExecStartPost=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/kubernetes.raw > /tmp/kubernetes-new"
             ExecStartPost=/usr/bin/sh -c "if ! cmp --silent /tmp/kubernetes /tmp/kubernetes-new; then touch /run/reboot-required; fi"
     - name: locksmithd.service


### PR DESCRIPTION
It was initially done here: https://github.com/flatcar/sysext-bakery/blob/9ebba24d11e66145f1c4f14c0557ac5aa4a3ea75/docs/kubernetes.md#usage

I think it's a side effect of the sysext-bakery refactoring. 