### PR TITLE
containerd: list all latest releases

### DIFF
--- a/containerd.sysext/create.sh
+++ b/containerd.sysext/create.sh
@@ -14,6 +14,31 @@ function list_available_versions() {
 }
 # --
 
+# Containerd supports multiple minor release branches in parallel, so we return
+# the latest patch level releases of the latest 5 minor release series.
+# The "5" is chosen arbitrarily and reflects the active release branches
+# at the time of writing (2026-06-23).
+function list_latest_release() {
+  local active_branches_count="5"
+  local rel_cache active_release_branches
+
+  rel_cache="$(mktemp)"
+  trap "rm -f '${rel_cache}'" EXIT
+
+  list_available_versions "${@}" > "${rel_cache}"
+  # Note this escapes the '.' between major and minor so we can safely use it with
+  # 'grep -E' below.
+  active_release_branches="$(sed 's/\([0-9]\+\)\.\([0-9]\+\)\..*/\1\\.\2/' "${rel_cache}" \
+                             | sort -rV \
+                             | uniq \
+                             | head -n "${active_branches_count}")"
+  local b
+  for b in ${active_release_branches}; do
+    grep -E "^${b}\." "${rel_cache}" | sort -rV | head -n 1
+  done
+}
+# --
+
 function populate_sysext_root() {
   local sysextroot="$1"
   local arch="$2"


### PR DESCRIPTION
Containerd releases patch level updates for multiple minor releases - at the time of writing, for 1.7, 2.0, 2.1, 2.2, and 2.3. See https://github.com/containerd/containerd/blob/main/RELEASES.md#current-state-of-containerd-releases for more information. The containerd sysext automation however only lists the latest release of the latest major / minor, leading to all lower version active release beanches not being built.

This change lists the latest releases of the 5 most recent minor versions to mitigate the issue.
