### PR TITLE
docs/rke2.md: Fix sysupdate component name

### DIFF
--- a/docs/rke2.md
+++ b/docs/rke2.md
@@ -53,7 +53,7 @@ systemd:
           contents: |
             [Service]
             ExecStartPre=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/rke2.raw > /tmp/rke2"
-            ExecStartPre=/usr/lib/systemd/systemd-sysupdate -C rke2-v1.32 update
+            ExecStartPre=/usr/lib/systemd/systemd-sysupdate -C rke2 update
             ExecStartPost=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/rke2.raw > /tmp/rke2-new"
             ExecStartPost=/usr/bin/sh -c "if ! cmp --silent /tmp/rke2 /tmp/rke2-new; then touch /run/reboot-required; fi"
 ```


### PR DESCRIPTION
The RKE2 docs use the wrong sysupdate component name. Since the sysupdate configuration resides in `/etc/sysupdate.rke2.d/`, the component name is `rke2` instead of `rke2-v<version>` which is currently used. 

Similar to 66bcf44a8f347b61c42c00f457d1a2f7daf3fb32 / https://github.com/flatcar/sysext-bakery/pull/162/.

