### PR TITLE
cloud-hypervisor: add system extension

### DIFF
--- a/cloud-hypervisor.sysext/create.sh
+++ b/cloud-hypervisor.sysext/create.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# vim: et ts=2 syn=bash
+#
+# Cloud Hypervisor system extension.
+#
+# Ships the upstream statically linked cloud-hypervisor VMM and
+# its ch-remote control tool.
+#
+
+RELOAD_SERVICES_ON_MERGE="false"
+
+function list_available_versions() {
+  list_github_releases "cloud-hypervisor" "cloud-hypervisor"
+}
+# --
+
+function populate_sysext_root() {
+  local sysextroot="$1"
+  local arch="$2"
+  local version="$3"
+
+  # Upstream publishes one static binary per architecture, suffixed
+  # with -aarch64 for arm64 and unsuffixed for x86-64.
+  local suffix=""
+  case "${arch}" in
+    arm64) suffix="-aarch64" ;;
+  esac
+
+  local base_url="https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/${version}"
+
+  curl --remote-name -fsSL "${base_url}/cloud-hypervisor-static${suffix}"
+  curl --remote-name -fsSL "${base_url}/ch-remote-static${suffix}"
+
+  mkdir -p "${sysextroot}/usr/bin"
+  install -m 0755 "cloud-hypervisor-static${suffix}" \
+    "${sysextroot}/usr/bin/cloud-hypervisor"
+  install -m 0755 "ch-remote-static${suffix}" \
+    "${sysextroot}/usr/bin/ch-remote"
+}
+# --

--- a/docs/cloud-hypervisor.md
+++ b/docs/cloud-hypervisor.md
@@ -1,0 +1,62 @@
+# Cloud Hypervisor sysext
+
+This sysext ships [Cloud Hypervisor](https://www.cloudhypervisor.org/), a
+Virtual Machine Monitor (VMM) optimised for running modern cloud workloads.
+
+The sysext installs the upstream statically-linked `cloud-hypervisor`
+binary to `/usr/bin/cloud-hypervisor` and the `ch-remote` control tool to
+`/usr/bin/ch-remote`. Cloud Hypervisor is typically invoked by a higher
+level orchestrator (for example Kata Containers or Firecracker-compatible
+tooling), so this sysext does not ship a service unit.
+
+## Usage
+
+Download and merge the sysext at provisioning time using the below butane
+snippet.
+
+The snippet includes automated updates via systemd-sysupdate.
+Sysupdate will stage updates and request a reboot by creating a flag file
+at `/run/reboot-required`.
+You can deactivate updates by changing `enabled: true` to `enabled: false`
+in `systemd-sysupdate.timer`.
+
+Note that the snippet is for the x86-64 version of cloud-hypervisor v44.0.
+
+Check out the metadata release at
+https://github.com/flatcar/sysext-bakery/releases/tag/cloud-hypervisor for
+a list of all versions available in the bakery.
+
+```yaml
+variant: flatcar
+version: 1.0.0
+
+storage:
+  files:
+    - path: /opt/extensions/cloud-hypervisor/cloud-hypervisor-v44.0-x86-64.raw
+      mode: 0644
+      contents:
+        source: https://extensions.flatcar.org/extensions/cloud-hypervisor-v44.0-x86-64.raw
+    - path: /etc/sysupdate.cloud-hypervisor.d/cloud-hypervisor.conf
+      contents:
+        source: https://extensions.flatcar.org/extensions/cloud-hypervisor.conf
+    - path: /etc/sysupdate.d/noop.conf
+      contents:
+        source: https://extensions.flatcar.org/extensions/noop.conf
+  links:
+    - target: /opt/extensions/cloud-hypervisor/cloud-hypervisor-v44.0-x86-64.raw
+      path: /etc/extensions/cloud-hypervisor.raw
+      hard: false
+systemd:
+  units:
+    - name: systemd-sysupdate.timer
+      enabled: true
+    - name: systemd-sysupdate.service
+      dropins:
+        - name: cloud-hypervisor.conf
+          contents: |
+            [Service]
+            ExecStartPre=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/cloud-hypervisor.raw > /tmp/cloud-hypervisor"
+            ExecStartPre=/usr/lib/systemd/systemd-sysupdate -C cloud-hypervisor update
+            ExecStartPost=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/cloud-hypervisor.raw > /tmp/cloud-hypervisor-new"
+            ExecStartPost=/usr/bin/sh -c "if ! cmp --silent /tmp/cloud-hypervisor /tmp/cloud-hypervisor-new; then touch /run/reboot-required; fi"
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -63,6 +63,7 @@ Check out documentation on specific extensions at the navigation menu on the lef
 | `bird`           |  released    | [bird versions](https://github.com/flatcar/sysext-bakery/releases/tag/bird) |
 | `chrony`         |  released    | [chrony versions](https://github.com/flatcar/sysext-bakery/releases/tag/chrony) |
 | `cilium`         |  released    | [cilium versions](https://github.com/flatcar/sysext-bakery/releases/tag/cilium) |
+| `cloud-hypervisor` |  released  | [cloud-hypervisor versions](https://github.com/flatcar/sysext-bakery/releases/tag/cloud-hypervisor) |
 | `consul`          |  released    | [consul versions](https://github.com/flatcar/sysext-bakery/releases/tag/consul) |
 | `containerd`     |  released    | [containerd versions](https://github.com/flatcar/sysext-bakery/releases/tag/containerd) |
 | `crio`           |  released    | [crio versions](https://github.com/flatcar/sysext-bakery/releases/tag/crio) |

--- a/release_build_versions.txt
+++ b/release_build_versions.txt
@@ -92,9 +92,11 @@ wasmtime v13.0.0 # Used in Flatcar wasm OS demo
 wasmtime v24.0.0 # Used in README.md. Update readme when version changes.
 wasmtime latest
 
-cilium v0.16.24 
+cilium v0.16.24
 cilium v0.18.2
 cilium latest
+
+cloud-hypervisor latest
 
 bird 3.1.2
 bird latest


### PR DESCRIPTION
## Summary

- Adds a new `cloud-hypervisor.sysext` shipping the upstream statically-linked [Cloud Hypervisor](https://www.cloudhypervisor.org/) VMM (`cloud-hypervisor`) and its control tool (`ch-remote`) from the official [cloud-hypervisor GitHub releases](https://github.com/cloud-hypervisor/cloud-hypervisor/releases).
- Cloud Hypervisor is typically invoked by a higher-level orchestrator (Kata Containers, Firecracker-compatible tooling, etc.), so this sysext does not ship a service unit.
- Wires the new sysext into the release pipeline (`release_build_versions.txt`) and adds usage documentation (`docs/cloud-hypervisor.md`).

## Test plan

- [ ] `./bakery.sh list cloud-hypervisor` lists upstream versions
- [ ] `./bakery.sh create cloud-hypervisor <version>` produces a working `cloud-hypervisor.raw` for x86-64 and arm64
- [ ] `./bakery.sh boot cloud-hypervisor` boots a Flatcar VM with the extension and `cloud-hypervisor --version` and `ch-remote --version` work

🤖 Generated with [Claude Code](https://claude.com/claude-code)