### PR TITLE
scx: install openssl-dev for the build container

### DIFF
--- a/scx.sysext/build.sh
+++ b/scx.sysext/build.sh
@@ -23,6 +23,8 @@ apk add --no-cache \
   zstd-dev \
   zstd-static \
   libseccomp-dev \
+  openssl-dev \
+  openssl-libs-static \
   cargo \
   rust \
   pkgconf \


### PR DESCRIPTION
## Summary
scx v1.1.2 fails to build in the daily GH action because a crate now transitively depends on `openssl-sys`, and the Alpine build container doesn't install openssl:

```
Could not find openssl via pkg-config:
...
Package openssl was not found in the pkg-config search path.
```

Add `openssl-dev` (so pkg-config finds `openssl.pc`) and `openssl-libs-static` (so the fully-static link succeeds under `CARGO_TARGET_..._PKG_CONFIG_ALL_STATIC=1`) to the `apk add` list.

Fixes #236.

## Test plan
- [ ] `./bakery.sh create scx v1.1.2` completes and produces `scx.raw`.
- [ ] Daily build workflow succeeds on the next run.