### PR TITLE
podman: add system extension

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -81,6 +81,7 @@ Check out documentation on specific extensions at the navigation menu on the lef
 | `nvidia-runtime` |  released    | [nvidia-runtime versions](https://github.com/flatcar/sysext-bakery/releases/tag/nvidia-runtime) |
 | `ollama`         |  released    | [ollama versions](https://github.com/flatcar/sysext-bakery/releases/tag/ollama) |
 | `opkssh`         |  released    | [opkssh versions](https://github.com/flatcar/sysext-bakery/releases/tag/opkssh) |
+| `podman`         |  released    | [podman versions](https://github.com/flatcar/sysext-bakery/releases/tag/podman) |
 | `rke2`           |  released    | [rke2 versions](https://github.com/flatcar/sysext-bakery/releases/tag/rke2) |
 | `scx`            |  released    | [scx versions](https://github.com/flatcar/sysext-bakery/releases/tag/scx) |
 | `tailscale`      |  released    | [tailscale versions](https://github.com/flatcar/sysext-bakery/releases/tag/tailscale) |

--- a/docs/podman.md
+++ b/docs/podman.md
@@ -1,0 +1,66 @@
+# Podman sysext
+
+This sysext ships [podman](https://podman.io/), a daemonless container engine
+for developing, managing, and running OCI containers on Linux.
+
+The sysext bundles statically-linked binaries built by the
+[mgoltzsche/podman-static](https://github.com/mgoltzsche/podman-static)
+project. These include podman, conmon, crun, runc, fuse-overlayfs,
+slirp4netns, netavark, aardvark-dns and CNI plugins so the sysext is
+self-contained.
+
+The sysext ships a socket-activated `podman.service` to expose the rootful
+Podman REST API at `/run/podman/podman.sock`. The socket is enabled on
+merge via a `sockets.target` drop-in.
+
+## Usage
+
+Download and merge the sysext at provisioning time using the below butane
+snippet.
+
+The snippet includes automated updates via systemd-sysupdate.
+Sysupdate will stage updates and request a reboot by creating a flag file
+at `/run/reboot-required`.
+You can deactivate updates by changing `enabled: true` to `enabled: false`
+in `systemd-sysupdate.timer`.
+
+Note that the snippet is for the x86-64 version of podman v5.5.2.
+
+Check out the metadata release at
+https://github.com/flatcar/sysext-bakery/releases/tag/podman for a list of
+all versions available in the bakery.
+
+```yaml
+variant: flatcar
+version: 1.0.0
+
+storage:
+  files:
+    - path: /opt/extensions/podman/podman-v5.5.2-x86-64.raw
+      mode: 0644
+      contents:
+        source: https://extensions.flatcar.org/extensions/podman-v5.5.2-x86-64.raw
+    - path: /etc/sysupdate.podman.d/podman.conf
+      contents:
+        source: https://extensions.flatcar.org/extensions/podman.conf
+    - path: /etc/sysupdate.d/noop.conf
+      contents:
+        source: https://extensions.flatcar.org/extensions/noop.conf
+  links:
+    - target: /opt/extensions/podman/podman-v5.5.2-x86-64.raw
+      path: /etc/extensions/podman.raw
+      hard: false
+systemd:
+  units:
+    - name: systemd-sysupdate.timer
+      enabled: true
+    - name: systemd-sysupdate.service
+      dropins:
+        - name: podman.conf
+          contents: |
+            [Service]
+            ExecStartPre=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/podman.raw > /tmp/podman"
+            ExecStartPre=/usr/lib/systemd/systemd-sysupdate -C podman update
+            ExecStartPost=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/podman.raw > /tmp/podman-new"
+            ExecStartPost=/usr/bin/sh -c "if ! cmp --silent /tmp/podman /tmp/podman-new; then touch /run/reboot-required; fi"
+```

--- a/podman.sysext/create.sh
+++ b/podman.sysext/create.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# vim: et ts=2 syn=bash
+#
+# Podman system extension.
+#
+# Ships statically linked podman binaries built by the
+# mgoltzsche/podman-static project. The release tarballs bundle
+# podman together with conmon, crun, runc, fuse-overlayfs,
+# slirp4netns, netavark, aardvark-dns and CNI plugins so the
+# sysext is self-contained.
+#
+
+RELOAD_SERVICES_ON_MERGE="true"
+
+function list_available_versions() {
+  list_github_releases "mgoltzsche" "podman-static"
+}
+# --
+
+function populate_sysext_root() {
+  local sysextroot="$1"
+  local arch="$2"
+  local version="$3"
+
+  local rel_arch="$(arch_transform 'x86-64' 'amd64' "$arch")"
+
+  local tarball="podman-linux-${rel_arch}.tar.gz"
+  curl --remote-name -fsSL \
+    "https://github.com/mgoltzsche/podman-static/releases/download/${version}/${tarball}"
+
+  tar --force-local -xf "${tarball}"
+
+  # The release tarball extracts to ./podman-linux-<arch>/{etc,usr}.
+  # Move /usr contents into the sysext root; we ignore /etc since
+  # extensions must not ship /etc files.
+  local extracted="podman-linux-${rel_arch}"
+
+  mkdir -p "${sysextroot}/usr"
+  cp -aR "${extracted}/usr/." "${sysextroot}/usr/"
+
+  # /usr/sbin is a symlink to /usr/bin on Flatcar. Merge any sbin
+  # contents into /usr/bin so we don't clobber the symlink.
+  if [[ -d "${sysextroot}/usr/sbin" ]] ; then
+    cp -aR "${sysextroot}/usr/sbin/." "${sysextroot}/usr/bin/"
+    rm -rf "${sysextroot}/usr/sbin"
+  fi
+
+  # The release tarball ships binaries under /usr/local. Flatcar
+  # mounts /usr read-only and conventionally uses /usr/bin and
+  # /usr/libexec, so flatten the /usr/local tree into /usr.
+  if [[ -d "${sysextroot}/usr/local" ]] ; then
+    cp -aR "${sysextroot}/usr/local/." "${sysextroot}/usr/"
+    rm -rf "${sysextroot}/usr/local"
+  fi
+}
+# --

--- a/podman.sysext/files/usr/lib/systemd/system/podman.service
+++ b/podman.sysext/files/usr/lib/systemd/system/podman.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Podman API Service
+Requires=podman.socket
+After=podman.socket
+Documentation=man:podman-system-service(1)
+StartLimitIntervalSec=0
+
+[Service]
+Type=exec
+KillMode=process
+Environment=LOGGING="--log-level=info"
+ExecStart=/usr/bin/podman $LOGGING system service
+
+[Install]
+WantedBy=default.target

--- a/podman.sysext/files/usr/lib/systemd/system/podman.socket
+++ b/podman.sysext/files/usr/lib/systemd/system/podman.socket
@@ -1,0 +1,10 @@
+[Unit]
+Description=Podman API Socket
+Documentation=man:podman-system-service(1)
+
+[Socket]
+ListenStream=%t/podman/podman.sock
+SocketMode=0660
+
+[Install]
+WantedBy=sockets.target

--- a/podman.sysext/files/usr/lib/systemd/system/sockets.target.d/10-podman-socket.conf
+++ b/podman.sysext/files/usr/lib/systemd/system/sockets.target.d/10-podman-socket.conf
@@ -1,0 +1,2 @@
+[Unit]
+Upholds=podman.socket

--- a/release_build_versions.txt
+++ b/release_build_versions.txt
@@ -70,6 +70,8 @@ nvidia-runtime latest
 
 ollama latest
 
+podman latest
+
 rke2 v1.32.2+rke2r1
 rke2 latest
 


### PR DESCRIPTION
## Summary

- Adds a new `podman.sysext` shipping statically-linked podman binaries from the [mgoltzsche/podman-static](https://github.com/mgoltzsche/podman-static) project. Each release tarball bundles podman together with conmon, crun, runc, fuse-overlayfs, slirp4netns, netavark, aardvark-dns and CNI plugins, so the sysext is self-contained and works on a stock Flatcar OS image.
- Ships a socket-activated `podman.service` exposing the rootful Podman REST API at `/run/podman/podman.sock`, with a `sockets.target` drop-in that activates the socket on merge.
- Wires the new sysext into the release pipeline (`release_build_versions.txt`) and adds usage documentation (`docs/podman.md`).

Source: https://github.com/mgoltzsche/podman-static — the project tracks upstream podman releases and produces signed multi-arch (`amd64`, `arm64`) static tarballs.

## Test plan

- [ ] `./bakery.sh list podman` lists upstream versions
- [ ] `./bakery.sh create podman <version>` produces a working `podman.raw` for x86-64 and arm64
- [ ] `./bakery.sh boot podman` boots a Flatcar VM with the extension and `podman run hello-world` succeeds
- [ ] `systemctl status podman.socket` shows the socket activated after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)