### PR TITLE
dataplaneapi: add system extension

### DIFF
--- a/dataplaneapi.sysext/create.sh
+++ b/dataplaneapi.sysext/create.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# vim: et ts=2 syn=bash
+#
+# HAProxy Data Plane API system extension.
+#
+# Ships the upstream "dataplaneapi" Go binary from the linux release
+# tarball.
+#
+
+RELOAD_SERVICES_ON_MERGE="true"
+
+function list_available_versions() {
+  list_github_releases "haproxytech" "dataplaneapi"
+}
+# --
+
+function populate_sysext_root() {
+  local sysextroot="$1"
+  local arch="$2"
+  local version="$3"
+
+  # Upstream artefact names use "x86_64" / "arm64".
+  local rel_arch="$(arch_transform 'x86-64' 'x86_64' "$arch")"
+
+  # Tarballs are named with the version sans leading "v".
+  local rel_version="${version#v}"
+
+  local tarball="dataplaneapi_${rel_version}_linux_${rel_arch}.tar.gz"
+  local base_url="https://github.com/haproxytech/dataplaneapi/releases/download/${version}"
+
+  curl --parallel --fail --silent --show-error --location \
+    --remote-name "${base_url}/${tarball}" \
+    --remote-name "${base_url}/checksums.txt"
+
+  local expected
+  expected="$(awk -v t="${tarball}" \
+    '$2 == t || $2 == "*"t {print $1; exit}' \
+    checksums.txt)"
+  if [[ -z "${expected}" ]] ; then
+    echo "ERROR: ${tarball} not listed in upstream checksums file." >&2
+    return 1
+  fi
+  echo "${expected}  ${tarball}" | sha256sum -c -
+
+  mkdir -p "${sysextroot}/usr/bin" extract
+  tar --force-local -xf "${tarball}" -C extract
+  install -m 0755 "$(find extract -type f -name dataplaneapi -print -quit)" \
+    "${sysextroot}/usr/bin/dataplaneapi"
+}
+# --

--- a/dataplaneapi.sysext/create.sh
+++ b/dataplaneapi.sysext/create.sh
@@ -44,7 +44,12 @@ function populate_sysext_root() {
 
   mkdir -p "${sysextroot}/usr/bin" extract
   tar --force-local -xf "${tarball}" -C extract
-  install -m 0755 "$(find extract -type f -name dataplaneapi -print -quit)" \
-    "${sysextroot}/usr/bin/dataplaneapi"
+  local binary
+  binary="$(find extract -type f -name dataplaneapi -print -quit)"
+  if [[ -z "${binary}" ]] ; then
+    echo "ERROR: dataplaneapi binary not found in ${tarball}." >&2
+    return 1
+  fi
+  install -m 0755 "${binary}" "${sysextroot}/usr/bin/dataplaneapi"
 }
 # --

--- a/dataplaneapi.sysext/files/usr/lib/systemd/system/dataplaneapi.service
+++ b/dataplaneapi.sysext/files/usr/lib/systemd/system/dataplaneapi.service
@@ -1,0 +1,39 @@
+[Unit]
+Description=HAProxy Data Plane API
+Documentation=https://www.haproxy.com/documentation/dataplaneapi/
+After=network-online.target
+Wants=network-online.target
+After=haproxy.service
+
+[Service]
+Type=simple
+EnvironmentFile=-/etc/default/dataplaneapi
+EnvironmentFile=-/etc/sysconfig/dataplaneapi
+Environment="SYSD_OPTIONS=-f /etc/dataplaneapi/dataplaneapi.yml"
+ExecStart=/usr/bin/dataplaneapi $SYSD_OPTIONS
+ExecReload=/bin/kill -s SIGUSR1 $MAINPID
+Restart=on-failure
+RestartSec=5
+
+# Dataplane API needs to invoke `systemctl reload haproxy.service`
+# (reload_strategy: systemd in dataplaneapi.yml), so it runs as root.
+# Drop-ins can trim this if you switch to a socket-based reload
+# strategy and grant the coordinating user access to the HAProxy
+# master socket.
+User=root
+Group=root
+
+RuntimeDirectory=dataplaneapi
+StateDirectory=dataplaneapi
+NoNewPrivileges=true
+ProtectHome=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6 AF_NETLINK
+RestrictNamespaces=true
+RestrictRealtime=true
+LockPersonality=true
+
+[Install]
+WantedBy=multi-user.target

