### PR TITLE
coder, haproxy: add system extensions

### DIFF
--- a/coder.sysext/create.sh
+++ b/coder.sysext/create.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# vim: et ts=2 syn=bash
+#
+# Coder system extension.
+#
+# Ships the upstream "coder" Go binary from the linux release tarball.
+#
+
+RELOAD_SERVICES_ON_MERGE="true"
+
+function list_available_versions() {
+  list_github_releases "coder" "coder"
+}
+# --
+
+function populate_sysext_root() {
+  local sysextroot="$1"
+  local arch="$2"
+  local version="$3"
+
+  # Upstream artefact names use "amd64" / "arm64".
+  local rel_arch="$(arch_transform 'x86-64' 'amd64' "$arch")"
+
+  # Coder tarballs are named with the version sans leading "v".
+  local rel_version="${version#v}"
+
+  local tarball="coder_${rel_version}_linux_${rel_arch}.tar.gz"
+  local base_url="https://github.com/coder/coder/releases/download/${version}"
+
+  curl --parallel --fail --silent --show-error --location \
+    --remote-name "${base_url}/${tarball}" \
+    --remote-name "${base_url}/coder_${rel_version}_checksums.txt"
+
+  grep -F "${tarball}" "coder_${rel_version}_checksums.txt" | sha256sum -c -
+
+  mkdir -p "${sysextroot}/usr/bin"
+  tar --force-local -xf "${tarball}" ./coder
+  install -m 0755 coder "${sysextroot}/usr/bin/coder"
+}
+# --

--- a/coder.sysext/files/usr/lib/systemd/system/coder-workspace-proxy.service
+++ b/coder.sysext/files/usr/lib/systemd/system/coder-workspace-proxy.service
@@ -1,0 +1,31 @@
+[Unit]
+Description="Coder - external workspace proxy server"
+Documentation=https://coder.com/docs
+Requires=network-online.target
+After=network-online.target
+ConditionFileNotEmpty=/etc/coder.d/coder-workspace-proxy.env
+StartLimitIntervalSec=60
+StartLimitBurst=3
+
+[Service]
+Type=notify
+EnvironmentFile=/etc/coder.d/coder-workspace-proxy.env
+User=coder
+Group=coder
+ProtectSystem=full
+PrivateTmp=yes
+PrivateDevices=yes
+SecureBits=keep-caps
+AmbientCapabilities=CAP_IPC_LOCK CAP_NET_BIND_SERVICE
+CacheDirectory=coder
+CapabilityBoundingSet=CAP_SYSLOG CAP_IPC_LOCK CAP_NET_BIND_SERVICE
+KillSignal=SIGINT
+KillMode=mixed
+NoNewPrivileges=yes
+ExecStart=/usr/bin/coder workspace-proxy server
+Restart=on-failure
+RestartSec=5
+TimeoutStopSec=90
+
+[Install]
+WantedBy=multi-user.target

--- a/coder.sysext/files/usr/lib/systemd/system/coder.service
+++ b/coder.sysext/files/usr/lib/systemd/system/coder.service
@@ -1,0 +1,31 @@
+[Unit]
+Description="Coder - Self-hosted developer workspaces on your infra"
+Documentation=https://coder.com/docs
+Requires=network-online.target
+After=network-online.target
+ConditionFileNotEmpty=/etc/coder.d/coder.env
+StartLimitIntervalSec=10
+StartLimitBurst=3
+
+[Service]
+Type=notify
+EnvironmentFile=/etc/coder.d/coder.env
+User=coder
+Group=coder
+ProtectSystem=full
+PrivateTmp=yes
+PrivateDevices=yes
+SecureBits=keep-caps
+AmbientCapabilities=CAP_IPC_LOCK CAP_NET_BIND_SERVICE
+CacheDirectory=coder
+CapabilityBoundingSet=CAP_SYSLOG CAP_IPC_LOCK CAP_NET_BIND_SERVICE
+KillSignal=SIGINT
+KillMode=mixed
+NoNewPrivileges=yes
+ExecStart=/usr/bin/coder server
+Restart=on-failure
+RestartSec=5
+TimeoutStopSec=90
+
+[Install]
+WantedBy=multi-user.target

--- a/coder.sysext/files/usr/lib/sysusers.d/coder.conf
+++ b/coder.sysext/files/usr/lib/sysusers.d/coder.conf
@@ -1,0 +1,1 @@
+u coder - "Coder developer workspaces" /var/lib/coder /sbin/nologin

