### PR TITLE
consul: create the consul user and data dir via sysusers/tmpfiles

### DIFF
--- a/consul.sysext/files/usr/lib/sysusers.d/consul.conf
+++ b/consul.sysext/files/usr/lib/sysusers.d/consul.conf
@@ -1,0 +1,1 @@
+u consul - "HashiCorp Consul" /opt/consul /sbin/nologin

--- a/consul.sysext/files/usr/lib/tmpfiles.d/10-consul.conf
+++ b/consul.sysext/files/usr/lib/tmpfiles.d/10-consul.conf
@@ -1,0 +1,1 @@
+d /opt/consul 0700 consul consul - -


### PR DESCRIPTION
The consul sysext ships `consul.service` with `User=consul`/`Group=consul` but — unlike the `vault`, `haproxy`, and `coder` sysexts — provides no `sysusers.d` entry to create that user and no `tmpfiles.d` entry for its data directory. As a result the unit fails to start out of the box once a config is supplied; systemd cannot resolve the user:

```
consul.service: Failed to determine user credentials: No such process
consul.service: Failed at step USER spawning /usr/bin/consul: No such process
```

This adds the missing provisioning, mirroring `vault.sysext`:

- `usr/lib/sysusers.d/consul.conf` — creates the `consul` system user + group
- `usr/lib/tmpfiles.d/10-consul.conf` — creates `/opt/consul` (the `data_dir` in the shipped `consul.hcl`) owned by `consul:consul`

Both are baked into the sysext via the existing `files/` tree, so no `create.sh` change is needed. (`*.conf` is force-added past `.gitignore`, the same as the existing `vault.sysext` `.conf` files.)

Verified on Flatcar stable: with these files `consul.service` starts cleanly given a user-supplied `/etc/consul.d/consul.hcl`; without them it fails at the `USER` step.
