### PR TITLE
podman: add system extension built from source

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -81,6 +81,7 @@ Check out documentation on specific extensions at the navigation menu on the lef
 | `nvidia-runtime` |  released    | [nvidia-runtime versions](https://github.com/flatcar/sysext-bakery/releases/tag/nvidia-runtime) |
 | `ollama`         |  released    | [ollama versions](https://github.com/flatcar/sysext-bakery/releases/tag/ollama) |
 | `opkssh`         |  released    | [opkssh versions](https://github.com/flatcar/sysext-bakery/releases/tag/opkssh) |
+| `podman`         |  released    | [podman versions](https://github.com/flatcar/sysext-bakery/releases/tag/podman) |
 | `rke2`           |  released    | [rke2 versions](https://github.com/flatcar/sysext-bakery/releases/tag/rke2) |
 | `scx`            |  released    | [scx versions](https://github.com/flatcar/sysext-bakery/releases/tag/scx) |
 | `tailscale`      |  released    | [tailscale versions](https://github.com/flatcar/sysext-bakery/releases/tag/tailscale) |

--- a/docs/podman.md
+++ b/docs/podman.md
@@ -1,0 +1,87 @@
+# Podman sysext
+
+This sysext ships [podman](https://podman.io/), a daemonless container engine
+for developing, managing, and running OCI containers on Linux.
+
+The sysext is built entirely from upstream source inside an ephemeral
+Alpine container. Each release statically links the following components
+against musl libc so the sysext is self-contained:
+
+- `podman`, `podman-remote`, `rootlessport`, `quadlet`
+  ([containers/podman](https://github.com/containers/podman))
+- `conmon` ([containers/conmon](https://github.com/containers/conmon))
+- `crun` ([containers/crun](https://github.com/containers/crun))
+- `runc` ([opencontainers/runc](https://github.com/opencontainers/runc))
+- `netavark`, `aardvark-dns`
+  ([containers/netavark](https://github.com/containers/netavark),
+  [containers/aardvark-dns](https://github.com/containers/aardvark-dns))
+- `slirp4netns`
+  ([rootless-containers/slirp4netns](https://github.com/rootless-containers/slirp4netns))
+- `fuse-overlayfs`
+  ([containers/fuse-overlayfs](https://github.com/containers/fuse-overlayfs))
+
+Helper binaries land in `/usr/libexec/podman/` and a default
+`/usr/share/containers/containers.conf` points podman at them and selects
+`netavark` as the network backend.
+
+The sysext ships a socket-activated `podman.service` to expose the rootful
+Podman REST API at `/run/podman/podman.sock`. The socket is enabled on
+merge via a `sockets.target` drop-in.
+
+## Building
+
+`./bakery.sh create podman <version>` builds the sysext. The companion
+binary versions can be overridden via build flags — see
+`./bakery.sh create podman help` for the full list.
+
+## Usage
+
+Download and merge the sysext at provisioning time using the below butane
+snippet.
+
+The snippet includes automated updates via systemd-sysupdate.
+Sysupdate will stage updates and request a reboot by creating a flag file
+at `/run/reboot-required`.
+You can deactivate updates by changing `enabled: true` to `enabled: false`
+in `systemd-sysupdate.timer`.
+
+Note that the snippet is for the x86-64 version of podman v5.5.2.
+
+Check out the metadata release at
+https://github.com/flatcar/sysext-bakery/releases/tag/podman for a list of
+all versions available in the bakery.
+
+```yaml
+variant: flatcar
+version: 1.0.0
+
+storage:
+  files:
+    - path: /opt/extensions/podman/podman-v5.5.2-x86-64.raw
+      mode: 0644
+      contents:
+        source: https://extensions.flatcar.org/extensions/podman-v5.5.2-x86-64.raw
+    - path: /etc/sysupdate.podman.d/podman.conf
+      contents:
+        source: https://extensions.flatcar.org/extensions/podman.conf
+    - path: /etc/sysupdate.d/noop.conf
+      contents:
+        source: https://extensions.flatcar.org/extensions/noop.conf
+  links:
+    - target: /opt/extensions/podman/podman-v5.5.2-x86-64.raw
+      path: /etc/extensions/podman.raw
+      hard: false
+systemd:
+  units:
+    - name: systemd-sysupdate.timer
+      enabled: true
+    - name: systemd-sysupdate.service
+      dropins:
+        - name: podman.conf
+          contents: |
+            [Service]
+            ExecStartPre=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/podman.raw > /tmp/podman"
+            ExecStartPre=/usr/lib/systemd/systemd-sysupdate -C podman update
+            ExecStartPost=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/podman.raw > /tmp/podman-new"
+            ExecStartPost=/usr/bin/sh -c "if ! cmp --silent /tmp/podman /tmp/podman-new; then touch /run/reboot-required; fi"
+```

--- a/podman.sysext/build.sh
+++ b/podman.sysext/build.sh
@@ -1,0 +1,194 @@
+#!/bin/ash
+#
+# Build script helper for the podman sysext.
+# Runs inside an ephemeral Alpine container, builds podman and the
+# companion binaries it depends on statically against musl, and exports
+# everything to a bind-mounted volume at /install_root.
+#
+set -euo pipefail
+
+podman_version="$1"
+conmon_version="$2"
+crun_version="$3"
+runc_version="$4"
+netavark_version="$5"
+aardvark_version="$6"
+slirp4netns_version="$7"
+fuse_overlayfs_version="$8"
+export_user_group="$9"
+
+apk add --no-cache \
+  autoconf \
+  automake \
+  bash \
+  binutils \
+  bsd-compat-headers \
+  build-base \
+  cargo \
+  ca-certificates \
+  curl \
+  git \
+  glib-dev \
+  glib-static \
+  go \
+  gpgme-dev \
+  libassuan-dev \
+  libassuan-static \
+  libcap-dev \
+  libcap-static \
+  libgpg-error-dev \
+  libgpg-error-static \
+  libseccomp-dev \
+  libseccomp-static \
+  libslirp-dev \
+  libslirp-static \
+  libtool \
+  linux-headers \
+  m4 \
+  make \
+  meson \
+  ninja \
+  pcre2-dev \
+  pkgconf \
+  python3 \
+  rust \
+  util-linux-dev \
+  yajl-dev \
+  yajl-static \
+  zlib-dev \
+  zlib-static
+
+install_root=/install_root
+mkdir -p "${install_root}/usr/bin" "${install_root}/usr/libexec/podman"
+build_dir=/build
+mkdir -p "${build_dir}"
+cd "${build_dir}"
+
+# Rust static linking: target current host triple.
+rust_target="$(rustc -vV | sed -n 's/^host: //p')"
+rust_target_env="$(echo "${rust_target}" | tr 'a-z-' 'A-Z_')"
+export CARGO_BUILD_TARGET="${rust_target}"
+export CARGO_TARGET_${rust_target_env}_RUSTFLAGS="-C target-feature=+crt-static"
+
+# ---- conmon ---------------------------------------------------------------
+echo ">>> Building conmon ${conmon_version}"
+git clone --depth 1 --branch "${conmon_version}" \
+  https://github.com/containers/conmon.git
+( cd conmon
+  make CFLAGS='-std=c99 -static' LDFLAGS='-static' bin/conmon
+  install -m 0755 bin/conmon "${install_root}/usr/libexec/podman/conmon"
+)
+
+# ---- crun -----------------------------------------------------------------
+echo ">>> Building crun ${crun_version}"
+git clone --depth 1 --branch "${crun_version}" \
+  https://github.com/containers/crun.git
+( cd crun
+  ./autogen.sh
+  ./configure --disable-shared --enable-static --disable-systemd
+  make LDFLAGS='-all-static'
+  install -m 0755 crun "${install_root}/usr/bin/crun"
+)
+
+# ---- runc -----------------------------------------------------------------
+echo ">>> Building runc ${runc_version}"
+git clone --depth 1 --branch "${runc_version}" \
+  https://github.com/opencontainers/runc.git
+( cd runc
+  make static BUILDTAGS='seccomp'
+  install -m 0755 runc "${install_root}/usr/bin/runc"
+)
+
+# ---- netavark -------------------------------------------------------------
+echo ">>> Building netavark ${netavark_version}"
+git clone --depth 1 --branch "${netavark_version}" \
+  https://github.com/containers/netavark.git
+( cd netavark
+  cargo build --release
+  install -m 0755 "target/${rust_target}/release/netavark" \
+    "${install_root}/usr/libexec/podman/netavark"
+)
+
+# ---- aardvark-dns ---------------------------------------------------------
+echo ">>> Building aardvark-dns ${aardvark_version}"
+git clone --depth 1 --branch "${aardvark_version}" \
+  https://github.com/containers/aardvark-dns.git
+( cd aardvark-dns
+  cargo build --release
+  install -m 0755 "target/${rust_target}/release/aardvark-dns" \
+    "${install_root}/usr/libexec/podman/aardvark-dns"
+)
+
+# ---- slirp4netns ----------------------------------------------------------
+echo ">>> Building slirp4netns ${slirp4netns_version}"
+git clone --depth 1 --branch "${slirp4netns_version}" \
+  https://github.com/rootless-containers/slirp4netns.git
+( cd slirp4netns
+  ./autogen.sh
+  LDFLAGS='-static' ./configure
+  make
+  install -m 0755 slirp4netns "${install_root}/usr/bin/slirp4netns"
+)
+
+# ---- fuse-overlayfs -------------------------------------------------------
+# fuse-overlayfs needs libfuse3 with static libs. Alpine does not ship a
+# fuse3-static package, so build libfuse from source first.
+echo ">>> Building libfuse for fuse-overlayfs"
+git clone --depth 1 --branch fuse-3.16.2 \
+  https://github.com/libfuse/libfuse.git
+( cd libfuse
+  mkdir build && cd build
+  meson setup --default-library=static --prefix=/usr \
+    -Dexamples=false -Dtests=false -Dutils=false ..
+  ninja
+  ninja install
+)
+
+echo ">>> Building fuse-overlayfs ${fuse_overlayfs_version}"
+git clone --depth 1 --branch "${fuse_overlayfs_version}" \
+  https://github.com/containers/fuse-overlayfs.git
+( cd fuse-overlayfs
+  ./autogen.sh
+  LIBS='-lpthread' LDFLAGS='-static' ./configure
+  make
+  install -m 0755 fuse-overlayfs "${install_root}/usr/bin/fuse-overlayfs"
+)
+
+# ---- podman ---------------------------------------------------------------
+echo ">>> Building podman ${podman_version}"
+git clone --depth 1 --branch "${podman_version}" \
+  https://github.com/containers/podman.git
+( cd podman
+  # Build statically. We exclude graphdrivers that need device-mapper or
+  # btrfs userspace libraries and disable libsubid since musl does not
+  # ship the shadow-utils subid C API. SELinux is also excluded because
+  # Alpine does not provide libselinux.
+  make BUILDTAGS='seccomp systemd exclude_graphdriver_devicemapper exclude_graphdriver_btrfs remote' \
+       EXTRA_LDFLAGS='-linkmode external -extldflags "-static"' \
+       CGO_ENABLED=1 \
+       bin/podman bin/podman-remote bin/rootlessport bin/quadlet
+
+  install -m 0755 bin/podman "${install_root}/usr/bin/podman"
+  install -m 0755 bin/podman-remote "${install_root}/usr/bin/podman-remote"
+  install -m 0755 bin/rootlessport "${install_root}/usr/libexec/podman/rootlessport"
+  install -m 0755 bin/quadlet "${install_root}/usr/libexec/podman/quadlet"
+)
+
+# ---- containers.conf and friends -----------------------------------------
+# Ship default helper-binary directories that point at our /usr/libexec
+# locations so podman finds conmon, netavark, aardvark-dns and the
+# rootlessport / quadlet helpers without further configuration.
+mkdir -p "${install_root}/usr/share/containers"
+cat >"${install_root}/usr/share/containers/containers.conf" <<'EOF'
+[engine]
+helper_binaries_dir = ["/usr/libexec/podman"]
+
+[network]
+network_backend = "netavark"
+
+[containers]
+init_path = "/usr/libexec/podman/catatonit"
+EOF
+
+chown -R "${export_user_group}" "${install_root}"
+chmod -R u+rwX,go+rX "${install_root}"

--- a/podman.sysext/create.sh
+++ b/podman.sysext/create.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# vim: et ts=2 syn=bash
+#
+# Podman system extension.
+#
+# Builds podman and its required companion binaries (conmon, crun,
+# runc, netavark, aardvark-dns, slirp4netns, fuse-overlayfs) from
+# source inside an ephemeral Alpine container. All binaries are
+# statically linked against musl so the sysext is self-contained.
+#
+
+RELOAD_SERVICES_ON_MERGE="true"
+
+function list_available_versions() {
+  list_github_releases "containers" "podman"
+}
+# --
+
+function populate_sysext_root_options() {
+  echo "  --conmon <version>         : conmon version to bundle (default: v2.1.13)."
+  echo "  --crun <version>           : crun version to bundle (default: 1.21)."
+  echo "  --runc <version>           : runc version to bundle (default: v1.2.6)."
+  echo "  --netavark <version>       : netavark version to bundle (default: v1.14.1)."
+  echo "  --aardvark-dns <version>   : aardvark-dns version to bundle (default: v1.14.0)."
+  echo "  --slirp4netns <version>    : slirp4netns version to bundle (default: v1.3.3)."
+  echo "  --fuse-overlayfs <version> : fuse-overlayfs version to bundle (default: v1.14)."
+}
+# --
+
+function populate_sysext_root() {
+  local sysextroot="$1"
+  local arch="$2"
+  local version="$3"
+
+  local conmon_version="$(get_optional_param "conmon" "v2.1.13" "$@")"
+  local crun_version="$(get_optional_param "crun" "1.21" "$@")"
+  local runc_version="$(get_optional_param "runc" "v1.2.6" "$@")"
+  local netavark_version="$(get_optional_param "netavark" "v1.14.1" "$@")"
+  local aardvark_version="$(get_optional_param "aardvark-dns" "v1.14.0" "$@")"
+  local slirp4netns_version="$(get_optional_param "slirp4netns" "v1.3.3" "$@")"
+  local fuse_overlayfs_version="$(get_optional_param "fuse-overlayfs" "v1.14" "$@")"
+
+  local img_arch="$(arch_transform 'x86-64' 'amd64' "$arch")"
+  img_arch="$(arch_transform 'arm64' 'arm64/v8' "$img_arch")"
+
+  local image="docker.io/alpine:3.21"
+
+  announce "Building podman ${version} for ${arch}"
+
+  local user_group="$(id -u):$(id -g)"
+
+  cp "${scriptroot}/podman.sysext/build.sh" .
+
+  docker run --rm \
+    -i \
+    -v "$(pwd)":/install_root \
+    --platform "linux/${img_arch}" \
+    --pull always \
+    "${image}" \
+    /install_root/build.sh \
+      "${version}" \
+      "${conmon_version}" \
+      "${crun_version}" \
+      "${runc_version}" \
+      "${netavark_version}" \
+      "${aardvark_version}" \
+      "${slirp4netns_version}" \
+      "${fuse_overlayfs_version}" \
+      "${user_group}"
+
+  cp -aR usr "${sysextroot}/"
+}
+# --

--- a/podman.sysext/files/usr/lib/systemd/system/podman.service
+++ b/podman.sysext/files/usr/lib/systemd/system/podman.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Podman API Service
+Requires=podman.socket
+After=podman.socket
+Documentation=man:podman-system-service(1)
+StartLimitIntervalSec=0
+
+[Service]
+Type=exec
+KillMode=process
+Environment=LOGGING="--log-level=info"
+ExecStart=/usr/bin/podman $LOGGING system service
+
+[Install]
+WantedBy=default.target

--- a/podman.sysext/files/usr/lib/systemd/system/podman.socket
+++ b/podman.sysext/files/usr/lib/systemd/system/podman.socket
@@ -1,0 +1,10 @@
+[Unit]
+Description=Podman API Socket
+Documentation=man:podman-system-service(1)
+
+[Socket]
+ListenStream=%t/podman/podman.sock
+SocketMode=0660
+
+[Install]
+WantedBy=sockets.target

--- a/podman.sysext/files/usr/lib/systemd/system/sockets.target.d/10-podman-socket.conf
+++ b/podman.sysext/files/usr/lib/systemd/system/sockets.target.d/10-podman-socket.conf
@@ -1,0 +1,2 @@
+[Unit]
+Upholds=podman.socket

--- a/release_build_versions.txt
+++ b/release_build_versions.txt
@@ -70,6 +70,8 @@ nvidia-runtime latest
 
 ollama latest
 
+podman latest
+
 rke2 v1.32.2+rke2r1
 rke2 latest
 


### PR DESCRIPTION
## Summary

Replaces the closed #219, which used a third-party static-binary release. This PR builds podman and all of its runtime dependencies from upstream source inside an ephemeral Alpine container — same pattern as the `keepalived` and `scx` sysexts — and statically links everything against musl libc so the sysext is self-contained.

Components built from source:

- `podman`, `podman-remote`, `rootlessport`, `quadlet` ([containers/podman](https://github.com/containers/podman))
- `conmon` ([containers/conmon](https://github.com/containers/conmon))
- `crun` ([containers/crun](https://github.com/containers/crun))
- `runc` ([opencontainers/runc](https://github.com/opencontainers/runc))
- `netavark`, `aardvark-dns` ([containers/netavark](https://github.com/containers/netavark), [containers/aardvark-dns](https://github.com/containers/aardvark-dns))
- `slirp4netns` ([rootless-containers/slirp4netns](https://github.com/rootless-containers/slirp4netns))
- `fuse-overlayfs` ([containers/fuse-overlayfs](https://github.com/containers/fuse-overlayfs)) — `libfuse` is also built from source since Alpine does not ship a static `fuse3` package.

Helper binaries land under `/usr/libexec/podman/`. A default `/usr/share/containers/containers.conf` points podman at them and selects `netavark` as the network backend. Companion versions are pinned in `create.sh` and overridable via build flags (see `./bakery.sh create podman help`).

Ships a socket-activated `podman.service` exposing the rootful Podman REST API at `/run/podman/podman.sock`, with a `sockets.target` drop-in activating the socket on merge.

## Test plan

- [ ] `./bakery.sh list podman` lists upstream versions
- [ ] `./bakery.sh create podman <version>` produces a working `podman.raw` for x86-64 and arm64
- [ ] `./bakery.sh boot podman` boots a Flatcar VM with the extension and `podman run hello-world` succeeds
- [ ] `systemctl status podman.socket` shows the socket activated after merge
- [ ] All bundled binaries are statically linked (`ldd /usr/bin/podman` reports \"not a dynamic executable\")

🤖 Generated with [Claude Code](https://claude.com/claude-code)