### PR TITLE
wasmedge: fix build for version 0.15.1 and higher

### DIFF
--- a/lib/helpers.sh
+++ b/lib/helpers.sh
@@ -190,3 +190,25 @@ function transpile() {
     >"${outfile}" <"${yamlfile}"
 }
 # --
+
+function semver_equals_or_higher() {
+  local ver="${1#v}"
+  local comp="${2#v}"
+
+  local highest="$(echo -e "${ver}\n${comp}" | sort --version-sort --reverse | head -n 1)"
+
+  if [[ "${highest}" == "${ver}" ]] ; then
+    return 0
+  fi
+
+  return 1
+}
+# --
+
+function semver_lower() {
+  if semver_equals_or_higher "${@}"; then
+    return 1
+  fi
+
+  return 0
+}

--- a/wasmedge.sysext/create.sh
+++ b/wasmedge.sysext/create.sh
@@ -26,7 +26,12 @@ function populate_sysext_root() {
   mkdir -p "${sysextroot}/usr/bin"
   mkdir -p "${sysextroot}/usr/lib"
 
-  cp -a "WasmEdge-${version}-Linux"/bin/wasmedge "${sysextroot}"/usr/bin/
-  cp -a "WasmEdge-${version}-Linux"/lib/* "${sysextroot}"/usr/lib/
+  local prefix="./"
+  if semver_lower "${version}" "0.15.0" ; then
+    local prefix="WasmEdge-${version}-Linux/"
+  fi
+
+  cp -a "${prefix}"/bin/* "${sysextroot}"/usr/bin/
+  cp -a "${prefix}"/lib/* "${sysextroot}"/usr/lib/
 }
 # --

--- a/wasmedge.sysext/create.sh
+++ b/wasmedge.sysext/create.sh
@@ -26,9 +26,9 @@ function populate_sysext_root() {
   mkdir -p "${sysextroot}/usr/bin"
   mkdir -p "${sysextroot}/usr/lib"
 
-  local prefix="./"
+  local prefix="."
   if semver_lower "${version}" "0.15.0" ; then
-    local prefix="WasmEdge-${version}-Linux/"
+    local prefix="WasmEdge-${version}-Linux"
   fi
 
   cp -a "${prefix}"/bin/* "${sysextroot}"/usr/bin/


### PR DESCRIPTION
WasmEdge tarball 0.15.0 and higher do not contain a WasmEdge.../ subdirectory anymore. Instead, the FS root is shipped directly.

This change fixes the wasmedge build for versions >=0.15.0 and adds helper functions to compare semvers.

Tested with local builds, both wasmedge-0.14.1 and wasmedge-0.15.0.