### PR TITLE
Docker buildx

### DIFF
--- a/docker-buildx.sysext/create.sh
+++ b/docker-buildx.sysext/create.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# vim: et ts=2 syn=bash
+#
+# Docker buildx system extension.
+#
+
+RELOAD_SERVICES_ON_MERGE="false"
+
+function list_available_versions() {
+  list_github_releases "docker" "buildx" \
+    | sed 's/^v//'
+}
+# --
+
+function populate_sysext_root() {
+  local sysextroot="$1"
+  local arch="$2"
+  local version="$3"
+
+  # The github release uses different arch identifiers
+  local rel_arch="$(arch_transform 'x86-64' 'amd64' "$arch")"
+  rel_arch="$(arch_transform 'arm64' 'arm64' "$rel_arch")"
+
+  mkdir -p "${sysextroot}/usr/local/lib/docker/cli-plugins"
+  curl -o "${sysextroot}/usr/local/lib/docker/cli-plugins/docker-compose" \
+    -fsSL "https://github.com/docker/buildx/releases/download/v${version}/buildx-v${version}.linux-${rel_arch}"
+  chmod +x "${sysextroot}/usr/local/lib/docker/cli-plugins/docker-compose"
+}
+# --

--- a/docs/docker_buildx.md
+++ b/docs/docker_buildx.md
@@ -1,0 +1,51 @@
+# Docker-buildx sysext
+
+This sysext ships [docker-buildx](https://github.com/docker/buildx).
+
+## Usage
+
+Download and merge the sysext at provisioning time using the below butane snippet.
+
+The snippet includes automated updates via systemd-sysupdate.
+Sysupdate will stage updates and request a reboot by creating a flag file at `/run/reboot-required`.
+You can deactivate updates by changing `enabled: true` to `enabled: false` in `systemd-sysupdate.timer`.
+
+Note that the snippet is for the x86-64 version of docker-buildx 0.25.0.
+
+Check out the metadata release at https://github.com/flatcar/sysext-bakery/releases/tag/docker-buildx for a list of all versions available in the bakery.
+
+```yaml
+variant: flatcar
+version: 1.0.0
+
+storage:
+  files:
+    - path: /opt/extensions/docker-buildx/docker-buildx-0.25.0-x86-64.raw
+      mode: 0644
+      contents:
+        source: https://extensions.flatcar.org/extensions/docker-buildx-0.25.0-x86-64.raw
+    - path: /etc/sysupdate.docker-buildx.d/docker-buildx.conf
+      contents:
+        source: https://extensions.flatcar.org/extensions/docker-buildx.conf
+    - path: /etc/sysupdate.d/noop.conf
+      contents:
+        source: https://extensions.flatcar.org/extensions/noop.conf
+  links:
+    - target: /opt/extensions/docker-buildx/docker-buildx-0.25.0-x86-64.raw
+      path: /etc/extensions/docker-buildx.raw
+      hard: false
+systemd:
+  units:
+    - name: systemd-sysupdate.timer
+      enabled: true
+    - name: systemd-sysupdate.service
+      dropins:
+        - name: docker-buildx.conf
+          contents: |
+            [Service]
+            ExecStartPre=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/docker-buildx.raw > /tmp/docker-buildx"
+            ExecStartPre=/usr/lib/systemd/systemd-sysupdate -C docker-buildx update
+            ExecStartPost=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/docker-buildx.raw > /tmp/docker-buildx-new"
+            ExecStartPost=/usr/bin/sh -c "if ! cmp --silent /tmp/docker-buildx /tmp/docker-buildx-new; then touch /run/reboot-required; fi"
+```
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -63,6 +63,7 @@ Check out documentation on specific extensions at the navigation menu on the lef
 | `cilium`         |  released    | [cilium versions](https://github.com/flatcar/sysext-bakery/releases/tag/cilium) |
 | `containerd`     |  released    | [containerd versions](https://github.com/flatcar/sysext-bakery/releases/tag/containerd) |
 | `crio`           |  released    | [crio versions](https://github.com/flatcar/sysext-bakery/releases/tag/crio) |
+| `docker-buildx`  |  released    | [docker-buildx versions](https://github.com/flatcar/sysext-bakery/releases/tag/docker-buildx) |
 | `docker-compose` |  released    | [docker-compose versions](https://github.com/flatcar/sysext-bakery/releases/tag/docker-compose) |
 | `docker`         |  released    | [docker versions](https://github.com/flatcar/sysext-bakery/releases/tag/docker) |
 | `falco`          |  released    | [falco versions](https://github.com/flatcar/sysext-bakery/releases/tag/falco) |

--- a/release_build_versions.txt
+++ b/release_build_versions.txt
@@ -22,6 +22,9 @@ containerd latest
 
 crio latest
 
+docker-buildx 0.25.0
+docker-buildx latest
+
 docker-compose 2.22.0
 docker-compose 2.24.5
 docker-compose latest


### PR DESCRIPTION
# Add docker-buildx sysext

This adds the docker-buildx sysext to the repo. It is usually heavily used when running docker build/docker compose build. Currently docker compose build throws a warning that this is missing and this will fix that issue.
