### PR TITLE
[FIX] Fix building erofs images in workflows

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -77,7 +77,8 @@ jobs:
             curl \
             jq \
             squashfs-tools \
-            xz-utils
+            xz-utils \
+            erofs-utils
 
       - name: build
         id: build
@@ -123,7 +124,8 @@ jobs:
             curl \
             jq \
             squashfs-tools \
-            xz-utils
+            xz-utils \
+            erofs-utils
 
       - name: Fetch extension release metadata
         env:
@@ -163,7 +165,8 @@ jobs:
             curl \
             jq \
             squashfs-tools \
-            xz-utils
+            xz-utils \
+            erofs-utils
 
       - name: Fetch all extension releases metadata
         env:


### PR DESCRIPTION
my initial commit to add erofs support to github workflows missed a couple spots where erofs-utils was needed, this fixes that