--- a/coder.sysext/files/usr/lib/tmpfiles.d/10-coder.conf
+++ b/coder.sysext/files/usr/lib/tmpfiles.d/10-coder.conf
@@ -1,0 +1,4 @@
+d /etc/coder.d 0755 root root - -
+C /etc/coder.d/coder.env - - - - /usr/share/coder/coder.env
+C /etc/coder.d/coder-workspace-proxy.env - - - - /usr/share/coder/coder-workspace-proxy.env
+d /var/lib/coder 0700 coder coder - -

--- a/coder.sysext/files/usr/share/coder/coder-workspace-proxy.env
+++ b/coder.sysext/files/usr/share/coder/coder-workspace-proxy.env
@@ -1,0 +1,15 @@
+# Required: workspace proxy session token (paired with the Coder server).
+CODER_PROXY_SESSION_TOKEN=
+
+# Required: URL of the Coder primary server the proxy registers with.
+CODER_PRIMARY_ACCESS_URL=
+
+# Optional: external URL the proxy is reachable at.
+CODER_ACCESS_URL=
+
+CODER_HTTP_ADDRESS=
+CODER_TLS_CERT_FILE=
+CODER_TLS_ENABLE=
+CODER_TLS_KEY_FILE=
+
+# Run "coder workspace-proxy server --help" for flag information.

--- a/coder.sysext/files/usr/share/coder/coder.env
+++ b/coder.sysext/files/usr/share/coder/coder.env
@@ -1,0 +1,11 @@
+# Coder must be reachable from an external URL for users and workspaces to connect.
+# e.g. https://coder.example.com
+CODER_ACCESS_URL=
+
+CODER_HTTP_ADDRESS=
+CODER_PG_CONNECTION_URL=
+CODER_TLS_CERT_FILE=
+CODER_TLS_ENABLE=
+CODER_TLS_KEY_FILE=
+
+# Run "coder server --help" for flag information.

