### PR TITLE
vault: add HashiCorp Vault sysext

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -89,6 +89,7 @@ Check out documentation on specific extensions at the navigation menu on the lef
 | `rke2`           |  released    | [rke2 versions](https://github.com/flatcar/sysext-bakery/releases/tag/rke2) |
 | `scx`            |  released    | [scx versions](https://github.com/flatcar/sysext-bakery/releases/tag/scx) |
 | `tailscale`      |  released    | [tailscale versions](https://github.com/flatcar/sysext-bakery/releases/tag/tailscale) |
+| `vault`          |  released    | [vault versions](https://github.com/flatcar/sysext-bakery/releases/tag/vault) |
 | `wasmcloud`      |  released    | [wasmcloud versions](https://github.com/flatcar/sysext-bakery/releases/tag/wasmcloud) |
 | `wasmedge`       |  released    | [wasmedge versions](https://github.com/flatcar/sysext-bakery/releases/tag/wasmedge) |
 | `wasmtime`       |  released    | [wasmtime versions](https://github.com/flatcar/sysext-bakery/releases/tag/wasmtime) |

--- a/docs/vault.md
+++ b/docs/vault.md
@@ -1,0 +1,51 @@
+# Vault sysext
+
+This sysext ships [vault](https://github.com/hashicorp/vault).
+
+The sysext includes a service unit file to start vault at boot.
+The default configuration can be modified or replaced via a custom Butane config.
+
+# Usage
+
+The snippet includes automated updates via systemd-sysupdate.
+Sysupdate will stage updates, refresh the merged sysext, and restart `vault.service` — no reboot is required.
+You can deactivate updates by changing `enabled: true` to `enabled: false` in `systemd-sysupdate.timer`.
+
+Note that the snippet is for the x86-64 version of vault 1.20.0.
+
+Check out the metadata release at https://github.com/flatcar/sysext-bakery/releases/tag/vault for a list of all versions available in the bakery.
+
+```yaml
+variant: flatcar
+version: 1.0.0
+
+storage:
+  files:
+    - path: /opt/extensions/vault/vault-1.20.0-x86-64.raw
+      mode: 0644
+      contents:
+        source: https://extensions.flatcar.org/extensions/vault-1.20.0-x86-64.raw
+    - path: /etc/sysupdate.vault.d/vault.conf
+      contents:
+        source: https://extensions.flatcar.org/extensions/vault.conf
+  links:
+    - path: /etc/systemd/system/multi-user.target.wants/vault.service
+      target: /usr/local/lib/systemd/system/vault.service
+      overwrite: true
+    - target: /opt/extensions/vault/vault-1.20.0-x86-64.raw
+      path: /etc/extensions/vault.raw
+      hard: false
+systemd:
+  units:
+    - name: systemd-sysupdate.timer
+      enabled: true
+    - name: systemd-sysupdate.service
+      dropins:
+        - name: vault.conf
+          contents: |
+            [Service]
+            ExecStartPre=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/vault.raw > /tmp/vault"
+            ExecStartPre=/usr/lib/systemd/systemd-sysupdate -C vault update
+            ExecStartPost=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/vault.raw > /tmp/vault-new"
+            ExecStartPost=/usr/bin/sh -c "if ! cmp --silent /tmp/vault /tmp/vault-new; then systemd-sysext refresh && systemctl restart vault.service; fi"
+```

--- a/release_build_versions.txt
+++ b/release_build_versions.txt
@@ -118,3 +118,6 @@ tilde latest
 opkssh latest
 
 dataplaneapi latest
+
+vault 1.20.0
+vault latest

--- a/vault.sysext/create.sh
+++ b/vault.sysext/create.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# vim: et ts=2 syn=bash
+#
+
+RELOAD_SERVICES_ON_MERGE="true"
+
+# The HashiCorp releases API caps ?limit at 20 and returns newest first,
+# so walk pages via ?after=<timestamp> until a short page comes back
+# (last page) or the safety cap trips. Emit versions as they arrive so
+# `--latest true` can abort after the first fetch.
+function list_available_versions() {
+  local base="https://api.releases.hashicorp.com/v1/releases/vault"
+  local after=""
+  local max_pages=20
+  local curl_opts=(
+    -fsSL
+    --retry-delay 1 --retry 60 --retry-connrefused
+    --retry-max-time 60 --connect-timeout 20
+  )
+
+  local page
+  for page in $(seq 1 "$max_pages") ; do
+    local response
+    if [[ -z "$after" ]] ; then
+      response="$(curl "${curl_opts[@]}" "${base}?limit=20")"
+    else
+      response="$(curl "${curl_opts[@]}" -G \
+        --data-urlencode "limit=20" \
+        --data-urlencode "after=${after}" \
+        "${base}")"
+    fi
+
+    local count
+    count="$(printf '%s' "$response" | jq 'length')"
+    [[ "$count" -eq 0 ]] && break
+
+    printf '%s' "$response" | jq -r '.[] | select(.is_prerelease == false)
+                                         | select(.license_class == "oss")
+                                         | .version'
+
+    [[ "$count" -lt 20 ]] && break
+
+    after="$(printf '%s' "$response" | jq -r '.[-1].timestamp_created')"
+  done
+}
+# --
+
+function populate_sysext_root() {
+  local sysextroot="$1"
+  local arch="$2"
+  local version="$3"
+
+  local rel_arch
+  rel_arch="$(arch_transform "x86-64" "amd64" "$arch")"
+  curl -fsSLZO --retry-delay 1 --retry 60 \
+    --retry-connrefused --retry-max-time 60 --connect-timeout 20 \
+    "https://releases.hashicorp.com/vault/${version}/vault_${version}_linux_${rel_arch}.zip"
+  # Unzip the binary
+  mkdir -p "${sysextroot}/usr/bin"
+  unzip -q "vault_${version}_linux_${rel_arch}.zip"
+  install -m 0755 vault "${sysextroot}/usr/bin"
+}
+# --

--- a/vault.sysext/files/usr/lib/systemd/system/multi-user.target.upholds/vault.service
+++ b/vault.sysext/files/usr/lib/systemd/system/multi-user.target.upholds/vault.service
@@ -1,0 +1,1 @@
+../vault.service

--- a/vault.sysext/files/usr/lib/systemd/system/vault.service
+++ b/vault.sysext/files/usr/lib/systemd/system/vault.service
@@ -1,0 +1,34 @@
+[Unit]
+Description="HashiCorp Vault - A tool for managing secrets"
+Documentation=https://developer.hashicorp.com/vault/docs
+Requires=network-online.target
+After=network-online.target
+ConditionFileNotEmpty=/etc/vault.d/vault.hcl
+StartLimitIntervalSec=60
+StartLimitBurst=3
+
+[Service]
+Type=notify
+EnvironmentFile=-/etc/vault.d/vault.env
+User=vault
+Group=vault
+ProtectSystem=full
+ProtectHome=read-only
+PrivateTmp=yes
+PrivateDevices=yes
+SecureBits=keep-caps
+AmbientCapabilities=CAP_IPC_LOCK
+CapabilityBoundingSet=CAP_SYSLOG CAP_IPC_LOCK
+NoNewPrivileges=yes
+ExecStart=/usr/bin/vault server -config=/etc/vault.d/vault.hcl
+ExecReload=/bin/kill --signal HUP $MAINPID
+KillMode=process
+KillSignal=SIGINT
+Restart=on-failure
+RestartSec=5
+TimeoutStopSec=30
+LimitNOFILE=65536
+LimitMEMLOCK=infinity
+
+[Install]
+UpheldBy=multi-user.target

--- a/vault.sysext/files/usr/lib/sysusers.d/vault.conf
+++ b/vault.sysext/files/usr/lib/sysusers.d/vault.conf
@@ -1,0 +1,1 @@
+u vault - "HashiCorp Vault" /var/lib/vault /sbin/nologin

--- a/vault.sysext/files/usr/lib/tmpfiles.d/10-vault.conf
+++ b/vault.sysext/files/usr/lib/tmpfiles.d/10-vault.conf
@@ -1,0 +1,4 @@
+C /etc/vault.d/vault.env 0600 root root - /usr/share/vault/vault.env
+C /etc/vault.d/vault.hcl 0640 root vault - /usr/share/vault/vault.hcl
+d /var/lib/vault 0700 vault vault - -
+d /var/lib/vault/data 0700 vault vault - -

--- a/vault.sysext/files/usr/share/vault/vault.hcl
+++ b/vault.sysext/files/usr/share/vault/vault.hcl
@@ -1,0 +1,45 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+# Full configuration options can be found at https://developer.hashicorp.com/vault/docs/configuration
+
+ui = true
+
+# storage
+# The storage stanza configures the storage backend, which represents the location
+# for the durable storage of Vault's information. Each backend has pros, cons,
+# advantages, and trade-offs. For example, some backends support high availability
+# while others provide a more robust backup and restoration process.
+storage "file" {
+  path = "/var/lib/vault/data"
+}
+
+# For production the recommended storage backends are Integrated Storage (raft)
+# or Consul. Example raft configuration:
+#storage "raft" {
+#  path    = "/var/lib/vault/data"
+#  node_id = "node1"
+#}
+
+# listener
+# The listener stanza configures the addresses and ports on which Vault will
+# respond to requests. At least one listener is required. By default the listener
+# below binds to loopback only; adjust address and TLS settings for production use.
+listener "tcp" {
+  address     = "127.0.0.1:8200"
+  tls_disable = 1
+}
+
+# api_addr
+# Specifies the address (full URL) to advertise to other Vault servers in the
+# cluster for client redirection.
+#api_addr = "https://vault.example.com:8200"
+
+# cluster_addr
+# Indicates the address and port to be used for communication between the Vault
+# nodes in a cluster.
+#cluster_addr = "https://vault.example.com:8201"
+
+# Enterprise License
+# Vault Enterprise requires a license.
+#license_path = "/etc/vault.d/vault.hclic"


### PR DESCRIPTION
## Summary
- Adds a `vault` sysext that ships the OSS Vault release binary from `releases.hashicorp.com`, matching the layout of the existing `consul` and `nomad` sysexts.
- Bundles a `vault.service` systemd unit (Type=notify, `CAP_IPC_LOCK` + `LimitMEMLOCK=infinity` for Vault's mlock requirement, `UpheldBy=multi-user.target`) and the standard `multi-user.target.upholds/vault.service` symlink.
- Ships a static `vault` system user via `sysusers.d/vault.conf` (home `/var/lib/vault`, `/sbin/nologin`) instead of relying on `DynamicUser`, matching the coder sysext precedent — Vault operators regularly need stable UID ownership on the storage dir for backup/restore, which `DynamicUser`'s per-boot allocation doesn't provide.
- Shipped default config runs a loopback TCP listener over `storage "file"` at `/var/lib/vault/data` (under the sysusers home), with the UI on. `tmpfiles.d/10-vault.conf` creates `/var/lib/vault` and `/var/lib/vault/data` owned by the `vault` user. Meant to be replaced via a custom Butane config for production.
- Registered in `release_build_versions.txt` (`vault 1.20.0` + `vault latest`) and in the `docs/index.md` extensions table.

## Test plan
- [ ] `./bakery.sh list vault` returns OSS versions from the HashiCorp releases API.
- [ ] `./bakery.sh create vault 1.20.0` produces `vault.raw` on x86-64.
- [ ] `./bakery.sh create vault 1.20.0 --arch arm64` produces the arm64 sysext.
- [ ] `./bakery.sh boot vault` — after merge, `vault --version` reports the pinned version, `systemctl status vault` shows the service running, and the sysusers/tmpfiles entries create `/var/lib/vault` and materialize `/etc/vault.d/vault.hcl`.