--- a/dataplaneapi.sysext/files/usr/lib/systemd/system/dataplaneapi.service
+++ b/dataplaneapi.sysext/files/usr/lib/systemd/system/dataplaneapi.service
@@ -4,6 +4,7 @@ Documentation=https://www.haproxy.com/documentation/dataplaneapi/
 After=network-online.target
 Wants=network-online.target
 After=haproxy.service
+Requires=haproxy.service
 
 [Service]
 Type=simple
@@ -24,7 +25,8 @@ User=root
 Group=root
 
 RuntimeDirectory=dataplaneapi
-StateDirectory=dataplaneapi
+StateDirectory=dataplaneapi dataplaneapi/transactions dataplaneapi/backups
+StateDirectoryMode=0750
 NoNewPrivileges=true
 ProtectHome=true
 ProtectKernelTunables=true

--- a/dataplaneapi.sysext/files/usr/lib/tmpfiles.d/10-dataplaneapi.conf
+++ b/dataplaneapi.sysext/files/usr/lib/tmpfiles.d/10-dataplaneapi.conf
@@ -1,0 +1,5 @@
+d /etc/dataplaneapi 0755 root root - -
+C /etc/dataplaneapi/dataplaneapi.yml 0600 root root - /usr/share/dataplaneapi/dataplaneapi.yml
+d /var/lib/dataplaneapi 0750 root root - -
+d /var/lib/dataplaneapi/transactions 0750 root root - -
+d /var/lib/dataplaneapi/backups 0750 root root - -

--- a/dataplaneapi.sysext/files/usr/share/dataplaneapi/dataplaneapi.yml
+++ b/dataplaneapi.sysext/files/usr/share/dataplaneapi/dataplaneapi.yml
@@ -1,0 +1,37 @@
+# Minimal HAProxy Data Plane API configuration shipped with the sysext.
+# Replace /etc/dataplaneapi/dataplaneapi.yml to customise.
+#
+# The haproxy_bin path targets the location used by the haproxy sysext
+# (/usr/bin/haproxy) rather than the upstream deb default
+# (/usr/sbin/haproxy).
+#
+# A "userlist dataplaneapi" section with at least one user must exist
+# in haproxy.cfg for the API to accept requests; see docs/dataplaneapi.md.
+
+dataplaneapi:
+  host: 0.0.0.0
+  port: 5555
+  userlist:
+    userlist: dataplaneapi
+  resources:
+    maps_dir: /etc/haproxy/maps
+    ssl_certs_dir: /etc/haproxy/ssl
+    general_storage_dir: /etc/haproxy/general
+    spoe_dir: /etc/haproxy/spoe
+  transaction:
+    transaction_dir: /var/lib/dataplaneapi/transactions
+    backups_number: 10
+    backups_dir: /var/lib/dataplaneapi/backups
+haproxy:
+  config_file: /etc/haproxy/haproxy.cfg
+  haproxy_bin: /usr/bin/haproxy
+  reload:
+    reload_delay: 5
+    service_name: haproxy
+    reload_strategy: systemd
+log_targets:
+- log_to: stdout
+  log_level: info
+  log_types:
+  - access
+  - app

--- a/dataplaneapi.sysext/files/usr/share/dataplaneapi/dataplaneapi.yml
+++ b/dataplaneapi.sysext/files/usr/share/dataplaneapi/dataplaneapi.yml
@@ -9,7 +9,11 @@
 # in haproxy.cfg for the API to accept requests; see docs/dataplaneapi.md.
 
 dataplaneapi:
-  host: 0.0.0.0
+  # Bound to loopback by default — the API accepts writes and shell-outs
+  # against haproxy, so exposing it on all interfaces without deliberate
+  # network policy is unsafe. Override in /etc/dataplaneapi/dataplaneapi.yml
+  # (or via a drop-in) if you need remote access.
+  host: 127.0.0.1
   port: 5555
   userlist:
     userlist: dataplaneapi

--- a/docs/dataplaneapi.md
+++ b/docs/dataplaneapi.md
@@ -76,11 +76,17 @@ file at `/run/reboot-required`.
 You can deactivate updates by changing `enabled: true` to
 `enabled: false` in `systemd-sysupdate.timer`.
 
