### PR TITLE
consul sysext

### DIFF
--- a/consul.sysext/create.sh
+++ b/consul.sysext/create.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# vim: et ts=2 syn=bash
+#
+
+RELOAD_SERVICES_ON_MERGE="true"
+
+function list_available_versions() {
+  curl -fsSL --retry-delay 1 --retry 60 \
+    --retry-connrefused --retry-max-time 60 --connect-timeout 20 \
+    https://api.releases.hashicorp.com/v1/releases/consul \
+  | jq -r '.[] | select(has("version"))
+               | .version
+               | select(type == "string")
+               | select(test("^[0-9.]+$"))
+               | capture("(?<v>[[:digit:].]+)").v' \
+  | sort -Vr
+}
+# --
+
+function populate_sysext_root() {
+  local sysextroot="$1"
+  local arch="$2"
+  local version="$3"
+
+  local rel_arch
+  rel_arch="$(arch_transform "x86-64" "amd64" "$arch")"
+  curl -fsSLZO --retry-delay 1 --retry 60 \
+    --retry-connrefused --retry-max-time 60 --connect-timeout 20 \
+    "https://releases.hashicorp.com/nomad/${version}/consul_${version}_linux_${rel_arch}.zip"
+  # Unzip the binary
+  mkdir -p "${sysextroot}/usr/bin"
+  unzip -q "consul_${version}_linux_${rel_arch}.zip"
+  install -m 0755 consul "${sysextroot}/usr/bin"
+}
+# --

--- a/consul.sysext/files/usr/lib/systemd/system/consul.service
+++ b/consul.sysext/files/usr/lib/systemd/system/consul.service
@@ -1,0 +1,21 @@
+[Unit]
+Description="HashiCorp Consul - A service mesh solution"
+Documentation=https://developer.hashicorp.com/
+Requires=network-online.target
+After=network-online.target
+ConditionFileNotEmpty=/etc/consul.d/consul.hcl
+
+[Service]
+Type=notify
+EnvironmentFile=-/etc/consul.d/consul.env
+User=consul
+Group=consul
+ExecStart=/usr/bin/consul agent -config-dir=/etc/consul.d/
+ExecReload=/bin/kill --signal HUP $MAINPID
+KillMode=process
+KillSignal=SIGTERM
+Restart=on-failure
+LimitNOFILE=65536
+
+[Install]
+WantedBy=multi-user.target

--- a/consul.sysext/files/usr/share/consul/consul.hcl
+++ b/consul.sysext/files/usr/share/consul/consul.hcl
@@ -1,0 +1,99 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+# Full configuration options can be found at https://developer.hashicorp.com/docs/agent/config
+
+# datacenter
+# This flag controls the datacenter in which the agent is running. If not provided,
+# it defaults to "dc1". Consul has first-class support for multiple datacenters, but 
+# it relies on proper configuration. Nodes in the same datacenter should be on a 
+# single LAN.
+#datacenter = "my-dc-1"
+
+# data_dir
+# This flag provides a data directory for the agent to store state. This is required
+# for all agents. The directory should be durable across reboots. This is especially
+# critical for agents that are running in server mode as they must be able to persist
+# cluster state. Additionally, the directory must support the use of filesystem
+# locking, meaning some types of mounted folders (e.g. VirtualBox shared folders) may
+# not be suitable.
+data_dir = "/opt/consul"
+
+# client_addr
+# The address to which Consul will bind client interfaces, including the HTTP and DNS
+# servers. By default, this is "127.0.0.1", allowing only loopback connections. In
+# Consul 1.0 and later this can be set to a space-separated list of addresses to bind
+# to, or a go-sockaddr template that can potentially resolve to multiple addresses.
+#client_addr = "0.0.0.0"
+
+# ui
+# Enables the built-in web UI server and the required HTTP routes. This eliminates
+# the need to maintain the Consul web UI files separately from the binary.
+# Version 1.10 deprecated ui=true in favor of ui_config.enabled=true
+#ui_config{
+#  enabled = true
+#}
+
+# server
+# This flag is used to control if an agent is in server or client mode. When provided,
+# an agent will act as a Consul server. Each Consul cluster must have at least one
+# server and ideally no more than 5 per datacenter. All servers participate in the Raft
+# consensus algorithm to ensure that transactions occur in a consistent, linearizable
+# manner. Transactions modify cluster state, which is maintained on all server nodes to
+# ensure availability in the case of node failure. Server nodes also participate in a
+# WAN gossip pool with server nodes in other datacenters. Servers act as gateways to
+# other datacenters and forward traffic as appropriate.
+#server = true
+
+# Bind addr
+# You may use IPv4 or IPv6 but if you have multiple interfaces you must be explicit.
+#bind_addr = "[::]" # Listen on all IPv6
+#bind_addr = "0.0.0.0" # Listen on all IPv4
+#
+# Advertise addr - if you want to point clients to a different address than bind or LB.
+#advertise_addr = "127.0.0.1"
+
+# Enterprise License
+# As of 1.10, Enterprise requires a license_path and does not have a short trial.
+#license_path = "/etc/consul.d/consul.hclic"
+
+# bootstrap_expect
+# This flag provides the number of expected servers in the datacenter. Either this value
+# should not be provided or the value must agree with other servers in the cluster. When
+# provided, Consul waits until the specified number of servers are available and then
+# bootstraps the cluster. This allows an initial leader to be elected automatically.
+# This cannot be used in conjunction with the legacy -bootstrap flag. This flag requires
+# -server mode.
+#bootstrap_expect=3
+
+# encrypt
+# Specifies the secret key to use for encryption of Consul network traffic. This key must
+# be 32-bytes that are Base64-encoded. The easiest way to create an encryption key is to
+# use consul keygen. All nodes within a cluster must share the same encryption key to
+# communicate. The provided key is automatically persisted to the data directory and loaded
+# automatically whenever the agent is restarted. This means that to encrypt Consul's gossip
+# protocol, this option only needs to be provided once on each agent's initial startup
+# sequence. If it is provided after Consul has been initialized with an encryption key,
+# then the provided key is ignored and a warning will be displayed.
+#encrypt = "..."
+
+# retry_join
+# Similar to -join but allows retrying a join until it is successful. Once it joins 
+# successfully to a member in a list of members it will never attempt to join again.
+# Agents will then solely maintain their membership via gossip. This is useful for
+# cases where you know the address will eventually be available. This option can be
+# specified multiple times to specify multiple agents to join. The value can contain
+# IPv4, IPv6, or DNS addresses. In Consul 1.1.0 and later this can be set to a go-sockaddr
+# template. If Consul is running on the non-default Serf LAN port, this must be specified
+# as well. IPv6 must use the "bracketed" syntax. If multiple values are given, they are
+# tried and retried in the order listed until the first succeeds. Here are some examples:
+#retry_join = ["consul.domain.internal"]
+#retry_join = ["10.0.4.67"]
+#retry_join = ["[::1]:8301"]
+#retry_join = ["consul.domain.internal", "10.0.4.67"]
+# Cloud Auto-join examples:
+# More details - https://developer.hashicorp.com/docs/agent/cloud-auto-join
+#retry_join = ["provider=aws tag_key=... tag_value=..."]
+#retry_join = ["provider=azure tag_name=... tag_value=... tenant_id=... client_id=... subscription_id=... secret_access_key=..."]
+#retry_join = ["provider=gce project_name=... tag_value=..."]
+ 

