### PR TITLE
Update CODEOWNERS with specialized team assignment

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,5 @@
+# CODEOWNERS file for sysext-bakery
+# This file defines who is responsible for code review
+# See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+* @flatcar/flatcar-integrations


### PR DESCRIPTION
This PR updates the CODEOWNERS file to assign the appropriate specialized maintainer team (@flatcar/flatcar-integrations) for pull request reviews, addressing the manual reviewer assignment issues outlined in https://github.com/flatcar/Flatcar/issues/1791.

This ensures that reviews are directed to team members with the most relevant domain expertise.