### PR TITLE
Bump tailscale version to 1.90.8

### DIFF
--- a/release_build_versions.txt
+++ b/release_build_versions.txt
@@ -71,7 +71,7 @@ ollama latest
 rke2 v1.32.2+rke2r1
 rke2 latest
 
-tailscale v1.76.6
+tailscale v1.90.8
 tailscale latest
 
 wasmcloud v1.0.0


### PR DESCRIPTION


# Bump tailscale version to 1.90.8

Bump is necessary to fix security issues

TS-2025-008: Tail Lock skip (in certain conditions).
TS-2025-007: race condition when using one-off auth keys.

## How to use

1.90.8 is the same version as latest for now. If latest works, this one will.
Otherwise install the sysext and see if node shows up on Tailscale website.

## Testing done

[Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got.]

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
