### PR TITLE
kata-containers: add system extension

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -73,6 +73,7 @@ Check out documentation on specific extensions at the navigation menu on the lef
 | `falco`          |  released    | [falco versions](https://github.com/flatcar/sysext-bakery/releases/tag/falco) |
 | `ig`             |  released    | [ig versions](https://github.com/flatcar/sysext-bakery/releases/tag/ig) |
 | `k3s`            |  released    | [k3s versions](https://github.com/flatcar/sysext-bakery/releases/tag/k3s) |
+| `kata-containers` |  released  | [kata-containers versions](https://github.com/flatcar/sysext-bakery/releases/tag/kata-containers) |
 | `keepalived`     |  released    | [keepalived versions](https://github.com/flatcar/sysext-bakery/releases/tag/keepalived) |
 | `kubernetes`     |  released    | [kubernetes versions](https://github.com/flatcar/sysext-bakery/releases/tag/kubernetes) |
 | `llamaedge`      |  released    | [llamaedge versions](https://github.com/flatcar/sysext-bakery/releases/tag/llamaedge) |

--- a/docs/kata-containers.md
+++ b/docs/kata-containers.md
@@ -14,9 +14,9 @@ in `/usr/bin` expose `kata-runtime`, `containerd-shim-kata-v2` and
 
 This sysext only ships the Kata binaries and assets. To run pods with
 Kata, your container runtime needs to be configured to use it. With
-containerd, that means adding a runtime stanza pointing at
-`containerd-shim-kata-v2`, for example via a drop-in to
-`/etc/containerd/config.toml`:
+containerd, that means adding a Kata runtime stanza to
+`/etc/containerd/config.toml`. containerd discovers `containerd-shim-kata-v2`
+on `$PATH` from the `runtime_type`:
 
 ```toml
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata]

--- a/docs/kata-containers.md
+++ b/docs/kata-containers.md
@@ -1,0 +1,74 @@
+# Kata Containers sysext
+
+This sysext ships [Kata Containers](https://katacontainers.io/), an OCI
+container runtime that runs each pod inside a lightweight virtual machine
+for hardware-enforced isolation.
+
+The sysext unpacks the upstream `kata-static` release tarball, which
+bundles the Kata runtime, agent, containerd shim, guest kernel, initrd
+and a hypervisor (QEMU and Cloud Hypervisor) under `/opt/kata`. Symlinks
+in `/usr/bin` expose `kata-runtime`, `containerd-shim-kata-v2` and
+`kata-collect-data.sh` on `$PATH` after the sysext is merged.
+
+## Usage
+
+This sysext only ships the Kata binaries and assets. To run pods with
+Kata, your container runtime needs to be configured to use it. With
+containerd, that means adding a runtime stanza pointing at
+`containerd-shim-kata-v2`, for example via a drop-in to
+`/etc/containerd/config.toml`:
+
+```toml
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata]
+  runtime_type = "io.containerd.kata.v2"
+```
+
+Download and merge the sysext at provisioning time using the below butane
+snippet.
+
+The snippet includes automated updates via systemd-sysupdate.
+Sysupdate will stage updates and request a reboot by creating a flag file
+at `/run/reboot-required`.
+You can deactivate updates by changing `enabled: true` to `enabled: false`
+in `systemd-sysupdate.timer`.
+
+Note that the snippet is for the x86-64 version of kata-containers 3.21.0.
+
+Check out the metadata release at
+https://github.com/flatcar/sysext-bakery/releases/tag/kata-containers for
+a list of all versions available in the bakery.
+
+```yaml
+variant: flatcar
+version: 1.0.0
+
+storage:
+  files:
+    - path: /opt/extensions/kata-containers/kata-containers-3.21.0-x86-64.raw
+      mode: 0644
+      contents:
+        source: https://extensions.flatcar.org/extensions/kata-containers-3.21.0-x86-64.raw
+    - path: /etc/sysupdate.kata-containers.d/kata-containers.conf
+      contents:
+        source: https://extensions.flatcar.org/extensions/kata-containers.conf
+    - path: /etc/sysupdate.d/noop.conf
+      contents:
+        source: https://extensions.flatcar.org/extensions/noop.conf
+  links:
+    - target: /opt/extensions/kata-containers/kata-containers-3.21.0-x86-64.raw
+      path: /etc/extensions/kata-containers.raw
+      hard: false
+systemd:
+  units:
+    - name: systemd-sysupdate.timer
+      enabled: true
+    - name: systemd-sysupdate.service
+      dropins:
+        - name: kata-containers.conf
+          contents: |
+            [Service]
+            ExecStartPre=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/kata-containers.raw > /tmp/kata-containers"
+            ExecStartPre=/usr/lib/systemd/systemd-sysupdate -C kata-containers update
+            ExecStartPost=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/kata-containers.raw > /tmp/kata-containers-new"
+            ExecStartPost=/usr/bin/sh -c "if ! cmp --silent /tmp/kata-containers /tmp/kata-containers-new; then touch /run/reboot-required; fi"
+```

--- a/docs/kata-containers.md
+++ b/docs/kata-containers.md
@@ -67,8 +67,8 @@ systemd:
         - name: kata-containers.conf
           contents: |
             [Service]
-            ExecStartPre=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/kata-containers.raw > /tmp/kata-containers"
+            ExecStartPre=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/kata-containers.raw > /run/kata-containers"
             ExecStartPre=/usr/lib/systemd/systemd-sysupdate -C kata-containers update
-            ExecStartPost=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/kata-containers.raw > /tmp/kata-containers-new"
-            ExecStartPost=/usr/bin/sh -c "if ! cmp --silent /tmp/kata-containers /tmp/kata-containers-new; then touch /run/reboot-required; fi"
+            ExecStartPost=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/kata-containers.raw > /run/kata-containers-new"
+            ExecStartPost=/usr/bin/sh -c "if ! cmp --silent /run/kata-containers /run/kata-containers-new; then touch /run/reboot-required; fi"
 ```

--- a/kata-containers.sysext/create.sh
+++ b/kata-containers.sysext/create.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# vim: et ts=2 syn=bash
+#
+# Kata Containers system extension.
+#
+# Ships the upstream "kata-static" release tarball, which bundles
+# the kata runtime, agent, shim, guest kernel, initrd and a hypervisor
+# (QEMU and/or Cloud Hypervisor) under /opt/kata.
+#
+
+RELOAD_SERVICES_ON_MERGE="true"
+
+function list_available_versions() {
+  list_github_releases "kata-containers" "kata-containers"
+}
+# --
+
+function populate_sysext_root() {
+  local sysextroot="$1"
+  local arch="$2"
+  local version="$3"
+
+  # Upstream artefact names use "amd64" / "arm64".
+  local rel_arch="$(arch_transform 'x86-64' 'amd64' "$arch")"
+
+  # Strip a leading "v" if present: kata tags are "3.21.0" not "v3.21.0".
+  local rel_version="${version#v}"
+
+  local tarball="kata-static-${rel_version}-${rel_arch}.tar.xz"
+  curl --remote-name -fsSL \
+    "https://github.com/kata-containers/kata-containers/releases/download/${rel_version}/${tarball}"
+
+  # The tarball expands to ./opt/kata/{bin,libexec,share,...}.
+  tar --force-local -xf "${tarball}"
+
+  mkdir -p "${sysextroot}/opt"
+  cp -aR opt/kata "${sysextroot}/opt/"
+
+  # Expose the user-facing binaries via /usr/bin so they're on $PATH
+  # after the sysext is merged. Use relative symlinks so they continue
+  # to work regardless of where the sysext is mounted.
+  mkdir -p "${sysextroot}/usr/bin"
+  local bin
+  for bin in kata-runtime kata-collect-data.sh containerd-shim-kata-v2 ; do
+    if [[ -e "${sysextroot}/opt/kata/bin/${bin}" ]] ; then
+      ln -sf "../../opt/kata/bin/${bin}" "${sysextroot}/usr/bin/${bin}"
+    fi
+  done
+}
+# --

--- a/kata-containers.sysext/create.sh
+++ b/kata-containers.sysext/create.sh
@@ -63,10 +63,16 @@ function populate_sysext_root() {
   # to work regardless of where the sysext is mounted.
   mkdir -p "${sysextroot}/usr/bin"
   local bin
-  for bin in kata-runtime kata-collect-data.sh containerd-shim-kata-v2 ; do
-    if [[ -e "${sysextroot}/opt/kata/bin/${bin}" ]] ; then
-      ln -sf "../../opt/kata/bin/${bin}" "${sysextroot}/usr/bin/${bin}"
+  for bin in kata-runtime containerd-shim-kata-v2 ; do
+    if [[ ! -e "${sysextroot}/opt/kata/bin/${bin}" ]] ; then
+      echo "ERROR: expected binary ${bin} missing from kata-static ${rel_version}." >&2
+      return 1
     fi
+    ln -sf "../../opt/kata/bin/${bin}" "${sysextroot}/usr/bin/${bin}"
   done
+  if [[ -e "${sysextroot}/opt/kata/bin/kata-collect-data.sh" ]] ; then
+    ln -sf "../../opt/kata/bin/kata-collect-data.sh" \
+      "${sysextroot}/usr/bin/kata-collect-data.sh"
+  fi
 }
 # --

--- a/kata-containers.sysext/create.sh
+++ b/kata-containers.sysext/create.sh
@@ -37,6 +37,21 @@ function populate_sysext_root() {
   curl --remote-name -fsSL \
     "https://github.com/kata-containers/kata-containers/releases/download/${rel_version}/${tarball}"
 
+  # Kata doesn't publish a separate checksum file, but recent releases
+  # carry a SHA-256 digest in the GitHub release asset metadata. Fetch
+  # and verify it; warn (don't fail) on older releases that pre-date the
+  # digest field.
+  local digest
+  digest="$(curl_api_wrapper \
+    "https://api.github.com/repos/kata-containers/kata-containers/releases/tags/${rel_version}" \
+    | jq -r --arg n "${tarball}" '.assets[] | select(.name == $n) | .digest // empty' \
+    | sed -n 's|^sha256:||p')"
+  if [[ -n "${digest}" ]] ; then
+    echo "${digest}  ${tarball}" | sha256sum -c -
+  else
+    echo "WARNING: upstream did not publish a SHA-256 digest for ${tarball}; skipping integrity check." >&2
+  fi
+
   # The tarball expands to ./opt/kata/{bin,libexec,share,...}.
   tar --force-local -xf "${tarball}"
 

--- a/kata-containers.sysext/create.sh
+++ b/kata-containers.sysext/create.sh
@@ -26,7 +26,14 @@ function populate_sysext_root() {
   # Strip a leading "v" if present: kata tags are "3.21.0" not "v3.21.0".
   local rel_version="${version#v}"
 
-  local tarball="kata-static-${rel_version}-${rel_arch}.tar.xz"
+  # Upstream switched the release tarball compression from xz to zstd
+  # starting with 3.21.0.
+  local sufx="tar.xz"
+  if semver_equals_or_higher "${rel_version}" "3.21.0" ; then
+    sufx="tar.zst"
+  fi
+
+  local tarball="kata-static-${rel_version}-${rel_arch}.${sufx}"
   curl --remote-name -fsSL \
     "https://github.com/kata-containers/kata-containers/releases/download/${rel_version}/${tarball}"
 

--- a/release_build_versions.txt
+++ b/release_build_versions.txt
@@ -48,6 +48,8 @@ ig latest
 k3s v1.32.2+k3s1
 k3s latest
 
+kata-containers latest
+
 keepalived v2.3.1
 keepalived latest
 


### PR DESCRIPTION
## Summary

- Adds a new `kata-containers.sysext` shipping [Kata Containers](https://katacontainers.io/), an OCI runtime that runs each pod inside a lightweight VM for hardware-enforced isolation.
- Unpacks the upstream `kata-static-<version>-<arch>.tar.xz` release tarball, which bundles the Kata runtime, agent, `containerd-shim-kata-v2`, guest kernel, initrd, and the QEMU and Cloud Hypervisor VMMs under `/opt/kata`.
- Symlinks `kata-runtime`, `containerd-shim-kata-v2` and `kata-collect-data.sh` into `/usr/bin` so they land on `$PATH` after merge. Users still need to register Kata as a runtime in their container runtime config (e.g. containerd's `config.toml`).
- Wires the new sysext into the release pipeline (`release_build_versions.txt`) and adds usage documentation (`docs/kata-containers.md`).

## Test plan

- [ ] `./bakery.sh list kata-containers` lists upstream versions
- [ ] `./bakery.sh create kata-containers <version>` produces a working `kata-containers.raw` for x86-64 and arm64
- [ ] `./bakery.sh boot kata-containers` boots a Flatcar VM with the extension and `kata-runtime --version` works
- [ ] Pod launched via `containerd` with the `kata` runtime starts in a Kata sandbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)