### PR TITLE
Extensions: Add ig

### DIFF
--- a/docs/ig.md
+++ b/docs/ig.md
@@ -1,0 +1,54 @@
+# Inspektor Gadget sysext
+
+This sysext ships [Inspektor Gadget](https://www.inspektor-gadget.io/), a collection of tools and framework for data collection and system inspection on Kubernetes clusters and Linux hosts using eBPF.
+
+This sysext includes both the `ig` and `gadgetctl` binaries:
+- `ig` - The main inspektor-gadget tool for running gadgets on Linux hosts
+- `gadgetctl` - Tool for managing gadgets and interacting with `ig` running in daemon mode
+
+## Usage
+
+Download and merge the sysext at provisioning time using the below butane snippet.
+
+The snippet includes automated updates via systemd-sysupdate.
+Sysupdate will stage updates and request a reboot by creating a flag file at `/run/reboot-required`.
+You can deactivate updates by changing `enabled: true` to `enabled: false` in `systemd-sysupdate.timer`.
+
+Note that the snippet is for the x86-64 version of Inspektor Gadget v0.43.0.
+
+Check out the metadata release at https://github.com/flatcar/sysext-bakery/releases/tag/ig for a list of all versions available in the bakery.
+
+```yaml
+variant: flatcar
+version: 1.0.0
+
+storage:
+  files:
+    - path: /opt/extensions/ig/ig-v0.43.0-x86-64.raw
+      mode: 0644
+      contents:
+        source: https://extensions.flatcar.org/extensions/ig-v0.43.0-x86-64.raw
+    - path: /etc/sysupdate.ig.d/ig.conf
+      contents:
+        source: https://extensions.flatcar.org/extensions/ig.conf
+    - path: /etc/sysupdate.d/noop.conf
+      contents:
+        source: https://extensions.flatcar.org/extensions/noop.conf
+  links:
+    - target: /opt/extensions/ig/ig-v0.43.0-x86-64.raw
+      path: /etc/extensions/ig.raw
+      hard: false
+systemd:
+  units:
+    - name: systemd-sysupdate.timer
+      enabled: true
+    - name: systemd-sysupdate.service
+      dropins:
+        - name: ig.conf
+          contents: |
+            [Service]
+            ExecStartPre=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/ig.raw > /tmp/ig"
+            ExecStartPre=/usr/lib/systemd/systemd-sysupdate -C ig update
+            ExecStartPost=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/ig.raw > /tmp/ig-new"
+            ExecStartPost=/usr/bin/sh -c "if ! cmp --silent /tmp/ig /tmp/ig-new; then touch /run/reboot-required; fi"
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -67,6 +67,7 @@ Check out documentation on specific extensions at the navigation menu on the lef
 | `docker-compose` |  released    | [docker-compose versions](https://github.com/flatcar/sysext-bakery/releases/tag/docker-compose) |
 | `docker`         |  released    | [docker versions](https://github.com/flatcar/sysext-bakery/releases/tag/docker) |
 | `falco`          |  released    | [falco versions](https://github.com/flatcar/sysext-bakery/releases/tag/falco) |
+| `ig`             |  released    | [ig versions](https://github.com/flatcar/sysext-bakery/releases/tag/ig) |
 | `k3s`            |  released    | [k3s versions](https://github.com/flatcar/sysext-bakery/releases/tag/k3s) |
 | `keepalived`     |  released    | [keepalived versions](https://github.com/flatcar/sysext-bakery/releases/tag/keepalived) |
 | `kubernetes`     |  released    | [kubernetes versions](https://github.com/flatcar/sysext-bakery/releases/tag/kubernetes) |

--- a/ig.sysext/create.sh
+++ b/ig.sysext/create.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# vim: et ts=2 syn=bash
+#
+# Extension creation skeleton script for sysext bakery extensions.
+#
+
+# Functions in this script will be called by bakery.sh.
+# All library functions from lib/ will be available.
+
+# NOTE: If you only ship static files in your sysext (in the files/ subdirectory)
+#       just delete create.sh for your sysext.
+
+# Set to "true" to cause a service units reload on merge, to make systemd aware
+#  of new service files shipped by this extension.
+# If you want to start your service on merge, ship an `upholds=...` drop-in
+#  for `multi-user.target` in the "files/..." directory of this extension.
+RELOAD_SERVICES_ON_MERGE="true"
+
+# If your extension publishes custom versions other than
+# "<extension>-v1.2.3" or "<extension>-1.2.3" please provide a regex match
+# pattern. Will be used by "bakery.sh list-bakery <extension>" and
+# by the release scripts.
+# EXTENSION_VERSION_MATCH_PATTERN='[.v0-9]+'
+
+# If you need to run curl calls to api.github.com consider using
+# 'curl_api_wrapper' (from lib/helpers.sh). The wrapper will use GH_TOKEN
+# if set to prevent throttling of unauthenticated calls, and handle pagination
+# etc.
+
+# Fetch and print a list of available versions.
+# Called by 'bakery.sh list <sysext>.
+function list_available_versions() {
+  # TODO: implement fetching a list of releases from upstream
+  #       and print available versions, one version per line.
+  #  e.g. using list_github_releases from lib/helpers.sh.      
+  
+  list_github_releases "inspektor-gadget" "inspektor-gadget"
+}
+# --
+
+# Download the application shipped with the sysext and populate the sysext root directory.
+# This function runs in a subshell inside of a temporary work directory.
+# It is safe to download / build directly in "./" as the work directory
+#   will be removed after this function returns.
+# Called by 'bakery.sh create <sysext>' with:
+#   "sysextroot" - First positional argument.
+#                    Root directory of the sysext to be created.
+#   "arch"       - Second positional argument.
+#                    Target architecture of the sysext.
+#   "version"    - Third positional argument.
+#                    Version number to build.
+function populate_sysext_root() {
+  local sysextroot="$1"
+  local arch="$2"
+  local version="$3"
+
+  # The release uses different arch identifiers
+  local rel_arch="$(arch_transform 'x86-64' 'amd64' "$arch")"
+
+  curl -o ig.tar.gz -fsSL "https://github.com/inspektor-gadget/inspektor-gadget/releases/download/${version}/ig-linux-${rel_arch}-${version}.tar.gz"
+  curl -o gadgetctl.tar.gz -fsSL "https://github.com/inspektor-gadget/inspektor-gadget/releases/download/${version}/gadgetctl-linux-${rel_arch}-${version}.tar.gz"
+
+  tar -xf ig.tar.gz
+  tar -xf gadgetctl.tar.gz
+
+  mkdir -p "${sysextroot}/usr/bin/"
+  mv ig "${sysextroot}/usr/bin/"
+  mv gadgetctl "${sysextroot}/usr/bin/"
+}
+# --

--- a/release_build_versions.txt
+++ b/release_build_versions.txt
@@ -34,6 +34,8 @@ docker latest
 falco 0.39.1
 falco latest
 
+ig latest
+
 k3s v1.32.2+k3s1
 k3s latest
 


### PR DESCRIPTION
# Adds the IG sysext extension

This PR adds an extension for [Inspektor Gadget](https://inspektor-gadget.io/). Specifically the `ig` and `gadgetctl` binary. One can use `ig` to directly inspect/observe the linux host with all its containers.  Another usage might be to spawn an `ig daemon`, which then runs in the background, and control that daemon instance with `gadgetctl`

## How to use

```
$ ./bakery.sh create ig v0.43.0
$ ./bakery.sh boot ig.raw
core@localhost $ while true; do sleep 1 && date > /dev/null; done &
core@localhost $ sudo ig daemon &
core@localhost $ sudo gadgetctl run trace_exec --host
RUNTIME.CONTAINERNAME   COMM                 PID        TID TTY ARGS         ER…
                        date                2007       2007 0   /usr/bin/da…    
                        sleep               2008       2008 0   /usr/bin/sl…    
                        date                2009       2009 0   /usr/bin/da…    
                        sleep               2010       2010 0   /usr/bin/sl…    

```

## Testing done

See `How to use`

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

I copy pasted the butane snippet mostly from other doc files. How can I test it when the contents point to config files on webservers, which are not there (yet).