### PR TITLE
Fix RKE2 butane and update to the latest release

### DIFF
--- a/docs/rke2.md
+++ b/docs/rke2.md
@@ -29,17 +29,18 @@ version: 1.0.0
 
 storage:
   files:
-    - path: /etc/extensions/rke2.raw
+    - path: /opt/extensions/rke2/rke2-v1.36.1+rke2r2-x86-64.raw
+      mode: 0644
       contents:
-        source: https://extensions.flatcar.org/extensions/rke2-v1.32.2+rke2r1-x86-64.raw
-    - path: /etc/sysupdate.rke2.d/rke2-v1.32.conf
+        source: https://extensions.flatcar.org/extensions/rke2-v1.36.1+rke2r2-x86-64.raw
+    - path: /etc/sysupdate.rke2.d/rke2-v1.36.conf
       contents:
-        source: https://extensions.flatcar.org/extensions/rke2/rke2-v1.32.conf
+        source: https://extensions.flatcar.org/extensions/rke2/rke2-v1.36.conf
     - path: /etc/sysupdate.d/noop.conf
       contents:
         source: https://extensions.flatcar.org/extensions/noop.conf
   links:
-    - target: /opt/extensions/rke2/rke2-v1.32.2+rke2r1-x86-64.raw
+    - target: /opt/extensions/rke2/rke2-v1.36.1+rke2r2-x86-64.raw
       path: /etc/extensions/rke2.raw
       hard: false
 


### PR DESCRIPTION
Updated a file path (closely matching the k3s example) to fix a duplicate file issue which caused a butane transpiler error.
Also, updated to the latest RKE2 release.

## Testing done

Prior example:
```
podman run --rm -i quay.io/coreos/butane:latest < orig_config.yaml > orig_config.ign
error[$.storage.links.0]:
  --> <stdin>:16:7
    |
 14 |         source: https://extensions.flatcar.org/extensions/noop.conf
 15 |   links:
 16 |     - target: /opt/extensions/rke2/rke2-v1.32.2+rke2r1-x86-64.raw
    |       ^^^^^^^ duplicate entry defined
 17 |       path: /etc/extensions/rke2.raw
 18 |       hard: false
    |
Error translating config: config generated was invalid
```

After the commit, I successfully launched a [QEMU instance](https://www.flatcar.org/docs/latest/installing/vms/qemu/) with the following command:
`./flatcar_production_qemu.sh -i config.ign -- -nographic` 