### PR TITLE
Add sched-ext/scx

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -81,6 +81,7 @@ Check out documentation on specific extensions at the navigation menu on the lef
 | `ollama`         |  released    | [ollama versions](https://github.com/flatcar/sysext-bakery/releases/tag/ollama) |
 | `opkssh`         |  released    | [opkssh versions](https://github.com/flatcar/sysext-bakery/releases/tag/opkssh) |
 | `rke2`           |  released    | [rke2 versions](https://github.com/flatcar/sysext-bakery/releases/tag/rke2) |
+| `scx`            |  released    | [scx versions](https://github.com/flatcar/sysext-bakery/releases/tag/scx) |
 | `tailscale`      |  released    | [tailscale versions](https://github.com/flatcar/sysext-bakery/releases/tag/tailscale) |
 | `wasmcloud`      |  released    | [wasmcloud versions](https://github.com/flatcar/sysext-bakery/releases/tag/wasmcloud) |
 | `wasmedge`       |  released    | [wasmedge versions](https://github.com/flatcar/sysext-bakery/releases/tag/wasmedge) |

--- a/docs/scx.md
+++ b/docs/scx.md
@@ -1,0 +1,88 @@
+# Scx sysext
+
+This sysext ships [sched-ext schedulers](https://github.com/sched-ext/scx).
+
+Sched-ext is a Linux kernel feature that enables implementing and loading custom process schedulers using BPF.
+The sysext includes several schedulers such as `scx_bpfland`, `scx_lavd`, `scx_rusty`, and others.
+
+The sysext includes a service unit file to start a sched-ext scheduler at boot as well as a default configuration.
+The service will only start if the kernel supports sched_ext (i.e., `/sys/kernel/sched_ext` exists).
+
+## Usage
+
+Download and merge the sysext at provisioning time using the below butane snippet.
+
+The default scheduler is `scx_bpfland`. You can change the scheduler and its flags by creating `/etc/default/scx` with your preferred configuration.
+Available schedulers include:
+- `scx_bpfland` - vruntime-based scheduler (default)
+- `scx_lavd` - latency-aware virtual deadline scheduler
+- `scx_rusty` - multi-domain BPF + user space hybrid scheduler
+- `scx_rustland` - BPF + user space rust scheduler
+- `scx_simple` - simple scheduler for demonstration purposes
+
+Run `scx_<name> --help` for scheduler-specific options.
+
+The snippet includes automated updates via systemd-sysupdate.
+Sysupdate will stage updates and request a reboot by creating a flag file at `/run/reboot-required`.
+You can deactivate updates by changing `enabled: true` to `enabled: false` in `systemd-sysupdate.timer`.
+
+Note that the snippet is for the x86-64 version of scx v1.0.19.
+
+Check out the metadata release at https://github.com/flatcar/sysext-bakery/releases/tag/scx for a list of all versions available in the bakery.
+
+```yaml
+variant: flatcar
+version: 1.0.0
+
+storage:
+  files:
+    - path: /opt/extensions/scx/scx-v1.0.19-x86-64.raw
+      mode: 0644
+      contents:
+        source: https://extensions.flatcar.org/extensions/scx-v1.0.19-x86-64.raw
+    - path: /etc/sysupdate.scx.d/scx.conf
+      contents:
+        source: https://extensions.flatcar.org/extensions/scx.conf
+    - path: /etc/sysupdate.d/noop.conf
+      contents:
+        source: https://extensions.flatcar.org/extensions/noop.conf
+  links:
+    - target: /opt/extensions/scx/scx-v1.0.19-x86-64.raw
+      path: /etc/extensions/scx.raw
+      hard: false
+systemd:
+  units:
+    - name: scx.service
+      enabled: true
+    - name: systemd-sysupdate.timer
+      enabled: true
+    - name: systemd-sysupdate.service
+      dropins:
+        - name: scx.conf
+          contents: |
+            [Service]
+            ExecStartPre=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/scx.raw > /tmp/scx"
+            ExecStartPre=/usr/lib/systemd/systemd-sysupdate -C scx update
+            ExecStartPost=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/scx.raw > /tmp/scx-new"
+            ExecStartPost=/usr/bin/sh -c "if ! cmp --silent /tmp/scx /tmp/scx-new; then touch /run/reboot-required; fi"
+```
+
+## Configuration
+
+To customize the scheduler, create `/etc/default/scx` with your settings:
+
+```yaml
+variant: flatcar
+version: 1.0.0
+
+storage:
+  files:
+    - path: /etc/default/scx
+      mode: 0644
+      contents:
+        inline: |
+          SCX_SCHEDULER_OVERRIDE=scx_lavd
+          SCX_FLAGS_OVERRIDE=-a
+```
+
+Then restart the service with `systemctl restart scx.service`.

--- a/docs/scx.md
+++ b/docs/scx.md
@@ -19,6 +19,20 @@ Available schedulers include:
 - `scx_rusty` - multi-domain BPF + user space hybrid scheduler
 - `scx_rustland` - BPF + user space rust scheduler
 - `scx_simple` - simple scheduler for demonstration purposes
+- `scx_beerland`
+- `scx_flash`
+- `scx_layered`
+- `scx_rlfifo`
+- `scx_wd40`
+- `scx_chaos`
+- `scx_cosmos`
+- `scx_mitosis`
+- `scx_p2dq`
+- `scx_tickless`
+
+Tools include:
+- `scxtop` - top-like utility for scheduler telemetry
+- `scxcash` - cache usage analyser
 
 Run `scx_<name> --help` for scheduler-specific options.
 

--- a/release_build_versions.txt
+++ b/release_build_versions.txt
@@ -71,6 +71,9 @@ ollama v0.13.2
 rke2 v1.32.2+rke2r1
 rke2 latest
 
+scx v1.1.1
+scx latest
+
 tailscale v1.76.6
 tailscale latest
 

--- a/scx.sysext/build.sh
+++ b/scx.sysext/build.sh
@@ -1,0 +1,101 @@
+#!/bin/ash
+#
+# Build script helper for scx sysext.
+# This script runs inside an ephemeral Alpine container.
+# It builds sched-ext schedulers and exports the binaries to a bind-mounted volume.
+#
+set -euo pipefail
+
+version="$1"
+export_user_group="$2"
+
+apk add --no-cache \
+  clang \
+  clang-dev \
+  clang-libclang \
+  llvm \
+  lld \
+  bpftool \
+  libbpf-dev \
+  elfutils-dev \
+  zlib-dev \
+  zstd-dev \
+  libseccomp-dev \
+  cargo \
+  rust \
+  pkgconf \
+  curl \
+  git \
+  make \
+  gcc \
+  musl-dev \
+  linux-headers \
+  jq \
+  ca-certificates \
+  pax-utils
+
+cd /opt
+git clone https://github.com/sched-ext/scx.git --depth 1 --branch ${version} --single-branch
+cd /opt/scx
+
+# Force static linking for Rust and C dependencies.
+target="$(rustc -vV | sed -n 's/^host: //p')"
+export CARGO_BUILD_TARGET="${target}"
+export RUSTFLAGS="-C target-feature=+crt-static"
+export PKG_CONFIG_ALL_STATIC=1
+export LIBBPF_SYS_STATIC=1
+export RUSTFLAGS="${RUSTFLAGS} -C link-arg=-lzstd"
+
+# Ensure libz static is available for fully static linking.
+if [ ! -f /usr/lib/libz.a ] && [ ! -f /lib/libz.a ] && [ ! -f /usr/local/lib/libz.a ]; then
+  zlib_version="1.3.1"
+  workdir="/tmp/zlib-${zlib_version}"
+  zlib_url="https://zlib.net/zlib-${zlib_version}.tar.gz"
+  if ! curl -fsSL "${zlib_url}" -o /tmp/zlib.tar.gz; then
+    curl -fsSL "https://zlib.net/fossils/zlib-${zlib_version}.tar.gz" -o /tmp/zlib.tar.gz
+  fi
+  tar -C /tmp -xf /tmp/zlib.tar.gz
+  cd "${workdir}"
+  ./configure --static
+  make -j"$(nproc)"
+  make install
+  cd /opt/scx
+  export LIBRARY_PATH="/usr/local/lib:${LIBRARY_PATH:-}"
+  export PKG_CONFIG_PATH="/usr/local/lib/pkgconfig:${PKG_CONFIG_PATH:-}"
+fi
+
+# Ensure libzstd static is available for libelf static linking.
+if [ ! -f /usr/lib/libzstd.a ] && [ ! -f /lib/libzstd.a ] && [ ! -f /usr/local/lib/libzstd.a ]; then
+  zstd_version="1.5.7"
+  workdir="/tmp/zstd-${zstd_version}"
+  curl -fsSL "https://github.com/facebook/zstd/releases/download/v${zstd_version}/zstd-${zstd_version}.tar.gz" -o /tmp/zstd.tar.gz
+  tar -C /tmp -xf /tmp/zstd.tar.gz
+  cd "${workdir}"
+  make -j"$(nproc)"
+  make install PREFIX=/usr/local
+  cd /opt/scx
+  export LIBRARY_PATH="/usr/local/lib:${LIBRARY_PATH:-}"
+  export PKG_CONFIG_PATH="/usr/local/lib/pkgconfig:${PKG_CONFIG_PATH:-}"
+fi
+
+# Build Rust schedulers (includes scx_bpfland and others)
+cargo build --release
+
+# Verify binaries are fully static (no NEEDED entries).
+for bin in target/release/scx_*; do
+  if [ -x "${bin}" ]; then
+    needed="$(scanelf --needed --nobanner -F '%N' "${bin}")"
+    if [ -n "${needed}" ]; then
+      echo "ERROR: ${bin} is not fully static (NEEDED: ${needed})"
+      exit 1
+    fi
+  fi
+done
+
+# Install binaries (only executables, not .d dependency files)
+mkdir -p /install_root/usr/bin
+find target/release -maxdepth 1 -name 'scx_*' -type f -executable -exec cp {} /install_root/usr/bin/ \;
+
+chown -R "$export_user_group" /install_root
+# Ensure host user can always read/delete build artifacts on the bind mount.
+chmod -R u+rwX,go+rX /install_root

--- a/scx.sysext/build.sh
+++ b/scx.sysext/build.sh
@@ -19,7 +19,9 @@ apk add --no-cache \
   libbpf-dev \
   elfutils-dev \
   zlib-dev \
+  zlib-static \
   zstd-dev \
+  zstd-static \
   libseccomp-dev \
   cargo \
   rust \
@@ -38,63 +40,22 @@ cd /opt
 git clone https://github.com/sched-ext/scx.git --depth 1 --branch ${version} --single-branch
 cd /opt/scx
 
-# Force static linking for Rust and C dependencies.
+# Force static linking for Rust and C dependencies. Since we set CARGO_BUILD_TARGET
+# below, cargo uses CARGO_TARGET_<TRIPLE>_* env vars in preference to generic ones,
+# so we have to set the prefixed forms.
 target="$(rustc -vV | sed -n 's/^host: //p')"
 export CARGO_BUILD_TARGET="${target}"
-export RUSTFLAGS="-C target-feature=+crt-static"
-export PKG_CONFIG_ALL_STATIC=1
-export LIBBPF_SYS_STATIC=1
-export RUSTFLAGS="${RUSTFLAGS} -C link-arg=-lzstd"
+TARGET="$(echo "${target}" | tr a-z- A-Z_)"
+export CARGO_TARGET_${TARGET}_RUSTFLAGS="-C target-feature=+crt-static -lz -lzstd -lpthread -L /usr/lib -C link-arg=-Wl,-static"
+export CARGO_TARGET_${TARGET}_PKG_CONFIG_ALL_STATIC=1
+export CARGO_TARGET_${TARGET}_LIBBPF_SYS_STATIC=1
 
-# Ensure libz static is available for fully static linking.
-if [ ! -f /usr/lib/libz.a ] && [ ! -f /lib/libz.a ] && [ ! -f /usr/local/lib/libz.a ]; then
-  zlib_version="1.3.1"
-  workdir="/tmp/zlib-${zlib_version}"
-  zlib_url="https://zlib.net/zlib-${zlib_version}.tar.gz"
-  if ! curl -fsSL "${zlib_url}" -o /tmp/zlib.tar.gz; then
-    curl -fsSL "https://zlib.net/fossils/zlib-${zlib_version}.tar.gz" -o /tmp/zlib.tar.gz
-  fi
-  tar -C /tmp -xf /tmp/zlib.tar.gz
-  cd "${workdir}"
-  ./configure --static
-  make -j"$(nproc)"
-  make install
-  cd /opt/scx
-  export LIBRARY_PATH="/usr/local/lib:${LIBRARY_PATH:-}"
-  export PKG_CONFIG_PATH="/usr/local/lib/pkgconfig:${PKG_CONFIG_PATH:-}"
-fi
-
-# Ensure libzstd static is available for libelf static linking.
-if [ ! -f /usr/lib/libzstd.a ] && [ ! -f /lib/libzstd.a ] && [ ! -f /usr/local/lib/libzstd.a ]; then
-  zstd_version="1.5.7"
-  workdir="/tmp/zstd-${zstd_version}"
-  curl -fsSL "https://github.com/facebook/zstd/releases/download/v${zstd_version}/zstd-${zstd_version}.tar.gz" -o /tmp/zstd.tar.gz
-  tar -C /tmp -xf /tmp/zstd.tar.gz
-  cd "${workdir}"
-  make -j"$(nproc)"
-  make install PREFIX=/usr/local
-  cd /opt/scx
-  export LIBRARY_PATH="/usr/local/lib:${LIBRARY_PATH:-}"
-  export PKG_CONFIG_PATH="/usr/local/lib/pkgconfig:${PKG_CONFIG_PATH:-}"
-fi
-
-# Build Rust schedulers (includes scx_bpfland and others)
+# Build Rust schedulers and tools (scx_* schedulers, scxtop, scxcash, ...).
 cargo build --release
 
-# Verify binaries are fully static (no NEEDED entries).
-for bin in target/release/scx_*; do
-  if [ -x "${bin}" ]; then
-    needed="$(scanelf --needed --nobanner -F '%N' "${bin}")"
-    if [ -n "${needed}" ]; then
-      echo "ERROR: ${bin} is not fully static (NEEDED: ${needed})"
-      exit 1
-    fi
-  fi
-done
-
-# Install binaries (only executables, not .d dependency files)
+# Install schedulers and tools (only executables, not .d dependency files).
 mkdir -p /install_root/usr/bin
-find target/release -maxdepth 1 -name 'scx_*' -type f -executable -exec cp {} /install_root/usr/bin/ \;
+find "target/${target}/release" -maxdepth 1 -name 'scx*' -type f -executable -exec cp \{\} /install_root/usr/bin/ \;
 
 chown -R "$export_user_group" /install_root
 # Ensure host user can always read/delete build artifacts on the bind mount.

--- a/scx.sysext/create.sh
+++ b/scx.sysext/create.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# vim: et ts=2 syn=bash
+#
+# sched-ext/scx system extension.
+# Provides sched_ext schedulers for Linux.
+
+RELOAD_SERVICES_ON_MERGE="true"
+
+function list_available_versions() {
+  list_github_releases "sched-ext" "scx"
+}
+# --
+
+function populate_sysext_root_options() {
+  echo "  --scheduler <name>  : Default scheduler to use (default: scx_bpfland)."
+}
+# --
+
+function populate_sysext_root() {
+  local sysextroot="$1"
+  local arch="$2"
+  local version="$3"
+
+  local scheduler="$(get_optional_param "scheduler" "scx_bpfland" "${@}")"
+
+  local img_arch="$(arch_transform 'x86-64' 'amd64' "$arch")"
+  img_arch="$(arch_transform 'arm64' 'arm64/v8' "$img_arch")"
+
+  local image="docker.io/alpine:latest"
+
+  announce "Building scx $version for $arch"
+
+  local user_group="$(id -u):$(id -g)"
+
+  cp "${scriptroot}/scx.sysext/build.sh" .
+
+  docker run --rm \
+    -i \
+    -v "$(pwd)":/install_root \
+    --platform "linux/${img_arch}" \
+    --pull always \
+    ${image} \
+      /install_root/build.sh "${version}" "$user_group"
+
+  cp -aR usr "${sysextroot}"/
+
+  # Update default scheduler in config if specified
+  if [[ "${scheduler}" != "scx_bpfland" ]]; then
+    sed -i "s/SCX_SCHEDULER=scx_bpfland/SCX_SCHEDULER=${scheduler}/" \
+      "${sysextroot}/usr/share/scx/scx"
+  fi
+}
+# --

--- a/scx.sysext/files/usr/lib/systemd/system/scx.service
+++ b/scx.sysext/files/usr/lib/systemd/system/scx.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Sched-ext Scheduler
+Documentation=https://github.com/sched-ext/scx
+ConditionPathIsDirectory=/sys/kernel/sched_ext
+StartLimitIntervalSec=30
+StartLimitBurst=2
+
+[Service]
+Type=simple
+EnvironmentFile=-/usr/share/scx/scx
+EnvironmentFile=-/etc/default/scx
+ExecStart=/bin/bash -c 'exec ${SCX_SCHEDULER_OVERRIDE:-$SCX_SCHEDULER} ${SCX_FLAGS_OVERRIDE:-$SCX_FLAGS}'
+Restart=on-failure
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/scx.sysext/files/usr/share/scx/scx
+++ b/scx.sysext/files/usr/share/scx/scx
@@ -1,0 +1,25 @@
+# sched-ext (scx) scheduler configuration
+#
+# Available schedulers (run scx_<name> --help for options):
+#   scx_bpfland  - vruntime-based scheduler
+#   scx_lavd     - latency-aware virtual deadline scheduler
+#   scx_rusty    - multi-domain BPF + user space hybrid scheduler
+#   scx_rustland - BPF + user space rust scheduler
+#   scx_simple   - simple scheduler for demonstration purposes
+#
+# For more information, see: https://github.com/sched-ext/scx
+
+# Select the scheduler to use
+SCX_SCHEDULER=scx_bpfland
+
+# Set custom flags for the scheduler (run scx_<name> --help for available options)
+SCX_FLAGS=
+
+# Override variables (for temporary testing without modifying this file)
+# Set SCX_SCHEDULER_OVERRIDE and SCX_FLAGS_OVERRIDE environment variables
+# to temporarily use different settings without editing this file.
+#
+# To use overrides, create /etc/default/scx with:
+#   SCX_SCHEDULER_OVERRIDE=scx_lavd
+#   SCX_FLAGS_OVERRIDE=-a
+# Then restart the service: systemctl restart scx.service

--- a/scx.sysext/files/usr/share/scx/scx
+++ b/scx.sysext/files/usr/share/scx/scx
@@ -6,6 +6,16 @@
 #   scx_rusty    - multi-domain BPF + user space hybrid scheduler
 #   scx_rustland - BPF + user space rust scheduler
 #   scx_simple   - simple scheduler for demonstration purposes
+#   scx_beerland
+#   scx_flash
+#   scx_layered
+#   scx_rlfifo
+#   scx_wd40
+#   scx_chaos
+#   scx_cosmos
+#   scx_mitosis
+#   scx_p2dq
+#   scx_tickless
 #
 # For more information, see: https://github.com/sched-ext/scx
 

--- a/scx.sysext/test.sh
+++ b/scx.sysext/test.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# vim: et ts=2 syn=bash
+#
+# Test script for scx sysext.
+#


### PR DESCRIPTION
# Run userspace schedulers with sched-ext/scx

Add the `scx` sysext that ships the [sched-ext userspace schedulers](https://github.com/sched-ext/scx) plus the `scxtop` and `scxcash` tools. sched-ext is a Linux kernel subsystem that allows running task schedulers in userspace. The upstream repo provides a set of reference schedulers and tooling to load and observe them.

This re-opens #203. All of @t-lo's review feedback from that thread is applied here:

- Build inside an Alpine container; install `zlib-static` / `zstd-static` via apk and drop the from-source fallback for libz / libzstd.
- Use `CARGO_BUILD_TARGET=$(rustc -vV ... host)` for cross-compile consistency, and set the target-prefixed `CARGO_TARGET_<TRIPLE>_RUSTFLAGS` / `CARGO_TARGET_<TRIPLE>_PKG_CONFIG_ALL_STATIC` / `CARGO_TARGET_<TRIPLE>_LIBBPF_SYS_STATIC` env vars so the static flags actually apply when `CARGO_BUILD_TARGET` is set. Link statically with `-C target-feature=+crt-static` and `-C link-arg=-Wl,-static`.
- Install from `target/<triple>/release/` and widen the install glob from `scx_*` to `scx*` so `scxtop` and `scxcash` come along.
- Document the full scheduler set and the bundled tools in `docs/scx.md` and `files/usr/share/scx/scx`.
- Register `scx` in `docs/index.md` and `release_build_versions.txt` so the release Action picks it up.

## How to use

Drop the sysext via Ignition (snippet in `docs/scx.md`). By default the bundled `scx.service` runs `scx_bpfland`. Override by writing `/etc/default/scx`:

```
SCX_SCHEDULER_OVERRIDE=scx_lavd
SCX_FLAGS_OVERRIDE=-a
```

…then `systemctl restart scx.service`. The unit is gated by `ConditionPathIsDirectory=/sys/kernel/sched_ext`, so it stays inert on kernels without sched_ext.

## Testing done

This update applies the suggested build-script fixes verbatim from the prior review. Yet to do another round of local boot tests.