### PR TITLE
release: add containerd v2.1.9 and v2.2.5

### DIFF
--- a/release_build_versions.txt
+++ b/release_build_versions.txt
@@ -23,6 +23,8 @@ chrony latest
 consul 1.21.4
 consul latest
 
+containerd 2.2.5
+containerd 2.1.9
 containerd 2.0.0
 containerd 1.7.29
 containerd latest


### PR DESCRIPTION
Add containerd v2.1.9 and v2.2.5

These containerd versions provide fixes for current vulnerability https://github.com/flatcar/Flatcar/issues/2182