--- a/docs/consul.md
+++ b/docs/consul.md
@@ -1,0 +1,51 @@
+# Consul sysext
+
+This sysext ships [consul](https://github.com/hashicorp/consul).
+
+The sysext includes a service unit file to start consul at boot.
+The default configuration can be modified or replaced via a custom Butane config.
+
+# Usage
+
+The snippet includes automated updates via systemd-sysupdate.
+Sysupdate will stage updates and request a reboot by creating a flag file at `/run/reboot-required`.
+You can deactivate updates by changing `enabled: true` to `enabled: false` in `systemd-sysupdate.timer`.
+
+Note that the snippet is for the x86-64 version of consul 1.21.2.
+
+Check out the metadata release at https://github.com/flatcar/sysext-bakery/releases/tag/consul for a list of all versions available in the bakery.
+
+```yaml
+variant: flatcar
+version: 1.0.0
+
+storage:
+  files:
+    - path: /opt/extensions/consul/consul-v1.21.2-x86-64.raw
+      mode: 0644
+      contents:
+        source: https://extensions.flatcar.org/extensions/consul-v1.21.2-x86-64.raw
+    - path: /etc/sysupdate.consul.d/consul.conf
+      contents:
+        source: https://extensions.flatcar.org/extensions/tailscale.conf
+  links:
+    - path: /etc/systemd/system/multi-user.target.wants/consul.service
+      target: /usr/local/lib/systemd/system/consul.service
+      overwrite: true
+    - target: /opt/extensions/consul/consul-v1.21.2-x86-64.raw
+      path: /etc/extensions/consul.raw
+      hard: false
+systemd:
+  units:
+    - name: systemd-sysupdate.timer
+      enabled: true
+    - name: systemd-sysupdate.service
+      dropins:
+        - name: consul.conf
+          contents: |
+            [Service]
+            ExecStartPre=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/consul.raw > /tmp/consul"
+            ExecStartPre=/usr/lib/systemd/systemd-sysupdate -C consul update
+            ExecStartPost=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/consul.raw > /tmp/consul-new"
+            ExecStartPost=/usr/bin/sh -c "if ! cmp --silent /tmp/consul /tmp/consul-new; then touch /run/reboot-required; fi"
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,6 +61,7 @@ Check out documentation on specific extensions at the navigation menu on the lef
 |    Extension     | Availability | Versions available |
 | ---------------- | ------------ | ------------- |
 | `cilium`         |  released    | [cilium versions](https://github.com/flatcar/sysext-bakery/releases/tag/cilium) |
+| `consul`          |  released    | [consul versions](https://github.com/flatcar/sysext-bakery/releases/tag/consul) |
 | `containerd`     |  released    | [containerd versions](https://github.com/flatcar/sysext-bakery/releases/tag/containerd) |
 | `crio`           |  released    | [crio versions](https://github.com/flatcar/sysext-bakery/releases/tag/crio) |
 | `docker-buildx`  |  released    | [docker-buildx versions](https://github.com/flatcar/sysext-bakery/releases/tag/docker-buildx) |

--- a/release_build_versions.txt
+++ b/release_build_versions.txt
@@ -17,6 +17,9 @@
 # to build the latest (i.e. highest version number) release(s).
 #
 
+consul 1.21.2
+consul latest
+
 containerd 2.0.0
 containerd latest
 


### PR DESCRIPTION
# Add [consul](https://github.com/hashicorp/consul) sysext to the bakery.

Add Hashicorp's Consul as a sysext to Flatcar.
Along with the Nomad sysext, this allows Flatcar users to run more of the Hashi orchestration stack.

## How to use

Build and use the Consul sysext.

## Testing done

Built and ran on my NixOS machine.

[Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got.]

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
