### PR TITLE
ollama: fix tarball suffix, re-activate "latest"

### DIFF
--- a/ollama.sysext/create.sh
+++ b/ollama.sysext/create.sh
@@ -16,17 +16,25 @@ function populate_sysext_root() {
   local arch="$2"
   local version="$3"
 
-  local rel_arch="$(arch_transform "x86-64" "amd64" "$arch")"
+  local rel_arch
+  rel_arch="$(arch_transform "x86-64" "amd64" "$arch")"
+
+  local sufx="tgz"
+  if semver_equals_or_higher "${version}" "v0.14.0" ; then
+    sufx="tar.zst"
+  fi
+
+  local tarball="ollama-linux-${rel_arch}.${sufx}"
 
   echo "This might take a while as the Ollama download is pretty sizeable (about 1.5 GB)."
   curl --parallel --fail --silent --show-error --location \
-    --remote-name "https://github.com/ollama/ollama/releases/download/${version}/ollama-linux-${rel_arch}.tgz" \
+    --remote-name "https://github.com/ollama/ollama/releases/download/${version}/${tarball}" \
     --remote-name "https://github.com/ollama/ollama/releases/download/${version}/sha256sum.txt"
 
-  grep "ollama-linux-${rel_arch}.tgz$" sha256sum.txt | sha256sum -c -
+  grep -F "${tarball}" sha256sum.txt | sha256sum -c -
 
   mkdir -p "${sysextroot}/usr/local"
-  tar --force-local -xf "ollama-linux-${rel_arch}.tgz" -C "${sysextroot}/usr/local"
+  tar --force-local -xf "${tarball}" -C "${sysextroot}/usr/local"
   chmod +x "${sysextroot}/usr/local/bin/ollama"
 }
 # --

--- a/release_build_versions.txt
+++ b/release_build_versions.txt
@@ -68,8 +68,7 @@ nomad latest
 nvidia-runtime v1.18.1
 nvidia-runtime latest
 
-ollama v0.3.9
-ollama v0.13.2
+ollama latest
 
 rke2 v1.32.2+rke2r1
 rke2 latest


### PR DESCRIPTION
This change fixes the tarball download filename suffix (Ollama uses .tar.zst since release v0.14.0) and re-activates the "latest" build which was de-activated because sysexts grew larger than 2GB. That's not the case anymore.