### PR TITLE
docs: report missing extension documentation drift

### DIFF
--- a/.github/workflows/report-missing-extension-docs.yaml
+++ b/.github/workflows/report-missing-extension-docs.yaml
@@ -1,0 +1,36 @@
+name: Report missing extension documentation
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - release_build_versions.txt
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: report-missing-extension-docs
+  cancel-in-progress: false
+
+jobs:
+  report-missing-extension-docs:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install prerequisites
+        run: |
+          set -euxo pipefail
+          sudo apt update -qq
+          sudo apt install -yqq jq
+
+      - name: Report missing extension documentation
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ./tools/report_missing_extension_docs.sh --create-issues true

--- a/.github/workflows/report-missing-extension-docs.yaml
+++ b/.github/workflows/report-missing-extension-docs.yaml
@@ -58,7 +58,7 @@ jobs:
                 per_page: 100,
               },
             );
-            const openTitles = new Set(openIssues.map(issue => issue.title));
+            const openTitles = new Set(openIssues.filter(issue => !issue.pull_request).map(issue => issue.title));
 
             for (const issue of missingIssues) {
               if (openTitles.has(issue.title)) {

--- a/.github/workflows/report-missing-extension-docs.yaml
+++ b/.github/workflows/report-missing-extension-docs.yaml
@@ -1,0 +1,76 @@
+name: Report missing extension documentation
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - release_build_versions.txt
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: report-missing-extension-docs
+  cancel-in-progress: false
+
+jobs:
+  report-missing-extension-docs:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install prerequisites
+        run: |
+          set -euxo pipefail
+          sudo apt update -qq
+          sudo apt install -yqq jq
+
+      - name: Report missing extension documentation
+        run: |
+          ./tools/report_missing_extension_docs.sh \
+            --output-json missing-extension-docs.json
+
+      - name: Create missing documentation issues
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const missingIssues = JSON.parse(
+              fs.readFileSync('missing-extension-docs.json', 'utf8'),
+            );
+
+            if (missingIssues.length === 0) {
+              core.info('No missing extension documentation issues to create.');
+              return;
+            }
+
+            const { owner, repo } = context.repo;
+            const openIssues = await github.paginate(
+              github.rest.issues.listForRepo,
+              {
+                owner,
+                repo,
+                state: 'open',
+                per_page: 100,
+              },
+            );
+            const openTitles = new Set(openIssues.map(issue => issue.title));
+
+            for (const issue of missingIssues) {
+              if (openTitles.has(issue.title)) {
+                core.info(`Open issue already exists: ${issue.title}`);
+                continue;
+              }
+
+              await github.rest.issues.create({
+                owner,
+                repo,
+                title: issue.title,
+                body: issue.body,
+              });
+              core.info(`Created issue: ${issue.title}`);
+            }

--- a/tools/report_missing_extension_docs.sh
+++ b/tools/report_missing_extension_docs.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+#
+# Detect extensions that are part of the automated release pipeline but are
+# missing from the documentation index and/or do not have a dedicated docs page.
+
+set -euo pipefail
+
+scriptroot="$(cd "$(dirname "${BASH_SOURCE[0]}")/.."; pwd)"
+source "${scriptroot}/lib/helpers.sh"
+
+create_issues="$(get_optional_param "create-issues" "false" "${@}")"
+repository="${GITHUB_REPOSITORY:-flatcar/sysext-bakery}"
+
+function list_release_extensions() {
+  sed -e 's:\s*#.*::' -e 's/[[:space:]]*$//' -e '/^$/d' \
+    "${scriptroot}/release_build_versions.txt" \
+  | awk '{print $1}' \
+  | sort -u
+}
+# --
+
+function list_index_extensions() {
+  sed -n -E 's/^\|[[:space:]]*`([^`]+)`[[:space:]]*\|.*$/\1/p' \
+    "${scriptroot}/docs/index.md" \
+  | sort -u
+}
+# --
+
+function docs_page_path() {
+  local extension="$1"
+  local candidate
+
+  # The repo usually uses docs/<extension>.md, but a few established pages map
+  # hyphens to underscores instead.
+  for candidate in "${extension}.md" "${extension//-/_}.md"; do
+    if [[ -f "${scriptroot}/docs/${candidate}" ]] ; then
+      echo "${candidate}"
+      return 0
+    fi
+  done
+
+  return 1
+}
+# --
+
+function issue_title() {
+  local extension="$1"
+  echo "docs: add documentation for ${extension} sysext"
+}
+# --
+
+function issue_body() {
+  local extension="$1"
+  local missing_index="$2"
+  local missing_page="$3"
+
+  cat <<EOF
+This extension was detected in \`release_build_versions.txt\`, but its documentation is incomplete.
+
+Current status:
+- Extension: \`${extension}\`
+- Missing from \`docs/index.md\`: \`${missing_index}\`
+- Missing dedicated docs page: \`${missing_page}\`
+
+Checklist:
+- [ ] Add a row to the extensions table in \`docs/index.md\`
+- [ ] Create \`docs/<extension>.md\` (or the repo's established underscore variant for hyphenated extensions) with a description, upstream project link, and a Butane configuration snippet
+- [ ] Verify the extension's releases are accessible at \`https://github.com/flatcar/sysext-bakery/releases/tag/${extension}\`
+EOF
+}
+# --
+
+declare -A index_extensions=()
+
+while IFS= read -r extension; do
+  index_extensions["${extension}"]="true"
+done < <(list_index_extensions)
+
+open_issues_json="$(gh issue list -R "${repository}" --state open --limit 200 --json title)"
+missing_extensions=()
+
+while IFS= read -r extension; do
+  missing_index="false"
+  missing_page="false"
+
+  if [[ -z ${index_extensions["${extension}"]+x} ]] ; then
+    missing_index="true"
+  fi
+
+  if ! docs_page_path "${extension}" >/dev/null ; then
+    missing_page="true"
+  fi
+
+  if [[ ${missing_index} == false && ${missing_page} == false ]] ; then
+    continue
+  fi
+
+  missing_extensions+=( "${extension}" )
+
+  echo "Missing documentation detected for '${extension}'"
+  echo "  docs/index.md entry missing: ${missing_index}"
+  echo "  dedicated docs page missing: ${missing_page}"
+
+  title="$(issue_title "${extension}")"
+  if jq -e --arg title "${title}" '.[] | select(.title == $title)' \
+      >/dev/null <<< "${open_issues_json}" ; then
+    echo "  Open issue already exists: ${title}"
+    continue
+  fi
+
+  if [[ ${create_issues} != true ]] ; then
+    echo "  Dry run only; no issue created."
+    continue
+  fi
+
+  gh issue create \
+    -R "${repository}" \
+    --title "${title}" \
+    --body "$(issue_body "${extension}" "${missing_index}" "${missing_page}")"
+done < <(list_release_extensions)
+
+if [[ ${#missing_extensions[@]} -eq 0 ]] ; then
+  echo "All extensions listed in release_build_versions.txt are documented."
+fi

--- a/tools/report_missing_extension_docs.sh
+++ b/tools/report_missing_extension_docs.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+#
+# Detect extensions that are part of the automated release pipeline but are
+# missing from the documentation index and/or do not have a dedicated docs page.
+
+set -euo pipefail
+
+scriptroot="$(cd "$(dirname "${BASH_SOURCE[0]}")/.."; pwd)"
+source "${scriptroot}/lib/helpers.sh"
+
+output_json="$(get_optional_param "output-json" "" "${@}")"
+
+function list_release_extensions() {
+  sed -e 's:\s*#.*::' -e 's/[[:space:]]*$//' -e '/^$/d' \
+    "${scriptroot}/release_build_versions.txt" \
+  | awk '{print $1}' \
+  | sort -u
+}
+# --
+
+function list_index_extensions() {
+  sed -n -E 's/^\|[[:space:]]*`([^`]+)`[[:space:]]*\|.*$/\1/p' \
+    "${scriptroot}/docs/index.md" \
+  | sort -u
+}
+# --
+
+function docs_page_path() {
+  local extension="$1"
+  local candidate
+
+  # The repo usually uses docs/<extension>.md, but a few established pages map
+  # hyphens to underscores instead.
+  for candidate in "${extension}.md" "${extension//-/_}.md"; do
+    if [[ -f "${scriptroot}/docs/${candidate}" ]] ; then
+      echo "${candidate}"
+      return 0
+    fi
+  done
+
+  return 1
+}
+# --
+
+function issue_title() {
+  local extension="$1"
+  echo "docs: add documentation for ${extension} sysext"
+}
+# --
+
+function issue_body() {
+  local extension="$1"
+  local missing_index="$2"
+  local missing_page="$3"
+
+  cat <<EOF
+This extension was detected in \`release_build_versions.txt\`, but its documentation is incomplete.
+
+Current status:
+- Extension: \`${extension}\`
+- Missing from \`docs/index.md\`: \`${missing_index}\`
+- Missing dedicated docs page: \`${missing_page}\`
+
+Checklist:
+- [ ] Add a row to the extensions table in \`docs/index.md\`
+- [ ] Create \`docs/<extension>.md\` (or the repo's established underscore variant for hyphenated extensions) with a description, upstream project link, and a Butane configuration snippet
+- [ ] Verify the extension's releases are accessible at \`https://github.com/flatcar/sysext-bakery/releases/tag/${extension}\`
+EOF
+}
+# --
+
+declare -A index_extensions=()
+
+while IFS= read -r extension; do
+  index_extensions["${extension}"]="true"
+done < <(list_index_extensions)
+
+missing_extensions=()
+missing_issues="[]"
+
+while IFS= read -r extension; do
+  missing_index="false"
+  missing_page="false"
+
+  if [[ -z ${index_extensions["${extension}"]+x} ]] ; then
+    missing_index="true"
+  fi
+
+  if ! docs_page_path "${extension}" >/dev/null ; then
+    missing_page="true"
+  fi
+
+  if [[ ${missing_index} == false && ${missing_page} == false ]] ; then
+    continue
+  fi
+
+  missing_extensions+=( "${extension}" )
+
+  echo "Missing documentation detected for '${extension}'"
+  echo "  docs/index.md entry missing: ${missing_index}"
+  echo "  dedicated docs page missing: ${missing_page}"
+
+  title="$(issue_title "${extension}")"
+  body="$(issue_body "${extension}" "${missing_index}" "${missing_page}")"
+  missing_issues="$(
+    jq \
+      --arg title "${title}" \
+      --arg body "${body}" \
+      '. + [{title: $title, body: $body}]' <<< "${missing_issues}"
+  )"
+done < <(list_release_extensions)
+
+if [[ ${#missing_extensions[@]} -eq 0 ]] ; then
+  echo "All extensions listed in release_build_versions.txt are documented."
+fi
+
+if [[ -n ${output_json} ]] ; then
+  jq '.' <<< "${missing_issues}" > "${output_json}"
+  echo "Wrote missing documentation issue payloads to ${output_json}."
+fi

--- a/tools/report_missing_extension_docs.sh
+++ b/tools/report_missing_extension_docs.sh
@@ -11,7 +11,7 @@ source "${scriptroot}/lib/helpers.sh"
 output_json="$(get_optional_param "output-json" "" "${@}")"
 
 function list_release_extensions() {
-  sed -e 's:\s*#.*::' -e 's/[[:space:]]*$//' -e '/^$/d' \
+  sed -e 's/[[:space:]]*#.*$//' -e 's/[[:space:]]*$//' -e '/^$/d' \
     "${scriptroot}/release_build_versions.txt" \
   | awk '{print $1}' \
   | sort -u


### PR DESCRIPTION
# docs: report missing extension documentation drift

Add a workflow that watches `release_build_versions.txt` on `main` and opens deduplicated issues whenever an extension is part of the automated release pipeline but its documentation is incomplete.

The checker parses the release list, the docs index table, and the existing docs pages. It also accepts the repository's established underscore filenames for hyphenated extensions so existing pages like `docker_buildx.md`, `docker_compose.md`, and `nvidia_runtime.md` do not get reported as false positives.

Closes: #207

## How to use

Run the new `Report missing extension documentation` workflow manually, or merge a change to `release_build_versions.txt` on `main`. The workflow will inspect the release list and open one issue per undocumented extension unless an open issue with the generated title already exists.

For local verification, run:
`./tools/report_missing_extension_docs.sh`

## Testing done

Ran:
`bash -n tools/report_missing_extension_docs.sh`

Ran:
`./tools/report_missing_extension_docs.sh`

Output:
```
Missing documentation detected for 'btop'
  docs/index.md entry missing: true
  dedicated docs page missing: true
  Dry run only; no issue created.
Missing documentation detected for 'tilde'
  docs/index.md entry missing: true
  dedicated docs page missing: true
  Dry run only; no issue created.
```

The changelog and image-diff checklist items below are not applicable for this workflow-only change.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.