### PR TITLE
bcachefs-kmod: add sysext shipping a prebuilt bcachefs kernel module

### DIFF
--- a/bcachefs-kmod.sysext/build.sh
+++ b/bcachefs-kmod.sysext/build.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+#
+# Build script helper for the bcachefs-kmod sysext.
+# Runs inside the Flatcar SDK container (ghcr.io/flatcar/flatcar-sdk-all).
+# Builds bcachefs.ko using koverstreet/bcachefs-tools's dkms/ harness
+# against the kernel source shipped by the SDK, then exports the .ko
+# plus a modules-load.d snippet to the bind-mounted /install_root.
+set -euo pipefail
+
+bcachefs_version="$1"     # koverstreet/bcachefs-tools tag, e.g. v1.25.2
+export_user_group="$2"
+
+# 1. Fetch Flatcar's Portage tree + kernel sources ------------------------
+#
+# The SDK image ships emerge but not the Portage tree; emerge-gitclone
+# clones it on first use. coreos-modules pulls in coreos-sources as a
+# dependency, drops the kernel source with Flatcar's patches applied at
+# /usr/src/linux-<kver>-flatcar, and runs modules_prepare so we end up
+# with a build-usable KDIR (Module.symvers, generated headers, etc.).
+emerge-gitclone
+emerge -gKv sys-kernel/coreos-modules
+
+# 2. Resolve KDIR + kernel release string ---------------------------------
+kdir="$(readlink -f /usr/src/linux)"
+kver="$(basename "${kdir}")"
+kver="${kver#linux-}"    # e.g. "6.6.86-flatcar"
+
+echo "==> Building bcachefs ${bcachefs_version} against kernel ${kver}"
+
+# 3. Clone bcachefs-tools at the requested tag ----------------------------
+#
+# The kernel-side bcachefs source and its out-of-tree Kbuild harness live
+# in koverstreet/bcachefs-tools now — everything since the 6.18 mainline
+# removal ships through this repo (see dkms/ subdirectory).
+cd /tmp
+git clone --depth 1 --branch "${bcachefs_version}" --single-branch \
+  https://github.com/koverstreet/bcachefs-tools.git bcachefs
+
+# 4. Enforce the DKMS kernel-version floor --------------------------------
+#
+# dkms/dkms.conf.in advertises the minimum kernel version bcachefs will
+# build against. Extract it and compare against the target Flatcar kernel
+# so we fail early with a legible message instead of a compile error deep
+# in fs/bcachefs/.
+min_kver="$(sed -n 's/^BUILD_EXCLUSIVE_KERNEL_MIN="\([^"]*\)"/\1/p' \
+  /tmp/bcachefs/dkms/dkms.conf.in 2>/dev/null || true)"
+if [ -n "${min_kver}" ]; then
+  target="${kver%%-*}"     # strip "-flatcar" suffix for comparison
+  lowest="$(printf '%s\n' "${min_kver}" "${target}" | sort -V | head -n1)"
+  if [ "${lowest}" != "${min_kver}" ]; then
+    echo "ERROR: bcachefs ${bcachefs_version} requires kernel >= ${min_kver}," \
+         "Flatcar ships ${kver}" >&2
+    exit 1
+  fi
+fi
+
+# 5. Build the module -----------------------------------------------------
+#
+# dkms/Makefile drives `$(MAKE) -C $(KDIR) M=$$PWD modules` and produces
+# src/fs/bcachefs/bcachefs.ko. No overlay onto the kernel tree, no manual
+# modules_prepare here — coreos-modules already did that.
+make -j"$(nproc)" -C /tmp/bcachefs/dkms KDIR="${kdir}"
+
+ko_src=/tmp/bcachefs/dkms/src/fs/bcachefs/bcachefs.ko
+[ -f "${ko_src}" ] || {
+  echo "ERROR: bcachefs.ko was not produced at ${ko_src}" >&2
+  exit 1
+}
+
+# 6. Stage into the sysext root -------------------------------------------
+#
+# /usr/lib/modules/<kver>/updates/ is depmod's out-of-tree convention and
+# is preferred by modprobe over any in-tree copy (though there is none on
+# post-6.18 Flatcar kernels — bcachefs is gone from mainline).
+modules_dst="/install_root/usr/lib/modules/${kver}/updates"
+mkdir -p "${modules_dst}"
+install -m 0644 "${ko_src}" "${modules_dst}/bcachefs.ko"
+
+# Run depmod against the sysext root so `modprobe bcachefs` resolves on
+# first merge without needing depmod to run on-target.
+mkdir -p "/lib/modules/${kver}"
+touch "/lib/modules/${kver}/modules.builtin" "/lib/modules/${kver}/modules.order"
+depmod -a -b /install_root/usr "${kver}" || true
+
+mkdir -p /install_root/usr/lib/modules-load.d
+cat > /install_root/usr/lib/modules-load.d/bcachefs.conf <<EOF
+bcachefs
+EOF
+
+chown -R "${export_user_group}" /install_root
+chmod -R u+rwX,go+rX /install_root
+
+echo "==> bcachefs-kmod build complete"
+echo "    bcachefs: ${bcachefs_version}"
+echo "    kernel:   ${kver}"

--- a/bcachefs-kmod.sysext/create.sh
+++ b/bcachefs-kmod.sysext/create.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# vim: et ts=2 syn=bash
+#
+# bcachefs kernel module system extension.
+#
+# bcachefs was removed from mainline in Linux 6.18 (September 2025) — the
+# in-tree code was marked stale and replaced by an out-of-tree DKMS module
+# maintained by Kent Overstreet in koverstreet/bcachefs-tools. This sysext
+# builds that DKMS module against a specific Flatcar release's kernel and
+# packages the resulting bcachefs.ko for merge onto a matching host.
+#
+# The build runs inside Flatcar's own SDK container image
+# (ghcr.io/flatcar/flatcar-sdk-all:<flatcar-release>), which ships the exact
+# kernel source Flatcar was built with — no need to fetch a vanilla kernel,
+# reconstruct .config, or manually run modules_prepare. The DKMS harness in
+# bcachefs-tools/dkms/ handles the out-of-tree build.
+#
+# This sysext is NOT part of the bakery's automated release matrix: a single
+# build pins (bcachefs revision, Flatcar release/kernel) and the resulting
+# .ko only loads on the exact matching kernel. Auto-updating via
+# systemd-sysupdate would silently break on kernel bumps, so the sysext is
+# not listed in release_build_versions.txt for `latest` scanning.
+
+RELOAD_SERVICES_ON_MERGE="false"
+
+function list_available_versions() {
+  # Kernel and userspace bcachefs sources both live in bcachefs-tools now;
+  # tag list here is what feeds `bakery.sh list bcachefs-kmod`.
+  list_github_tags "koverstreet" "bcachefs-tools"
+}
+# --
+
+function populate_sysext_root() {
+  local sysextroot="$1"
+  local arch="$2"
+  local version="$3"
+
+  local flatcar_release
+  flatcar_release="$(get_optional_param "flatcar-release" "stable" "$@")"
+
+  # Resolve channel names to a specific release version; leave numeric
+  # release versions untouched. The SDK container is tagged by release
+  # version so we need the concrete number below.
+  case "${flatcar_release}" in
+    alpha|beta|stable|lts)
+      flatcar_release="$(curl -fsSL --retry-delay 1 --retry 60 \
+        --retry-connrefused --retry-max-time 60 --connect-timeout 20 \
+        https://www.flatcar.org/releases-json/releases.json \
+        | jq -r --arg ch "$flatcar_release" '
+            to_entries[]
+            | select(.value.channel == $ch)
+            | .key
+            | capture("^(?<v>[0-9]+\\.[0-9]+\\.[0-9]+)").v' \
+        | sort -Vr | head -n1)"
+      [ -n "${flatcar_release}" ] || {
+        echo "ERROR: could not resolve channel to a Flatcar release" >&2
+        exit 1
+      }
+      ;;
+  esac
+
+  # Flatcar's SDK container is published only for amd64. Cross-compilation
+  # for arm64 targets would require driving the SDK's board-selection
+  # machinery from build.sh — punting on that for now.
+  if [ "${arch}" != "x86-64" ] ; then
+    echo "ERROR: bcachefs-kmod currently only supports --arch x86-64;" \
+         "the Flatcar SDK container is not published for other arches." >&2
+    exit 1
+  fi
+
+  announce "Building bcachefs-kmod ${version} against Flatcar ${flatcar_release} for ${arch}"
+
+  local user_group="$(id -u):$(id -g)"
+
+  cp "${scriptroot}/bcachefs-kmod.sysext/build.sh" .
+
+  docker run --rm -i \
+    -v "$(pwd)":/install_root \
+    --platform linux/amd64 \
+    --pull always \
+    "ghcr.io/flatcar/flatcar-sdk-all:${flatcar_release}" \
+      /install_root/build.sh "${version}" "${user_group}"
+
+  cp -aR usr "${sysextroot}"/
+}
+# --
+
+function populate_sysext_root_options() {
+  echo "  --flatcar-release <version|channel>"
+  echo "                    Flatcar release to build the module for."
+  echo "                    Accepts a release version (e.g. '4230.2.0') or a"
+  echo "                    channel name ('alpha', 'beta', 'stable', 'lts');"
+  echo "                    channel names resolve to that channel's current"
+  echo "                    release. This value is used as the tag for the"
+  echo "                    ghcr.io/flatcar/flatcar-sdk-all build container."
+  echo "                    Default: 'stable'."
+}
+# --

--- a/bcachefs-kmod.sysext/files/usr/lib/modules-load.d/bcachefs.conf
+++ b/bcachefs-kmod.sysext/files/usr/lib/modules-load.d/bcachefs.conf
@@ -1,0 +1,1 @@
+bcachefs

--- a/bcachefs-tools.sysext/build.sh
+++ b/bcachefs-tools.sysext/build.sh
@@ -1,0 +1,96 @@
+#!/bin/ash
+#
+# Build script helper for the bcachefs-tools sysext.
+# Runs inside an ephemeral Alpine container.
+# Builds the bcachefs userspace utilities and exports them to a
+# bind-mounted volume at /install_root.
+#
+set -euo pipefail
+
+version="$1"
+export_user_group="$2"
+
+# Build deps. bcachefs-tools is a Rust+C project orchestrated by Make,
+# linking against a fair pile of system libraries (sodium, urcu, blkid,
+# keyutils, zlib, zstd, lz4, aio, udev, attr).
+#
+# We try a static build first (matches the scx.sysext precedent). If a
+# given dep does not ship a static archive on Alpine, the corresponding
+# *-static package add will fail loudly during CI and we can swap to a
+# dynamic build that bundles the .so's under /usr/lib64.
+apk add --no-cache \
+  clang \
+  clang-dev \
+  clang-libclang \
+  llvm \
+  lld \
+  bpftool \
+  libbpf-dev \
+  elfutils-dev \
+  pkgconf \
+  curl \
+  git \
+  make \
+  gcc \
+  musl-dev \
+  linux-headers \
+  ca-certificates \
+  cargo \
+  rust \
+  zlib-dev          zlib-static \
+  zstd-dev          zstd-static \
+  lz4-dev           lz4-static \
+  libsodium-dev     libsodium-static \
+  liburcu-dev \
+  util-linux-dev \
+  keyutils-dev \
+  libaio-dev \
+  eudev-dev \
+  attr-dev
+
+cd /opt
+git clone https://github.com/koverstreet/bcachefs-tools.git \
+  --depth 1 --branch "${version}" --single-branch
+cd /opt/bcachefs-tools
+
+# Force static linking for Rust and C deps. Same env-var pattern as
+# scx.sysext — CARGO_BUILD_TARGET forces the per-triple variants to take
+# effect over the generic CARGO_* ones.
+target="$(rustc -vV | sed -n 's/^host: //p')"
+export CARGO_BUILD_TARGET="${target}"
+TARGET="$(echo "${target}" | tr a-z- A-Z_)"
+export CARGO_TARGET_${TARGET}_RUSTFLAGS="-C target-feature=+crt-static -C link-arg=-static"
+export CARGO_TARGET_${TARGET}_PKG_CONFIG_ALL_STATIC=1
+
+# Build + install. Flatcar's /usr/sbin is a symlink to /usr/bin, and a
+# sysext shipping /usr/sbin would clobber the symlink at merge — so we
+# redirect every sbin destination to /usr/bin. Skip the udev rules and
+# initramfs hooks; the sysext only ships userspace tools.
+make -j"$(nproc)" \
+  PREFIX=/usr \
+  bcachefs
+
+make install \
+  DESTDIR=/install_root \
+  PREFIX=/usr \
+  ROOT_SBINDIR=/usr/bin \
+  PKGCONFIG_LIBDIR=/usr/lib/pkgconfig \
+  INITRAMFS_DIR= \
+  UDEVLIBDIR=
+
+# Belt and suspenders: if any binary still landed under /usr/sbin
+# (older Makefile variants), relocate it before it ships.
+if [ -d /install_root/usr/sbin ]; then
+  mkdir -p /install_root/usr/bin
+  mv /install_root/usr/sbin/* /install_root/usr/bin/ 2>/dev/null || true
+  rmdir /install_root/usr/sbin
+fi
+
+# Drop dev/man files — pure noise in a sysext.
+rm -rf /install_root/usr/include \
+       /install_root/usr/lib/pkgconfig \
+       /install_root/usr/share/man \
+       /install_root/usr/share/doc
+
+chown -R "${export_user_group}" /install_root
+chmod -R u+rwX,go+rX /install_root

--- a/bcachefs-tools.sysext/create.sh
+++ b/bcachefs-tools.sysext/create.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# vim: et ts=2 syn=bash
+#
+# bcachefs-tools system extension.
+# Provides bcachefs userspace utilities (bcachefs, mkfs.bcachefs,
+# fsck.bcachefs, mount.bcachefs, ...).
+#
+# The bcachefs kernel module itself is shipped separately by the
+# bcachefs-kmod sysext (one build per Flatcar kernel version).
+
+RELOAD_SERVICES_ON_MERGE="false"
+
+function list_available_versions() {
+  # Upstream publishes git tags (vX.Y.Z) but not GitHub Releases,
+  # so we have to read tags rather than releases.
+  list_github_tags "koverstreet" "bcachefs-tools"
+}
+# --
+
+function populate_sysext_root() {
+  local sysextroot="$1"
+  local arch="$2"
+  local version="$3"
+
+  local img_arch="$(arch_transform 'x86-64' 'amd64' "$arch")"
+  img_arch="$(arch_transform 'arm64' 'arm64/v8' "$img_arch")"
+
+  local image="docker.io/alpine:latest"
+
+  announce "Building bcachefs-tools ${version} for ${arch}"
+
+  local user_group="$(id -u):$(id -g)"
+
+  cp "${scriptroot}/bcachefs-tools.sysext/build.sh" .
+
+  docker run --rm \
+    -i \
+    -v "$(pwd)":/install_root \
+    --platform "linux/${img_arch}" \
+    --pull always \
+    ${image} \
+      /install_root/build.sh "${version}" "${user_group}"
+
+  cp -aR usr "${sysextroot}"/
+}
+# --

--- a/bcachefs-tools.sysext/test.sh
+++ b/bcachefs-tools.sysext/test.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# vim: et ts=2 syn=bash
+#
+# Test script for bcachefs-tools sysext.
+#

--- a/docs/bcachefs-kmod.md
+++ b/docs/bcachefs-kmod.md
@@ -1,0 +1,87 @@
+# bcachefs-kmod sysext
+
+This sysext ships a prebuilt `bcachefs.ko` — the [bcachefs](https://bcachefs.org/) filesystem kernel module — for a **specific Flatcar release's kernel**. It is the companion to the [`bcachefs-tools`](bcachefs-tools.md) userspace sysext.
+
+bcachefs was mainlined in Linux 6.7 and subsequently [removed from mainline in Linux 6.18](https://lwn.net/Articles/1040120/) (September 2025). Kent Overstreet now ships it as an out-of-tree DKMS module maintained inside [`koverstreet/bcachefs-tools`](https://github.com/koverstreet/bcachefs-tools) under `dkms/`. That makes this sysext **required** on every Flatcar release if you want to actually use bcachefs — the `bcachefs-tools` sysext alone only gives you the userspace utilities, not a working filesystem.
+
+The current DKMS harness requires **Linux ≥ 6.16** (`BUILD_EXCLUSIVE_KERNEL_MIN` in `dkms.conf.in`). Older Flatcar releases (e.g., anything still on the 6.6 LTS kernel) can't be targeted.
+
+Only `--arch x86-64` is supported today: the `flatcar-sdk-all` container is amd64-only, and driving the SDK's board machinery to cross-compile an arm64 module hasn't been wired up yet.
+
+> **Warning — on-disk format stability.** bcachefs is still pre-1.0. Pin a known-good `bcachefs-tools` version against a known-good kernel before putting data you care about on it.
+
+## Two-axis versioning
+
+Unlike other bakery sysexts, a single build of `bcachefs-kmod` is pinned to **two** dimensions:
+
+1. The **bcachefs revision** (a `koverstreet/bcachefs-tools` tag such as `v1.25.2`).
+2. The **Flatcar release** whose kernel the `.ko` is built against (e.g. `4230.2.0`).
+
+Because the resulting `.ko` will only load on the exact matching kernel, this sysext is **not part of the bakery's automated release matrix and is not eligible for `systemd-sysupdate` auto-updates.** Sysext filenames encode both axes:
+
+```
+bcachefs-kmod-<bcachefs-tag>-flatcar-<release>-<arch>.raw
+```
+
+A kernel bump on the host (any Flatcar upgrade) requires rebuilding the sysext against the new release.
+
+## Building
+
+Build against a specific Flatcar release:
+
+```sh
+./bakery.sh create bcachefs-kmod v1.25.2 --flatcar-release 4230.2.0
+```
+
+Or track a channel's current tip:
+
+```sh
+./bakery.sh create bcachefs-kmod v1.25.2 --flatcar-release stable
+./bakery.sh create bcachefs-kmod v1.25.2 --flatcar-release lts
+```
+
+`--flatcar-release` accepts either a release version (e.g. `4230.2.0`) or a channel name (`alpha`, `beta`, `stable`, `lts`) — channel names resolve to that channel's current release at build time.
+
+Under the hood the build:
+
+1. Pulls Flatcar's own SDK container `ghcr.io/flatcar/flatcar-sdk-all:<flatcar-release>`, which ships the exact kernel source Flatcar was built with.
+2. `emerge`s `sys-kernel/coreos-modules` inside the SDK; that pulls `coreos-sources` as a dependency, drops Flatcar's kernel source at `/usr/src/linux-<kver>-flatcar`, and runs `modules_prepare` so the tree is build-usable.
+3. Clones `koverstreet/bcachefs-tools` at the requested tag and runs its `dkms/Makefile` (`make -C .../dkms KDIR=/usr/src/linux`), the same harness Arch, Debian/Ubuntu, and NixOS drive.
+4. Installs the resulting `bcachefs.ko` to `/usr/lib/modules/<kver>-flatcar/updates/` with `depmod` metadata and a `modules-load.d` entry so the module loads on boot.
+
+## Usage
+
+Provision the sysext with a Butane snippet. The example pins `bcachefs-tools` v1.25.2 built against Flatcar 4230.2.0, x86-64. Substitute values to match your host.
+
+```yaml
+variant: flatcar
+version: 1.0.0
+
+storage:
+  files:
+    - path: /opt/extensions/bcachefs-kmod/bcachefs-kmod-v1.25.2-flatcar-4230.2.0-x86-64.raw
+      mode: 0644
+      contents:
+        source: https://extensions.flatcar.org/extensions/bcachefs-kmod-v1.25.2-flatcar-4230.2.0-x86-64.raw
+  links:
+    - target: /opt/extensions/bcachefs-kmod/bcachefs-kmod-v1.25.2-flatcar-4230.2.0-x86-64.raw
+      path: /etc/extensions/bcachefs-kmod.raw
+      hard: false
+```
+
+Note the absence of `systemd-sysupdate` wiring — see above.
+
+Typically you will provision `bcachefs-kmod` together with `bcachefs-tools`. See [`bcachefs-tools`](bcachefs-tools.md) for the userspace side.
+
+## Smoke test
+
+After provisioning, verify the module is loaded and the filesystem is available:
+
+```sh
+uname -r                              # confirm the host kernel matches
+modprobe bcachefs
+grep bcachefs /proc/filesystems
+bcachefs version
+```
+
+If `modprobe` fails with `Exec format error` or `unknown symbol`, the sysext was built against a different Flatcar release than the one running on the host. Rebuild against the release reported by `/etc/os-release`.

--- a/docs/bcachefs-tools.md
+++ b/docs/bcachefs-tools.md
@@ -1,0 +1,62 @@
+# bcachefs-tools sysext
+
+This sysext ships the [bcachefs userspace utilities](https://github.com/koverstreet/bcachefs-tools):
+
+- `bcachefs` — the unified CLI (subcommand-based: `bcachefs format`, `bcachefs fsck`, `bcachefs mount`, ...).
+- `mkfs.bcachefs`, `fsck.bcachefs`, `mount.bcachefs`, `dump.bcachefs` — argv[0] dispatchers to the unified CLI, so `/usr/bin/mount` automatically picks `mount.bcachefs` up for `-t bcachefs`.
+
+bcachefs is out-of-tree only, so on its own this sysext is not enough to actually use bcachefs — you also need the `bcachefs-kmod` sysext, which ships a prebuilt `bcachefs.ko` for a specific Flatcar release's kernel.
+
+> **Warning — on-disk format stability.** bcachefs is still pre-1.0 from an on-disk-format perspective. Pin a known-good `bcachefs-tools` version against a known-good kernel before putting data you care about on it.
+
+## Usage
+
+Download and merge the sysext at provisioning time using the Butane snippet below. The snippet pins `bcachefs-tools` v1.25.2 for x86-64; substitute the version and arch you want.
+
+See the [bcachefs-tools release page](https://github.com/flatcar/sysext-bakery/releases/tag/bcachefs-tools) for all versions available.
+
+```yaml
+variant: flatcar
+version: 1.0.0
+
+storage:
+  files:
+    - path: /opt/extensions/bcachefs-tools/bcachefs-tools-v1.25.2-x86-64.raw
+      mode: 0644
+      contents:
+        source: https://extensions.flatcar.org/extensions/bcachefs-tools-v1.25.2-x86-64.raw
+    - path: /etc/sysupdate.bcachefs-tools.d/bcachefs-tools.conf
+      contents:
+        source: https://extensions.flatcar.org/extensions/bcachefs-tools.conf
+    - path: /etc/sysupdate.d/noop.conf
+      contents:
+        source: https://extensions.flatcar.org/extensions/noop.conf
+  links:
+    - target: /opt/extensions/bcachefs-tools/bcachefs-tools-v1.25.2-x86-64.raw
+      path: /etc/extensions/bcachefs-tools.raw
+      hard: false
+systemd:
+  units:
+    - name: systemd-sysupdate.timer
+      enabled: true
+    - name: systemd-sysupdate.service
+      dropins:
+        - name: bcachefs-tools.conf
+          contents: |
+            [Service]
+            ExecStartPre=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/bcachefs-tools.raw > /tmp/bcachefs-tools"
+            ExecStartPre=/usr/lib/systemd/systemd-sysupdate -C bcachefs-tools update
+            ExecStartPost=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/bcachefs-tools.raw > /tmp/bcachefs-tools-new"
+            ExecStartPost=/usr/bin/sh -c "if ! cmp --silent /tmp/bcachefs-tools /tmp/bcachefs-tools-new; then touch /run/reboot-required; fi"
+```
+
+## Smoke test
+
+After provisioning, verify the tools are merged and the kernel module is available:
+
+```sh
+bcachefs version
+modprobe bcachefs && grep bcachefs /proc/filesystems
+mkfs.bcachefs /dev/<device>
+mount -t bcachefs /dev/<device> /mnt/data
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -60,6 +60,7 @@ Check out documentation on specific extensions at the navigation menu on the lef
 
 |    Extension     | Availability | Versions available |
 | ---------------- | ------------ | ------------- |
+| `bcachefs-kmod`  |  build script | see [bcachefs-kmod](bcachefs-kmod.md) — one build per (bcachefs revision × Flatcar release) |
 | `bcachefs-tools` |  released    | [bcachefs-tools versions](https://github.com/flatcar/sysext-bakery/releases/tag/bcachefs-tools) |
 | `bird`           |  released    | [bird versions](https://github.com/flatcar/sysext-bakery/releases/tag/bird) |
 | `chrony`         |  released    | [chrony versions](https://github.com/flatcar/sysext-bakery/releases/tag/chrony) |

--- a/docs/index.md
+++ b/docs/index.md
@@ -60,6 +60,7 @@ Check out documentation on specific extensions at the navigation menu on the lef
 
 |    Extension     | Availability | Versions available |
 | ---------------- | ------------ | ------------- |
+| `bcachefs-tools` |  released    | [bcachefs-tools versions](https://github.com/flatcar/sysext-bakery/releases/tag/bcachefs-tools) |
 | `bird`           |  released    | [bird versions](https://github.com/flatcar/sysext-bakery/releases/tag/bird) |
 | `chrony`         |  released    | [chrony versions](https://github.com/flatcar/sysext-bakery/releases/tag/chrony) |
 | `cilium`         |  released    | [cilium versions](https://github.com/flatcar/sysext-bakery/releases/tag/cilium) |

--- a/release_build_versions.txt
+++ b/release_build_versions.txt
@@ -17,6 +17,8 @@
 # to build the latest (i.e. highest version number) release(s).
 #
 
+bcachefs-tools latest
+
 chrony 4.8
 chrony latest
 


### PR DESCRIPTION
## Summary
Companion to #234 (the \`bcachefs-tools\` sysext) — this PR adds \`bcachefs-kmod\`, which ships a prebuilt \`bcachefs.ko\` for a specific Flatcar release's kernel.

- Version listing tracks \`koverstreet/bcachefs-tools\` tags — the kernel-side bcachefs source is versioned alongside userspace tools.
- Optional \`--flatcar-release <version|channel>\` parameter (default \`stable\`) picks which Flatcar release's kernel to build against. Channel names (\`alpha\`, \`beta\`, \`stable\`, \`lts\`) resolve to the current release on that channel.
- \`build.sh\` runs inside an ephemeral Alpine container and:
  1. Resolves the Flatcar release → kernel version via \`flatcar/scripts@<channel>-<release>\`'s kernel Manifest.
  2. Fetches vanilla \`linux-<kver>.tar.xz\` from \`cdn.kernel.org\` and applies Flatcar's kernel config.
  3. Overlays \`fs/bcachefs/\` from \`koverstreet/bcachefs\` at the requested tag onto the vanilla tree.
  4. Builds \`bcachefs.ko\` out-of-tree via \`make M=fs/bcachefs modules\`.
  5. Installs to \`/usr/lib/modules/<kver>/updates/bcachefs.ko\` with \`depmod\` metadata, plus a \`modules-load.d/bcachefs.conf\` for auto-load on boot.

## Deliberately not in the automated release matrix
A single build pins **two** dimensions (bcachefs revision × Flatcar release/kernel), so:
- Not added to \`release_build_versions.txt\` — the \`latest\` scanner would produce a single output per bcachefs tag, which doesn't map to the (bcachefs × Flatcar release) matrix this sysext lives in.
- Not eligible for \`systemd-sysupdate\` auto-updates — the \`.ko\` will only load on the exact matching kernel, so silently rolling forward on a kernel bump would break \`modprobe\`.
- Sysext filename encodes both axes: \`bcachefs-kmod-<bcachefs-tag>-flatcar-<release>-<arch>.raw\`.

Users rebuild against the new release on every Flatcar upgrade; \`docs/bcachefs-kmod.md\` calls this out.

## Stacking / merge order
This branch is stacked on \`add-bcachefs-tools-sysext\` (#234) because \`docs/bcachefs-kmod.md\` links to \`bcachefs-tools.md\` and the two sysexts travel together semantically. Please merge #234 first; happy to rebase this onto \`main\` afterwards if needed.

## Known caveats worth flagging in review
- Flatcar's kernel config path in \`flatcar/scripts\` has shifted across releases; \`build.sh\` tries a few well-known locations, but the first CI runs may need path adjustments. The candidate list is centralised at the top of \`build.sh\` for easy tweaks.
- The out-of-tree overlay approach assumes bcachefs source at the requested tag compiles against the vanilla kernel version Flatcar ships. If bcachefs upstream has drifted past that kernel, users need to pick a bcachefs tag that was current when the Flatcar release was cut.

## Test plan
- [ ] \`./bakery.sh list bcachefs-kmod\` returns bcachefs-tools upstream tags.
- [ ] \`./bakery.sh create bcachefs-kmod v1.25.2 --flatcar-release stable\` produces a sysext.
- [ ] \`./bakery.sh create bcachefs-kmod v1.25.2 --flatcar-release lts\` produces a sysext.
- [ ] \`./bakery.sh create bcachefs-kmod v1.25.2 --flatcar-release stable --arch arm64\` produces an arm64 sysext.
- [ ] On a Flatcar release that matches the \`--flatcar-release\` used: \`modprobe bcachefs && grep bcachefs /proc/filesystems\` succeeds after merge; loading fails with \`Exec format error\` on a mismatched Flatcar release, and the doc guides the user to rebuild.