-Note that the snippet is for the x86-64 version of Data Plane API
-v3.3.5.
+The snippet bundles the [`haproxy` sysext](haproxy.md) alongside
+`dataplaneapi` because the API is only useful against a running HAProxy
+instance. It ships an `haproxy.cfg` with the `userlist dataplaneapi`
+block the API needs to accept requests.
 
-Check out the metadata release at
-https://github.com/flatcar/sysext-bakery/releases/tag/dataplaneapi for a
+Note that the snippet is for the x86-64 version of Data Plane API
+v3.3.5 and HAProxy 3.2.5.
+
+Check out the metadata releases at
+https://github.com/flatcar/sysext-bakery/releases/tag/dataplaneapi and
+https://github.com/flatcar/sysext-bakery/releases/tag/haproxy for a
 list of all versions available in the bakery.
 
 ```yaml
@@ -96,16 +102,54 @@ storage:
     - path: /etc/sysupdate.dataplaneapi.d/dataplaneapi.conf
       contents:
         source: https://extensions.flatcar.org/extensions/dataplaneapi.conf
+    - path: /opt/extensions/haproxy/haproxy-3.2.5-x86-64.raw
+      mode: 0644
+      contents:
+        source: https://extensions.flatcar.org/extensions/haproxy-3.2.5-x86-64.raw
+    - path: /etc/sysupdate.haproxy.d/haproxy.conf
+      contents:
+        source: https://extensions.flatcar.org/extensions/haproxy.conf
     - path: /etc/sysupdate.d/noop.conf
       contents:
         source: https://extensions.flatcar.org/extensions/noop.conf
+    - path: /etc/haproxy/haproxy.cfg
+      mode: 0644
+      contents:
+        inline: |
+          global
+              log     stdout format raw local0
+              user    haproxy
+              group   haproxy
+              maxconn 4096
+
+          defaults
+              log     global
+              mode    http
+              option  httplog
+              timeout connect 5s
+              timeout client  50s
+              timeout server  50s
+
+          userlist dataplaneapi
+              user admin insecure-password change-me
+
+          frontend stats
+              bind 127.0.0.1:8404
+              stats enable
+              stats uri /
+              stats refresh 10s
   links:
     - target: /opt/extensions/dataplaneapi/dataplaneapi-v3.3.5-x86-64.raw
       path: /etc/extensions/dataplaneapi.raw
       hard: false
+    - target: /opt/extensions/haproxy/haproxy-3.2.5-x86-64.raw
+      path: /etc/extensions/haproxy.raw
+      hard: false
 systemd:
   units:
     - name: dataplaneapi.service
+      enabled: true
+    - name: haproxy.service
       enabled: true
     - name: systemd-sysupdate.timer
       enabled: true
@@ -118,4 +162,11 @@ systemd:
             ExecStartPre=/usr/lib/systemd/systemd-sysupdate -C dataplaneapi update
             ExecStartPost=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/dataplaneapi.raw > /run/dataplaneapi-sysext-new"
             ExecStartPost=/usr/bin/sh -c "if ! cmp --silent /run/dataplaneapi-sysext /run/dataplaneapi-sysext-new; then touch /run/reboot-required; fi"
+        - name: haproxy.conf
+          contents: |
+            [Service]
+            ExecStartPre=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/haproxy.raw > /run/haproxy-sysext"
+            ExecStartPre=/usr/lib/systemd/systemd-sysupdate -C haproxy update
+            ExecStartPost=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/haproxy.raw > /run/haproxy-sysext-new"
+            ExecStartPost=/usr/bin/sh -c "if ! cmp --silent /run/haproxy-sysext /run/haproxy-sysext-new; then touch /run/reboot-required; fi"
 ```

--- a/docs/dataplaneapi.md
+++ b/docs/dataplaneapi.md
@@ -46,6 +46,16 @@ The unit also honours `EnvironmentFile=-/etc/default/dataplaneapi` and
 there to point `-f` at a different file or add flags without editing
 the unit.
 
+## Network exposure
+
+The shipped default binds the API to `127.0.0.1:5555`, which is a
+deliberately conservative default given the API can rewrite HAProxy
+config and shell out to reload it. To expose it on other interfaces,
+override `dataplaneapi.host` in your own
+`/etc/dataplaneapi/dataplaneapi.yml` and put the port behind an
+appropriately restricted network policy (a firewall, an HAProxy
+frontend with mTLS, etc.).
+
 ## Privileges
 
 The unit runs as `root` because the default `reload_strategy: systemd`
