### PR TITLE
Fix docker-buildx binary name

### DIFF
--- a/docker-buildx.sysext/create.sh
+++ b/docker-buildx.sysext/create.sh
@@ -22,8 +22,8 @@ function populate_sysext_root() {
   rel_arch="$(arch_transform 'arm64' 'arm64' "$rel_arch")"
 
   mkdir -p "${sysextroot}/usr/local/lib/docker/cli-plugins"
-  curl -o "${sysextroot}/usr/local/lib/docker/cli-plugins/docker-compose" \
+  curl -o "${sysextroot}/usr/local/lib/docker/cli-plugins/docker-buildx" \
     -fsSL "https://github.com/docker/buildx/releases/download/v${version}/buildx-v${version}.linux-${rel_arch}"
-  chmod +x "${sysextroot}/usr/local/lib/docker/cli-plugins/docker-compose"
+  chmod +x "${sysextroot}/usr/local/lib/docker/cli-plugins/docker-buildx"
 }
 # --


### PR DESCRIPTION
# Fix docker-buildx binary name

docker-buildx was being saved as docker-compose, which is overwritten when the docker compose sysext is also used

## How to use

[ describe what reviewers need to do in order to validate this PR ]

## Testing done

[Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got.]

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
