### PR TITLE
release_build_versions: add opkssh

### DIFF
--- a/release_build_versions.txt
+++ b/release_build_versions.txt
@@ -102,3 +102,5 @@ btop latest
 
 tilde 1.1.2
 tilde latest
+
+opkssh latest


### PR DESCRIPTION
without this the extension is not built by the automation

Closes: #206 