### PR TITLE
Kubernetes: Add kubectl/kubeadm/kubelet/CNI checksum validation

### DIFF
--- a/kubernetes.sysext/create.sh
+++ b/kubernetes.sysext/create.sh
@@ -46,7 +46,7 @@ function populate_sysext_root() {
                    | jq -r .tag_name)"
   fi
 
-  announce "Using CNI version '${version}'"
+  announce "Using CNI version '${cni_version}'"
 
   mkdir -p "${sysextroot}/usr/bin"
 

--- a/kubernetes.sysext/create.sh
+++ b/kubernetes.sysext/create.sh
@@ -52,16 +52,28 @@ function populate_sysext_root() {
 
   curl --parallel --fail --silent --show-error --location \
     --output "${sysextroot}/usr/bin/kubectl" "https://dl.k8s.io/${version}/bin/linux/${rel_arch}/kubectl" \
+    --output kubectl.sha256 "https://dl.k8s.io/${version}/bin/linux/${rel_arch}/kubectl.sha256" \
     --output "${sysextroot}/usr/bin/kubeadm" "https://dl.k8s.io/${version}/bin/linux/${rel_arch}/kubeadm" \
-    --output "${sysextroot}/usr/bin/kubelet" "https://dl.k8s.io/${version}/bin/linux/${rel_arch}/kubelet"
+    --output kubeadm.sha256 "https://dl.k8s.io/${version}/bin/linux/${rel_arch}/kubeadm.sha256" \
+    --output "${sysextroot}/usr/bin/kubelet" "https://dl.k8s.io/${version}/bin/linux/${rel_arch}/kubelet"\
+    --output kubelet.sha256 "https://dl.k8s.io/${version}/bin/linux/${rel_arch}/kubelet.sha256"
 
-  curl -o cni.tgz \
-       -fsSL "https://github.com/containernetworking/plugins/releases/download/${cni_version}/cni-plugins-linux-${rel_arch}-${cni_version}.tgz"
+  for bin in kubectl kubeadm kubelet; do
+    echo "Verifying ${bin} checksum..."
+    echo "$(cat "${bin}.sha256")  ${sysextroot}/usr/bin/${bin}" | shasum -a 256 --check
+  done
+
+  curl --parallel --fail --silent --show-error --location \
+    --output "cni-plugins-linux-${rel_arch}-${cni_version}.tgz" "https://github.com/containernetworking/plugins/releases/download/${cni_version}/cni-plugins-linux-${rel_arch}-${cni_version}.tgz" \
+    --output cni.sha256 "https://github.com/containernetworking/plugins/releases/download/${cni_version}/cni-plugins-linux-${rel_arch}-${cni_version}.tgz.sha256"
+
+  echo "Verifying CNI checksum..."
+  shasum -a 256 --check cni.sha256
 
   chmod +x "${sysextroot}/usr/bin/"*
 
   mkdir -p "${sysextroot}/usr/local/bin/cni"
-  tar --force-local -xf "cni.tgz" -C "${sysextroot}/usr/local/bin/cni"
+  tar --force-local -xf "cni-plugins-linux-${rel_arch}-${cni_version}.tgz" -C "${sysextroot}/usr/local/bin/cni"
 
   mkdir -p "${sysextroot}/usr/local/share/"
   echo "${version}" > "${sysextroot}/usr/local/share/kubernetes-version"


### PR DESCRIPTION
# Add binary sha256 checksum validation

This PR introduces shasum validation for the kubernetes sysext binaries kubectl/kubeadm/kubelet and the CNI plugins.

It also fixes one minor issue where the build would output the K8s version instead of the CNI version in `Using CNI version 'v1.36.1'`

## Testing done

`./bakery.sh create kubernetes v1.36.1`

```
    ----- ===== ##### Using CNI version 'v1.9.1' ##### ===== -----
Verifying kubectl checksum...
/tmp/tmp.L9UKup8VCg/kubernetes/usr/bin/kubectl: OK
Verifying kubeadm checksum...
/tmp/tmp.L9UKup8VCg/kubernetes/usr/bin/kubeadm: OK
Verifying kubelet checksum...
/tmp/tmp.L9UKup8VCg/kubernetes/usr/bin/kubelet: OK
Verifying CNI checksum...
cni-plugins-linux-amd64-v1.9.1.tgz: OK
```