@@ -57,8 +67,8 @@ and grant that user access to the master socket.
 
 ## Usage
 
-Download and merge the sysext at provisioning time using the below
-butane snippet.
+Download and merge the sysext at provisioning time using the Butane
+snippet below.
 
 The snippet includes automated updates via systemd-sysupdate.
 Sysupdate will stage updates and request a reboot by creating a flag

--- a/docs/dataplaneapi.md
+++ b/docs/dataplaneapi.md
@@ -1,0 +1,111 @@
+# HAProxy Data Plane API sysext
+
+This sysext ships the
+[HAProxy Data Plane API](https://www.haproxy.com/documentation/dataplaneapi/),
+a REST API that manages an HAProxy instance's configuration and runtime
+state.
+
+The sysext installs:
+
+- `dataplaneapi` Go binary at `/usr/bin/dataplaneapi`
+- `dataplaneapi.service` systemd unit
+- `tmpfiles.d` entry that seeds `/etc/dataplaneapi/dataplaneapi.yml`
+  from a minimal default on first boot and creates
+  `/var/lib/dataplaneapi/{transactions,backups}` state directories
+
+The service is intended to run alongside the [`haproxy` sysext](haproxy.md)
+on the same host. The shipped default config points at
+`/usr/bin/haproxy`, `/etc/haproxy/haproxy.cfg` and reloads via
+`systemctl reload haproxy.service`, matching what the `haproxy` sysext
+lays down.
+
+## HAProxy prerequisites
+
+The API refuses requests until a `userlist` matching the one named in
+`dataplaneapi.yml` (`userlist: dataplaneapi` by default) is defined in
+`/etc/haproxy/haproxy.cfg`. Minimal example:
+
+```
+userlist dataplaneapi
+    user admin insecure-password change-me
+```
+
+Use `password` with a MD5 or SHA-512 crypt hash for real deployments;
+`insecure-password` is fine for the initial bring-up smoke test.
+
+## Custom configuration
+
+The `tmpfiles.d` rule uses `C /etc/dataplaneapi/dataplaneapi.yml`
+semantics, so the shipped default is only copied in when the file does
+not already exist. Provisioning tools that lay down
+`/etc/dataplaneapi/dataplaneapi.yml` will not be overwritten by the
+sysext or by subsequent sysext updates.
+
+The unit also honours `EnvironmentFile=-/etc/default/dataplaneapi` and
+`EnvironmentFile=-/etc/sysconfig/dataplaneapi`. Override `SYSD_OPTIONS`
+there to point `-f` at a different file or add flags without editing
+the unit.
+
+## Privileges
+
+The unit runs as `root` because the default `reload_strategy: systemd`
+requires the API process to invoke `systemctl reload
+haproxy.service`. If you switch to a socket-based strategy (talking to
+`/run/haproxy/haproxy-master.sock` directly), drop-in a lower-privilege
+`User=`/`Group=` under `/etc/systemd/system/dataplaneapi.service.d/`
+and grant that user access to the master socket.
+
+## Usage
+
+Download and merge the sysext at provisioning time using the below
+butane snippet.
+
+The snippet includes automated updates via systemd-sysupdate.
+Sysupdate will stage updates and request a reboot by creating a flag
+file at `/run/reboot-required`.
+You can deactivate updates by changing `enabled: true` to
+`enabled: false` in `systemd-sysupdate.timer`.
+
+Note that the snippet is for the x86-64 version of Data Plane API
+v3.3.5.
+
+Check out the metadata release at
+https://github.com/flatcar/sysext-bakery/releases/tag/dataplaneapi for a
+list of all versions available in the bakery.
+
+```yaml
+variant: flatcar
+version: 1.0.0
+
+storage:
+  files:
+    - path: /opt/extensions/dataplaneapi/dataplaneapi-v3.3.5-x86-64.raw
+      mode: 0644
+      contents:
+        source: https://extensions.flatcar.org/extensions/dataplaneapi-v3.3.5-x86-64.raw
+    - path: /etc/sysupdate.dataplaneapi.d/dataplaneapi.conf
+      contents:
+        source: https://extensions.flatcar.org/extensions/dataplaneapi.conf
+    - path: /etc/sysupdate.d/noop.conf
+      contents:
+        source: https://extensions.flatcar.org/extensions/noop.conf
+  links:
+    - target: /opt/extensions/dataplaneapi/dataplaneapi-v3.3.5-x86-64.raw
+      path: /etc/extensions/dataplaneapi.raw
+      hard: false
+systemd:
+  units:
+    - name: dataplaneapi.service
+      enabled: true
+    - name: systemd-sysupdate.timer
+      enabled: true
+    - name: systemd-sysupdate.service
+      dropins:
+        - name: dataplaneapi.conf
+          contents: |
+            [Service]
+            ExecStartPre=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/dataplaneapi.raw > /run/dataplaneapi-sysext"
+            ExecStartPre=/usr/lib/systemd/systemd-sysupdate -C dataplaneapi update
+            ExecStartPost=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/dataplaneapi.raw > /run/dataplaneapi-sysext-new"
+            ExecStartPost=/usr/bin/sh -c "if ! cmp --silent /run/dataplaneapi-sysext /run/dataplaneapi-sysext-new; then touch /run/reboot-required; fi"
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -68,6 +68,7 @@ Check out documentation on specific extensions at the navigation menu on the lef
 | `consul`          |  released    | [consul versions](https://github.com/flatcar/sysext-bakery/releases/tag/consul) |
 | `containerd`     |  released    | [containerd versions](https://github.com/flatcar/sysext-bakery/releases/tag/containerd) |
 | `crio`           |  released    | [crio versions](https://github.com/flatcar/sysext-bakery/releases/tag/crio) |
+| `dataplaneapi`   |  released    | [dataplaneapi versions](https://github.com/flatcar/sysext-bakery/releases/tag/dataplaneapi) |
 | `docker-buildx`  |  released    | [docker-buildx versions](https://github.com/flatcar/sysext-bakery/releases/tag/docker-buildx) |
 | `docker-compose` |  released    | [docker-compose versions](https://github.com/flatcar/sysext-bakery/releases/tag/docker-compose) |
 | `docker`         |  released    | [docker versions](https://github.com/flatcar/sysext-bakery/releases/tag/docker) |

--- a/release_build_versions.txt
+++ b/release_build_versions.txt
@@ -116,3 +116,5 @@ tilde 1.1.2
 tilde latest
 
 opkssh latest
+
+dataplaneapi latest


### PR DESCRIPTION
## Summary

Packages the [HAProxy Data Plane API](https://www.haproxy.com/documentation/dataplaneapi/) — the REST API that manages an HAProxy instance's configuration and runtime state — as its own sysext. Intended to compose with the `haproxy` sysext in #228, but kept separate so upstream release cadences and per-host use cases stay decoupled.

- Installs the upstream `dataplaneapi` Go binary from `dataplaneapi_<v>_linux_<arch>.tar.gz` to `/usr/bin/dataplaneapi`. The tarball is verified against the per-release `checksums.txt` (anchored on the exact filename, tolerates `sha256sum` binary-mode `*` prefix).
- Ships `dataplaneapi.service` modeled on the upstream Debian package, with sandboxing added. Runs as `root` because the default `reload_strategy: systemd` invokes `systemctl reload haproxy.service`; docs explain how to drop-in a lower-privilege user with a socket-based reload.
- `tmpfiles.d` seeds `/etc/dataplaneapi/dataplaneapi.yml` (mode `0600 root:root`) from `/usr/share/dataplaneapi/dataplaneapi.yml` on first boot via `C` semantics — later sysext updates never overwrite a user-provided file. The shipped default targets the paths used by the `haproxy` sysext (`/usr/bin/haproxy`, `/etc/haproxy/haproxy.cfg`).
- Creates state dirs under `/var/lib/dataplaneapi/{transactions,backups}`.
- Wires `dataplaneapi latest` into `release_build_versions.txt` and adds `docs/dataplaneapi.md` plus an index row.

## Test plan

- [ ] `./bakery.sh list dataplaneapi` lists upstream releases
- [ ] `./bakery.sh create dataplaneapi vX.Y.Z` produces a working `dataplaneapi.raw` for x86-64 and arm64
- [ ] Booted alongside the `haproxy` sysext with a `userlist dataplaneapi` block in `haproxy.cfg`, `curl -u admin:... http://localhost:5555/v3/info` returns the running HAProxy version