### PR TITLE
k3s,rke2: build all supported k8s major releases

### DIFF
--- a/k3s.sysext/create.sh
+++ b/k3s.sysext/create.sh
@@ -4,9 +4,31 @@
 # K3s system extension.
 #
 
+source "${scriptroot}/kubernetes.sysext/funcs.inc"
+
 RELOAD_SERVICES_ON_MERGE="true"
 EXTENSION_VERSION_MATCH_PATTERN='[.v0-9]+\+k3s[0-9]+'
 
+
+# Get the latest k3s release for all supported major Kubernetes versions.
+# Addresses https://github.com/flatcar/sysext-bakery/issues/213.
+function list_latest_release() {
+  local k8s_version
+  local relcache
+
+  relcache="$(mktemp)"
+  trap "rm -f '${relcache}'" EXIT
+  list_github_releases "k3s-io" "k3s" > "${relcache}"
+
+  for k8s_version in $(kubernetes_list_latest_release); do
+    cat "${relcache}" \
+      | grep -F "${k8s_version}+k3s" \
+      | sort -V \
+      | tail -n1
+  done
+}
+# --
+#
 function list_available_versions() {
   list_github_releases "k3s-io" "k3s"
 }

--- a/kubernetes.sysext/create.sh
+++ b/kubernetes.sysext/create.sh
@@ -4,25 +4,19 @@
 # Kubernetes system extension.
 #
 
+source "${scriptroot}/kubernetes.sysext/funcs.inc"
+
 RELOAD_SERVICES_ON_MERGE="true"
 
 # We overwrite this library function and return a list of all latest patch levels
 # of all supported release branches.
 function list_latest_release() {
-  curl -fsSL --retry-delay 1 --retry 60 --retry-connrefused \
-       --retry-max-time 60 --connect-timeout 20 \
-       https://raw.githubusercontent.com/kubernetes/website/main/data/releases/schedule.yaml \
-       | yq -r '.schedules[] | .previousPatches[0] // (.release = .release + ".0") | .release' \
-       | sed 's/^/v/'
+  kubernetes_list_latest_release "${@}"
 }
 # --
 
 function list_available_versions() {
-  curl -fsSL --retry-delay 1 --retry 60 --retry-connrefused \
-       --retry-max-time 60 --connect-timeout 20 \
-       https://raw.githubusercontent.com/kubernetes/website/main/data/releases/schedule.yaml \
-       | yq -r '.schedules[] | .previousPatches[] // (.release = .release + ".0") | .release' \
-       | sed 's/^/v/'
+  kubernetes_list_available_versions "${@}"
 }
 # --
 

--- a/kubernetes.sysext/funcs.inc
+++ b/kubernetes.sysext/funcs.inc
@@ -1,0 +1,22 @@
+# vim: et ts=2 syn=bash
+# Kubernetes system extension shared functions.
+
+# List latest patch level releases of all supported major release series
+function kubernetes_list_latest_release() {
+  curl -fsSL --retry-delay 1 --retry 60 --retry-connrefused \
+       --retry-max-time 60 --connect-timeout 20 \
+       https://raw.githubusercontent.com/kubernetes/website/main/data/releases/schedule.yaml \
+       | yq -r '.schedules[] | .previousPatches[0] // (.release = .release + ".0") | .release' \
+       | sed 's/^/v/'
+}
+# --
+
+# List all releases of all supported major release series
+function kubernetes_list_available_versions() {
+  curl -fsSL --retry-delay 1 --retry 60 --retry-connrefused \
+       --retry-max-time 60 --connect-timeout 20 \
+       https://raw.githubusercontent.com/kubernetes/website/main/data/releases/schedule.yaml \
+       | yq -r '.schedules[] | .previousPatches[] // (.release = .release + ".0") | .release' \
+       | sed 's/^/v/'
+}
+# --

--- a/rke2.sysext/create.sh
+++ b/rke2.sysext/create.sh
@@ -4,8 +4,29 @@
 # RKE2, aka Rancher 2, sysext.
 #
 
+source "${scriptroot}/kubernetes.sysext/funcs.inc"
+
 RELOAD_SERVICES_ON_MERGE="true"
 EXTENSION_VERSION_MATCH_PATTERN='[.v0-9]+\+rke2r[0-9]+'
+
+# Get the latest rke2 release for all supported major Kubernetes versions.
+# Addresses https://github.com/flatcar/sysext-bakery/issues/213.
+function list_latest_release() {
+  local k8s_version
+  local relcache
+
+  relcache="$(mktemp)"
+  trap "rm -f '${relcache}'" EXIT
+  list_github_releases "rancher" "rke2" > "${relcache}"
+
+  for k8s_version in $(kubernetes_list_latest_release); do
+    cat "${relcache}" \
+      | grep -F "${k8s_version}+rke2r" \
+      | sort -V \
+      | tail -n1
+  done
+}
+# --
 
 function list_available_versions() {
   list_github_releases "rancher" "rke2"


### PR DESCRIPTION
This change fixes an issue with k3s and rke2 "latest" automated builds. Currently, the builds only honor the very latest k3s and rke2 release for the latest k8s major release series. See
https://github.com/flatcar/sysext-bakery/issues/213 for details.

The fix filters latest k3s and rke2 releases based on all supported Kubernetes major releases. It re-uses functions provided by the Kubernetes sysext which have now been moved into a separate file.

Fixes https://github.com/flatcar/sysext-bakery/issues/213.