### PR TITLE
[FIX] Fixes eorfs when utils is less than 1.8.5

### DIFF
--- a/lib/generate.sh
+++ b/lib/generate.sh
@@ -133,7 +133,7 @@ function _generate_sysext() {
     erofs)
       # Compression recommendations from https://erofs.docs.kernel.org/en/latest/mkfs.html
       # and forcing a zero UUID for reproducibility (maybe we could also hash the name and version)
-      mkfs.erofs -zlz4hc,12 -C65536 -Efragments,ztailpacking -Uclear --all-root "${fname}" "${basedir}"
+      mkfs.erofs -zlz4hc,12 -C65536 -Efragments,ztailpacking -U00000000-0000-0000-0000-000000000000 --all-root "${fname}" "${basedir}"
       ;;
 
   esac


### PR DESCRIPTION
The `clear` option was added in 1.8.5 which does the same as `00000000-0000-0000-0000-000000000000`. By switch from `clear` to `00000000-0000-0000-0000-000000000000` support versions prior to 1.8.5 like 1.7.1 which ubuntu 24.04 runs.
