### PR TITLE
bcachefs-tools: add sysext for bcachefs userspace utilities

### DIFF
--- a/bcachefs-tools.sysext/build.sh
+++ b/bcachefs-tools.sysext/build.sh
@@ -1,0 +1,96 @@
+#!/bin/ash
+#
+# Build script helper for the bcachefs-tools sysext.
+# Runs inside an ephemeral Alpine container.
+# Builds the bcachefs userspace utilities and exports them to a
+# bind-mounted volume at /install_root.
+#
+set -euo pipefail
+
+version="$1"
+export_user_group="$2"
+
+# Build deps. bcachefs-tools is a Rust+C project orchestrated by Make,
+# linking against a fair pile of system libraries (sodium, urcu, blkid,
+# keyutils, zlib, zstd, lz4, aio, udev, attr).
+#
+# We try a static build first (matches the scx.sysext precedent). If a
+# given dep does not ship a static archive on Alpine, the corresponding
+# *-static package add will fail loudly during CI and we can swap to a
+# dynamic build that bundles the .so's under /usr/lib64.
+apk add --no-cache \
+  clang \
+  clang-dev \
+  clang-libclang \
+  llvm \
+  lld \
+  bpftool \
+  libbpf-dev \
+  elfutils-dev \
+  pkgconf \
+  curl \
+  git \
+  make \
+  gcc \
+  musl-dev \
+  linux-headers \
+  ca-certificates \
+  cargo \
+  rust \
+  zlib-dev          zlib-static \
+  zstd-dev          zstd-static \
+  lz4-dev           lz4-static \
+  libsodium-dev     libsodium-static \
+  liburcu-dev \
+  util-linux-dev \
+  keyutils-dev \
+  libaio-dev \
+  eudev-dev \
+  attr-dev
+
+cd /opt
+git clone https://github.com/koverstreet/bcachefs-tools.git \
+  --depth 1 --branch "${version}" --single-branch
+cd /opt/bcachefs-tools
+
+# Force static linking for Rust and C deps. Same env-var pattern as
+# scx.sysext — CARGO_BUILD_TARGET forces the per-triple variants to take
+# effect over the generic CARGO_* ones.
+target="$(rustc -vV | sed -n 's/^host: //p')"
+export CARGO_BUILD_TARGET="${target}"
+TARGET="$(echo "${target}" | tr a-z- A-Z_)"
+export CARGO_TARGET_${TARGET}_RUSTFLAGS="-C target-feature=+crt-static -C link-arg=-static"
+export CARGO_TARGET_${TARGET}_PKG_CONFIG_ALL_STATIC=1
+
+# Build + install. Flatcar's /usr/sbin is a symlink to /usr/bin, and a
+# sysext shipping /usr/sbin would clobber the symlink at merge — so we
+# redirect every sbin destination to /usr/bin. Skip the udev rules and
+# initramfs hooks; the sysext only ships userspace tools.
+make -j"$(nproc)" \
+  PREFIX=/usr \
+  bcachefs
+
+make install \
+  DESTDIR=/install_root \
+  PREFIX=/usr \
+  ROOT_SBINDIR=/usr/bin \
+  PKGCONFIG_LIBDIR=/usr/lib/pkgconfig \
+  INITRAMFS_DIR= \
+  UDEVLIBDIR=
+
+# Belt and suspenders: if any binary still landed under /usr/sbin
+# (older Makefile variants), relocate it before it ships.
+if [ -d /install_root/usr/sbin ]; then
+  mkdir -p /install_root/usr/bin
+  mv /install_root/usr/sbin/* /install_root/usr/bin/ 2>/dev/null || true
+  rmdir /install_root/usr/sbin
+fi
+
+# Drop dev/man files — pure noise in a sysext.
+rm -rf /install_root/usr/include \
+       /install_root/usr/lib/pkgconfig \
+       /install_root/usr/share/man \
+       /install_root/usr/share/doc
+
+chown -R "${export_user_group}" /install_root
+chmod -R u+rwX,go+rX /install_root

--- a/bcachefs-tools.sysext/create.sh
+++ b/bcachefs-tools.sysext/create.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# vim: et ts=2 syn=bash
+#
+# bcachefs-tools system extension.
+# Provides bcachefs userspace utilities (bcachefs, mkfs.bcachefs,
+# fsck.bcachefs, mount.bcachefs, ...).
+#
+# The bcachefs kernel module itself is shipped separately by the
+# bcachefs-kmod sysext (one build per Flatcar kernel version).
+
+RELOAD_SERVICES_ON_MERGE="false"
+
+function list_available_versions() {
+  # Upstream publishes git tags (vX.Y.Z) but not GitHub Releases,
+  # so we have to read tags rather than releases.
+  list_github_tags "koverstreet" "bcachefs-tools"
+}
+# --
+
+function populate_sysext_root() {
+  local sysextroot="$1"
+  local arch="$2"
+  local version="$3"
+
+  local img_arch="$(arch_transform 'x86-64' 'amd64' "$arch")"
+  img_arch="$(arch_transform 'arm64' 'arm64/v8' "$img_arch")"
+
+  local image="docker.io/alpine:latest"
+
+  announce "Building bcachefs-tools ${version} for ${arch}"
+
+  local user_group="$(id -u):$(id -g)"
+
+  cp "${scriptroot}/bcachefs-tools.sysext/build.sh" .
+
+  docker run --rm \
+    -i \
+    -v "$(pwd)":/install_root \
+    --platform "linux/${img_arch}" \
+    --pull always \
+    ${image} \
+      /install_root/build.sh "${version}" "${user_group}"
+
+  cp -aR usr "${sysextroot}"/
+}
+# --

--- a/bcachefs-tools.sysext/test.sh
+++ b/bcachefs-tools.sysext/test.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# vim: et ts=2 syn=bash
+#
+# Test script for bcachefs-tools sysext.
+#

--- a/docs/bcachefs-tools.md
+++ b/docs/bcachefs-tools.md
@@ -1,0 +1,62 @@
+# bcachefs-tools sysext
+
+This sysext ships the [bcachefs userspace utilities](https://github.com/koverstreet/bcachefs-tools):
+
+- `bcachefs` — the unified CLI (subcommand-based: `bcachefs format`, `bcachefs fsck`, `bcachefs mount`, ...).
+- `mkfs.bcachefs`, `fsck.bcachefs`, `mount.bcachefs`, `dump.bcachefs` — argv[0] dispatchers to the unified CLI, so `/usr/bin/mount` automatically picks `mount.bcachefs` up for `-t bcachefs`.
+
+bcachefs is out-of-tree only, so on its own this sysext is not enough to actually use bcachefs — you also need the `bcachefs-kmod` sysext, which ships a prebuilt `bcachefs.ko` for a specific Flatcar release's kernel.
+
+> **Warning — on-disk format stability.** bcachefs is still pre-1.0 from an on-disk-format perspective. Pin a known-good `bcachefs-tools` version against a known-good kernel before putting data you care about on it.
+
+## Usage
+
+Download and merge the sysext at provisioning time using the Butane snippet below. The snippet pins `bcachefs-tools` v1.25.2 for x86-64; substitute the version and arch you want.
+
+See the [bcachefs-tools release page](https://github.com/flatcar/sysext-bakery/releases/tag/bcachefs-tools) for all versions available.
+
+```yaml
+variant: flatcar
+version: 1.0.0
+
+storage:
+  files:
+    - path: /opt/extensions/bcachefs-tools/bcachefs-tools-v1.25.2-x86-64.raw
+      mode: 0644
+      contents:
+        source: https://extensions.flatcar.org/extensions/bcachefs-tools-v1.25.2-x86-64.raw
+    - path: /etc/sysupdate.bcachefs-tools.d/bcachefs-tools.conf
+      contents:
+        source: https://extensions.flatcar.org/extensions/bcachefs-tools.conf
+    - path: /etc/sysupdate.d/noop.conf
+      contents:
+        source: https://extensions.flatcar.org/extensions/noop.conf
+  links:
+    - target: /opt/extensions/bcachefs-tools/bcachefs-tools-v1.25.2-x86-64.raw
+      path: /etc/extensions/bcachefs-tools.raw
+      hard: false
+systemd:
+  units:
+    - name: systemd-sysupdate.timer
+      enabled: true
+    - name: systemd-sysupdate.service
+      dropins:
+        - name: bcachefs-tools.conf
+          contents: |
+            [Service]
+            ExecStartPre=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/bcachefs-tools.raw > /tmp/bcachefs-tools"
+            ExecStartPre=/usr/lib/systemd/systemd-sysupdate -C bcachefs-tools update
+            ExecStartPost=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/bcachefs-tools.raw > /tmp/bcachefs-tools-new"
+            ExecStartPost=/usr/bin/sh -c "if ! cmp --silent /tmp/bcachefs-tools /tmp/bcachefs-tools-new; then touch /run/reboot-required; fi"
+```
+
+## Smoke test
+
+After provisioning, verify the tools are merged and the kernel module is available:
+
+```sh
+bcachefs version
+modprobe bcachefs && grep bcachefs /proc/filesystems
+mkfs.bcachefs /dev/<device>
+mount -t bcachefs /dev/<device> /mnt/data
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -60,6 +60,7 @@ Check out documentation on specific extensions at the navigation menu on the lef
 
 |    Extension     | Availability | Versions available |
 | ---------------- | ------------ | ------------- |
+| `bcachefs-tools` |  released    | [bcachefs-tools versions](https://github.com/flatcar/sysext-bakery/releases/tag/bcachefs-tools) |
 | `bird`           |  released    | [bird versions](https://github.com/flatcar/sysext-bakery/releases/tag/bird) |
 | `chrony`         |  released    | [chrony versions](https://github.com/flatcar/sysext-bakery/releases/tag/chrony) |
 | `cilium`         |  released    | [cilium versions](https://github.com/flatcar/sysext-bakery/releases/tag/cilium) |

--- a/release_build_versions.txt
+++ b/release_build_versions.txt
@@ -17,6 +17,8 @@
 # to build the latest (i.e. highest version number) release(s).
 #
 
+bcachefs-tools latest
+
 chrony 4.8
 chrony latest
 


### PR DESCRIPTION
## Summary
- Adds a `bcachefs-tools` sysext shipping the [bcachefs userspace utilities](https://github.com/koverstreet/bcachefs-tools): the unified `bcachefs` CLI and its argv[0] dispatchers (`mkfs.bcachefs`, `fsck.bcachefs`, `mount.bcachefs`, `dump.bcachefs`) — so `mount -t bcachefs` picks up `mount.bcachefs` automatically once the sysext is merged.
- Statically builds bcachefs-tools inside an ephemeral Alpine container (Rust + C, Make-driven) with `+crt-static` for the Rust side and `PKG_CONFIG_ALL_STATIC=1` for the C side — same pattern as `scx.sysext`. This avoids any coupling to Flatcar's glibc.
- Redirects install targets that would land under `/usr/sbin` to `/usr/bin` (Flatcar's `/usr/sbin` is a symlink to `/usr/bin`; shipping the former in a sysext would clobber the symlink on merge). Belt-and-suspenders: if any binary still lands under `/usr/sbin`, it's relocated before packaging.
- Drops dev/man/pkgconfig files from the sysext — pure noise for a runtime sysext.
- Version listing uses `list_github_tags koverstreet/bcachefs-tools` since upstream tags releases but does not publish GitHub Releases.
- Registered in `release_build_versions.txt` (`bcachefs-tools latest`) and in the `docs/index.md` extensions table.

**Kernel module is out of scope for this PR.** The bcachefs kernel module is shipped separately by a companion `bcachefs-kmod` sysext (PR to follow) because the two have different lifecycles: userspace tools track bcachefs-tools upstream, while the kernel module is coupled to a specific Flatcar release's kernel and cannot share a version axis.

## Test plan
- [ ] `./bakery.sh list bcachefs-tools` returns upstream tags.
- [ ] `./bakery.sh create bcachefs-tools v1.25.2` produces `bcachefs-tools.raw` for x86-64.
- [ ] `./bakery.sh create bcachefs-tools v1.25.2 --arch arm64` produces the arm64 sysext.
- [ ] After merge on a Flatcar release whose kernel enables `CONFIG_BCACHEFS_FS`: `bcachefs version` reports the pinned version, `modprobe bcachefs && grep bcachefs /proc/filesystems` succeeds, and `mkfs.bcachefs` + `mount -t bcachefs` round-trip on a loopback device.
- [ ] On a Flatcar release without in-tree bcachefs: `bcachefs version` still works; kernel-side probing needs the `bcachefs-kmod` sysext (separate PR).