--- a/docs/coder.md
+++ b/docs/coder.md
@@ -1,0 +1,77 @@
+# Coder sysext
+
+This sysext ships [Coder](https://coder.com/), an open-source platform
+for self-hosted developer workspaces.
+
+The sysext installs:
+
+- `coder` Go binary at `/usr/bin/coder`
+- `coder.service` and `coder-workspace-proxy.service` units, taken
+  unmodified from the upstream Coder Debian package
+- `sysusers.d` entry to create the `coder` system user the units run as
+- `tmpfiles.d` entry that seeds `/etc/coder.d/coder.env` and
+  `/etc/coder.d/coder-workspace-proxy.env` on first boot
+
+At a minimum, set `CODER_ACCESS_URL` and `CODER_PG_CONNECTION_URL` in
+`/etc/coder.d/coder.env` before enabling `coder.service`.
+
+## Usage
+
+Download and merge the sysext at provisioning time using the below butane
+snippet.
+
+The snippet includes automated updates via systemd-sysupdate.
+Sysupdate will stage updates and request a reboot by creating a flag file
+at `/run/reboot-required`.
+You can deactivate updates by changing `enabled: true` to `enabled: false`
+in `systemd-sysupdate.timer`.
+
+Note that the snippet is for the x86-64 version of Coder v2.34.4.
+
+Check out the metadata release at
+https://github.com/flatcar/sysext-bakery/releases/tag/coder for a list of
+all versions available in the bakery.
+
+```yaml
+variant: flatcar
+version: 1.0.0
+
+storage:
+  files:
+    - path: /opt/extensions/coder/coder-v2.34.4-x86-64.raw
+      mode: 0644
+      contents:
+        source: https://extensions.flatcar.org/extensions/coder-v2.34.4-x86-64.raw
+    - path: /etc/sysupdate.coder.d/coder.conf
+      contents:
+        source: https://extensions.flatcar.org/extensions/coder.conf
+    - path: /etc/sysupdate.d/noop.conf
+      contents:
+        source: https://extensions.flatcar.org/extensions/noop.conf
+    - path: /etc/coder.d/coder.env
+      mode: 0644
+      contents:
+        inline: |
+          CODER_ACCESS_URL=https://coder.example.com
+          CODER_HTTP_ADDRESS=0.0.0.0:3000
+          CODER_PG_CONNECTION_URL=postgres://coder:coder@db.example.com/coder?sslmode=disable
+  links:
+    - target: /opt/extensions/coder/coder-v2.34.4-x86-64.raw
+      path: /etc/extensions/coder.raw
+      hard: false
+systemd:
+  units:
+    - name: coder.service
+      enabled: true
+    - name: systemd-sysupdate.timer
+      enabled: true
+    - name: systemd-sysupdate.service
+      dropins:
+        - name: coder.conf
+          contents: |
+            [Service]
+            ExecStartPre=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/coder.raw > /run/coder"
+            ExecStartPre=/usr/lib/systemd/systemd-sysupdate -C coder update
+            ExecStartPost=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/coder.raw > /run/coder-new"
+            ExecStartPost=/usr/bin/sh -c "if ! cmp --silent /run/coder /run/coder-new; then touch /run/reboot-required; fi"
+```

--- a/docs/haproxy.md
+++ b/docs/haproxy.md
@@ -1,0 +1,97 @@
+# HAProxy sysext
+
+This sysext ships [HAProxy](https://www.haproxy.org/), a reliable
+high-performance TCP/HTTP load balancer.
+
+The sysext is built from upstream source against the Alpine musl
+toolchain with OpenSSL, PCRE2 (JIT), zlib, threading and the Prometheus
+exporter enabled. The resulting statically linked `haproxy` binary lands
+at `/usr/bin/haproxy`. Alongside it the sysext ships:
+
+- `haproxy.service` based on the upstream
+  `admin/systemd/haproxy.service.in`, with sandboxing/`ProtectSystem`
+  options enabled
+- `sysusers.d` entry to create the `haproxy` system user the service
+  runs as
+- `tmpfiles.d` entry that seeds `/etc/haproxy/haproxy.cfg` from a
+  minimal default on first boot, exposing the stats page at
+  `127.0.0.1:8404`
+
+## Usage
+
+Download and merge the sysext at provisioning time using the below
+butane snippet.
+
+The snippet includes automated updates via systemd-sysupdate.
+Sysupdate will stage updates and request a reboot by creating a flag
+file at `/run/reboot-required`.
+You can deactivate updates by changing `enabled: true` to
+`enabled: false` in `systemd-sysupdate.timer`.
+
+Note that the snippet is for the x86-64 version of HAProxy 3.2.5.
+
+Check out the metadata release at
+https://github.com/flatcar/sysext-bakery/releases/tag/haproxy for a list
+of all versions available in the bakery.
+
+```yaml
+variant: flatcar
+version: 1.0.0
+
+storage:
+  files:
+    - path: /opt/extensions/haproxy/haproxy-3.2.5-x86-64.raw
+      mode: 0644
+      contents:
+        source: https://extensions.flatcar.org/extensions/haproxy-3.2.5-x86-64.raw
+    - path: /etc/sysupdate.haproxy.d/haproxy.conf
+      contents:
+        source: https://extensions.flatcar.org/extensions/haproxy.conf
+    - path: /etc/sysupdate.d/noop.conf
+      contents:
+        source: https://extensions.flatcar.org/extensions/noop.conf
+    - path: /etc/haproxy/haproxy.cfg
+      mode: 0644
+      contents:
+        inline: |
+          global
+              log         stdout format raw local0
+              chroot      /var/lib/haproxy
+              user        haproxy
+              group       haproxy
+              maxconn     4096
+
+          defaults
+              log     global
+              mode    http
+              option  httplog
+              timeout connect 5s
+              timeout client  50s
+              timeout server  50s
+
+          frontend http-in
+              bind *:80
+              default_backend servers
+
+          backend servers
+              server srv1 127.0.0.1:8080 check
+  links:
+    - target: /opt/extensions/haproxy/haproxy-3.2.5-x86-64.raw
+      path: /etc/extensions/haproxy.raw
+      hard: false
+systemd:
+  units:
+    - name: haproxy.service
+      enabled: true
+    - name: systemd-sysupdate.timer
+      enabled: true
+    - name: systemd-sysupdate.service
+      dropins:
+        - name: haproxy.conf
+          contents: |
+            [Service]
+            ExecStartPre=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/haproxy.raw > /run/haproxy-sysext"
+            ExecStartPre=/usr/lib/systemd/systemd-sysupdate -C haproxy update
+            ExecStartPost=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/haproxy.raw > /run/haproxy-sysext-new"
+            ExecStartPost=/usr/bin/sh -c "if ! cmp --silent /run/haproxy-sysext /run/haproxy-sysext-new; then touch /run/reboot-required; fi"
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -64,6 +64,7 @@ Check out documentation on specific extensions at the navigation menu on the lef
 | `chrony`         |  released    | [chrony versions](https://github.com/flatcar/sysext-bakery/releases/tag/chrony) |
 | `cilium`         |  released    | [cilium versions](https://github.com/flatcar/sysext-bakery/releases/tag/cilium) |
 | `cloud-hypervisor` |  released  | [cloud-hypervisor versions](https://github.com/flatcar/sysext-bakery/releases/tag/cloud-hypervisor) |
+| `coder`          |  released    | [coder versions](https://github.com/flatcar/sysext-bakery/releases/tag/coder) |
 | `consul`          |  released    | [consul versions](https://github.com/flatcar/sysext-bakery/releases/tag/consul) |
 | `containerd`     |  released    | [containerd versions](https://github.com/flatcar/sysext-bakery/releases/tag/containerd) |
 | `crio`           |  released    | [crio versions](https://github.com/flatcar/sysext-bakery/releases/tag/crio) |
@@ -71,6 +72,7 @@ Check out documentation on specific extensions at the navigation menu on the lef
 | `docker-compose` |  released    | [docker-compose versions](https://github.com/flatcar/sysext-bakery/releases/tag/docker-compose) |
 | `docker`         |  released    | [docker versions](https://github.com/flatcar/sysext-bakery/releases/tag/docker) |
 | `falco`          |  released    | [falco versions](https://github.com/flatcar/sysext-bakery/releases/tag/falco) |
+| `haproxy`        |  released    | [haproxy versions](https://github.com/flatcar/sysext-bakery/releases/tag/haproxy) |
 | `ig`             |  released    | [ig versions](https://github.com/flatcar/sysext-bakery/releases/tag/ig) |
 | `k3s`            |  released    | [k3s versions](https://github.com/flatcar/sysext-bakery/releases/tag/k3s) |
 | `keepalived`     |  released    | [keepalived versions](https://github.com/flatcar/sysext-bakery/releases/tag/keepalived) |

--- a/haproxy.sysext/build.sh
+++ b/haproxy.sysext/build.sh
@@ -1,0 +1,62 @@
+#!/bin/ash
+#
+# Build script helper for the haproxy sysext.
+# This script runs inside an ephemeral alpine container. It builds a
+# statically linked haproxy from the upstream source release at
+# https://www.haproxy.org/download/ and exports the binary to the
+# bind-mounted /install_root.
+#
+set -euo pipefail
+
+version="$1"
+export_user_group="$2"
+
+# Stable haproxy versions look like "3.2.5"; map to the upstream branch
+# directory (e.g. "3.2") under https://www.haproxy.org/download/.
+branch="$(echo "${version}" | awk -F. '{print $1"."$2}')"
+
+apk --no-cache add \
+  build-base \
+  curl \
+  linux-headers \
+  openssl-dev \
+  openssl-libs-static \
+  pcre2-dev \
+  zlib-dev \
+  zlib-static
+
+cd /opt
+curl -fsSLO "https://www.haproxy.org/download/${branch}/src/haproxy-${version}.tar.gz"
+curl -fsSLO "https://www.haproxy.org/download/${branch}/src/haproxy-${version}.tar.gz.sha256"
+sha256sum -c "haproxy-${version}.tar.gz.sha256"
+
+tar -xf "haproxy-${version}.tar.gz"
+cd "haproxy-${version}"
+
+# Build statically against musl. We deliberately omit Lua and the
+# bundled QuicTLS so the resulting binary works on any Flatcar host
+# without runtime dependencies.
+make -j"$(nproc)" \
+  TARGET=linux-musl \
+  USE_OPENSSL=1 \
+  USE_PCRE2=1 USE_PCRE2_JIT=1 USE_STATIC_PCRE2=1 \
+  USE_ZLIB=1 \
+  USE_THREAD=1 \
+  USE_TFO=1 \
+  USE_NS=1 \
+  USE_GETADDRINFO=1 \
+  USE_PROMEX=1 \
+  USE_LINUX_TPROXY=1 \
+  USE_LINUX_SPLICE=1 \
+  USE_LINUX_CAP=1 \
+  LDFLAGS="-static"
+
+make install-bin DESTDIR=/install_root PREFIX=/usr
+
+# Flatcar uses /usr/bin as the canonical bindir; haproxy installs to
+# /usr/sbin by default.
+mkdir -p /install_root/usr/bin
+mv /install_root/usr/sbin/haproxy /install_root/usr/bin/haproxy
+rmdir /install_root/usr/sbin
+
+chown -R "${export_user_group}" /install_root

--- a/haproxy.sysext/create.sh
+++ b/haproxy.sysext/create.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# vim: et ts=2 syn=bash
+#
+# HAProxy system extension.
+#
+# Builds a statically linked haproxy from upstream source against the
+# Alpine musl toolchain and ships it under /usr/bin/haproxy.
+#
+
+RELOAD_SERVICES_ON_MERGE="true"
+
+# Stable haproxy releases use plain "X.Y.Z" tags.
+EXTENSION_VERSION_MATCH_PATTERN='[0-9.]+'
+
+# HAProxy publishes one /download/<X.Y>/src/ directory per branch with a
+# releases.json index. Iterate every branch and collect stable releases
+# (skip "X.Y-devN", "X.Y-dev0", etc.) across all of them.
+function list_available_versions() {
+  local listing branches branch
+  listing="$(curl -fsSL --retry-delay 1 --retry 60 --retry-connrefused \
+    --retry-max-time 60 --connect-timeout 20 \
+    "https://www.haproxy.org/download/")"
+
+  branches="$(echo "${listing}" \
+    | grep -oE 'href="[0-9]+\.[0-9]+/"' \
+    | sed -E 's|href="||;s|/"||' \
+    | sort -uV)"
+
+  for branch in ${branches} ; do
+    curl -fsSL --retry-delay 1 --retry 60 --retry-connrefused \
+      --retry-max-time 60 --connect-timeout 20 \
+      "https://www.haproxy.org/download/${branch}/src/releases.json" \
+      | jq -r '.releases | keys[]' 2>/dev/null \
+      | grep -vE -- '-(dev|rc)' || true
+  done | sort -Vr
+}
+# --
+
+function populate_sysext_root() {
+  local sysextroot="$1"
+  local arch="$2"
+  local version="$3"
+
+  local img_arch
+  img_arch="$(arch_transform 'x86-64' 'amd64' "$arch")"
+  img_arch="$(arch_transform 'arm64' 'arm64/v8' "$img_arch")"
+
+  local image="docker.io/alpine:3.21"
+
+  announce "Building haproxy $version for $arch"
+
+  local user_group="$(id -u):$(id -g)"
+
+  cp "${scriptroot}/haproxy.sysext/build.sh" .
+  docker run --rm \
+    -i \
+    -v "$(pwd)":/install_root \
+    --platform "linux/${img_arch}" \
+    --pull always \
+    ${image} \
+        /install_root/build.sh "${version}" "$user_group"
+
+  cp -aR usr "${sysextroot}/"
+}
+# --

--- a/haproxy.sysext/files/usr/lib/systemd/system/haproxy.service
+++ b/haproxy.sysext/files/usr/lib/systemd/system/haproxy.service
@@ -1,0 +1,41 @@
+[Unit]
+Description=HAProxy Load Balancer
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+EnvironmentFile=-/etc/default/haproxy
+EnvironmentFile=-/etc/sysconfig/haproxy
+Environment="CONFIG=/etc/haproxy/haproxy.cfg" "PIDFILE=/run/haproxy.pid" "EXTRAOPTS=-S /run/haproxy-master.sock"
+ExecStart=/usr/bin/haproxy -Ws -f $CONFIG -p $PIDFILE $EXTRAOPTS
+ExecReload=/usr/bin/haproxy -Ws -f $CONFIG -c $EXTRAOPTS
+ExecReload=/bin/kill -USR2 $MAINPID
+KillMode=mixed
+Restart=always
+SuccessExitStatus=143
+Type=notify
+
+User=haproxy
+Group=haproxy
+RuntimeDirectory=haproxy
+RuntimeDirectoryMode=0755
+AmbientCapabilities=CAP_NET_BIND_SERVICE CAP_NET_ADMIN CAP_NET_RAW
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE CAP_NET_ADMIN CAP_NET_RAW
+NoNewPrivileges=true
+ProtectHome=true
+ProtectSystem=strict
+ReadWritePaths=/run
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6 AF_NETLINK
+RestrictNamespaces=true
+RestrictRealtime=true
+LockPersonality=true
+MemoryDenyWriteExecute=true
+SystemCallArchitectures=native
+SystemCallFilter=@system-service
+SystemCallFilter=~@cpu-emulation @keyring @module @obsolete @raw-io @reboot @swap @sync
+
+[Install]
+WantedBy=multi-user.target

--- a/haproxy.sysext/files/usr/lib/sysusers.d/haproxy.conf
+++ b/haproxy.sysext/files/usr/lib/sysusers.d/haproxy.conf
@@ -1,0 +1,1 @@
+u haproxy - "HAProxy load balancer" /var/lib/haproxy /sbin/nologin

--- a/haproxy.sysext/files/usr/lib/tmpfiles.d/10-haproxy.conf
+++ b/haproxy.sysext/files/usr/lib/tmpfiles.d/10-haproxy.conf
@@ -1,0 +1,3 @@
+d /etc/haproxy 0755 root root - -
+C /etc/haproxy/haproxy.cfg - - - - /usr/share/haproxy/haproxy.cfg
+d /var/lib/haproxy 0750 haproxy haproxy - -

--- a/haproxy.sysext/files/usr/share/haproxy/haproxy.cfg
+++ b/haproxy.sysext/files/usr/share/haproxy/haproxy.cfg
@@ -1,0 +1,29 @@
+#
+# Minimal HAProxy configuration shipped with the sysext.
+# Replace /etc/haproxy/haproxy.cfg to customise.
+#
+
+global
+    log         stdout format raw local0
+    chroot      /var/lib/haproxy
+    user        haproxy
+    group       haproxy
+    maxconn     4096
+    tune.ssl.default-dh-param 2048
+
+defaults
+    log                     global
+    mode                    http
+    option                  httplog
+    option                  dontlognull
+    option                  redispatch
+    retries                 3
+    timeout connect         5s
+    timeout client          50s
+    timeout server          50s
+
+frontend stats
+    bind 127.0.0.1:8404
+    stats enable
+    stats uri /
+    stats refresh 10s

--- a/release_build_versions.txt
+++ b/release_build_versions.txt
@@ -100,6 +100,10 @@ cilium latest
 
 cloud-hypervisor latest
 
+coder latest
+
+haproxy latest
+
 bird 3.1.2
 bird latest
 


### PR DESCRIPTION
## Summary

- Adds two new sysexts: `coder` and `haproxy`.
- **coder**: packages the upstream `coder_<v>_linux_<arch>.tar.gz` and ships `coder.service` / `coder-workspace-proxy.service` verbatim from the upstream Debian package. A `sysusers.d` entry creates the `coder` system user the units run as; `tmpfiles.d` seeds default env files into `/etc/coder.d/` on first boot. The tarball is verified against the per-release `coder_<v>_checksums.txt`.
- **haproxy**: builds a statically linked `haproxy` from upstream source inside Alpine with OpenSSL, PCRE2 (JIT), zlib, threads and the Prometheus exporter. Ships the upstream `admin/systemd/haproxy.service.in` with the documented sandboxing options enabled (`NoNewPrivileges`, `ProtectSystem=strict`, restricted capabilities/syscalls). `sysusers.d`/`tmpfiles.d` set up the `haproxy` user and a minimal default `/etc/haproxy/haproxy.cfg`.
- Wires both into `release_build_versions.txt` and the docs index, with usage docs at `docs/coder.md` and `docs/haproxy.md`.

## Test plan

- [ ] `./bakery.sh list coder` lists upstream `vX.Y.Z` releases
- [ ] `./bakery.sh list haproxy` lists upstream stable `X.Y.Z` releases (no `-devN`/`-rcN`)
- [ ] `./bakery.sh create coder vX.Y.Z` produces working `coder.raw` for x86-64 and arm64
- [ ] `./bakery.sh create haproxy X.Y.Z` produces working `haproxy.raw` for x86-64 and arm64 (static binary)
- [ ] `./bakery.sh boot coder` boots Flatcar, `coder --version` works, `coder.service` starts once `/etc/coder.d/coder.env` is populated
- [ ] `./bakery.sh boot haproxy` boots Flatcar, `haproxy -v` works, `haproxy.service` starts cleanly under the hardened sandbox with the seeded default config

🤖 Generated with [Claude Code](https://claude.com/claude-code)