### PR TITLE
cni-plugins: new sysext for the containernetworking reference plugins

### DIFF
--- a/cni-plugins.sysext/create.sh
+++ b/cni-plugins.sysext/create.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# vim: et ts=2 syn=bash
+#
+# CNI reference plugins system extension.
+#
+# Ships the upstream containernetworking/plugins binaries (bridge, host-local,
+# portmap, firewall, loopback, macvlan, ptp, …) under /opt/cni/bin — the
+# default plugin directory searched by Nomad (cni_path) and usable by any CNI
+# runtime (Consul Connect, container runtimes, …). There is no service; the
+# binaries are invoked by the CNI consumer.
+#
+
+RELOAD_SERVICES_ON_MERGE="false"
+
+function list_available_versions() {
+  list_github_releases "containernetworking" "plugins"
+}
+# --
+
+function populate_sysext_root() {
+  local sysextroot="$1"
+  local arch="$2"
+  local version="$3"
+
+  # Upstream artefact names use "amd64" / "arm64".
+  local rel_arch
+  rel_arch="$(arch_transform 'x86-64' 'amd64' "$arch")"
+
+  local tarball="cni-plugins-linux-${rel_arch}-${version}.tgz"
+  local base_url="https://github.com/containernetworking/plugins/releases/download/${version}"
+
+  # Upstream publishes a .sha256 alongside each tarball.
+  curl --remote-name -fsSL "${base_url}/${tarball}"
+  curl --remote-name -fsSL "${base_url}/${tarball}.sha256"
+  sha256sum -c "${tarball}.sha256"
+
+  # The tarball expands flat (bridge, host-local, portmap, …) into the target.
+  mkdir -p "${sysextroot}/opt/cni/bin"
+  tar --force-local -xzf "${tarball}" -C "${sysextroot}/opt/cni/bin"
+}
+# --

--- a/cni-plugins.sysext/create.sh
+++ b/cni-plugins.sysext/create.sh
@@ -4,10 +4,12 @@
 # CNI reference plugins system extension.
 #
 # Ships the upstream containernetworking/plugins binaries (bridge, host-local,
-# portmap, firewall, loopback, macvlan, ptp, …) under /opt/cni/bin — the
-# default plugin directory searched by Nomad (cni_path) and usable by any CNI
-# runtime (Consul Connect, container runtimes, …). There is no service; the
-# binaries are invoked by the CNI consumer.
+# portmap, firewall, loopback, macvlan, ptp, …) under /usr/libexec/cni, the
+# same location nerdctl.sysext uses for its bundled copy. Upstream's de-facto
+# default is /opt/cni/bin, but on Flatcar /opt is expected to be writable and a
+# sysext would make it read-only, so consumers are pointed at /usr instead (see
+# docs/cni-plugins.md). There is no service; the binaries are invoked by the
+# CNI consumer.
 #
 
 RELOAD_SERVICES_ON_MERGE="false"
@@ -35,7 +37,7 @@ function populate_sysext_root() {
   sha256sum -c "${tarball}.sha256"
 
   # The tarball expands flat (bridge, host-local, portmap, …) into the target.
-  mkdir -p "${sysextroot}/opt/cni/bin"
-  tar --force-local -xzf "${tarball}" -C "${sysextroot}/opt/cni/bin"
+  mkdir -p "${sysextroot}/usr/libexec/cni"
+  tar --force-local -xzf "${tarball}" -C "${sysextroot}/usr/libexec/cni"
 }
 # --

--- a/docs/cni-plugins.md
+++ b/docs/cni-plugins.md
@@ -1,0 +1,50 @@
+# CNI plugins sysext
+
+This sysext ships the upstream
+[containernetworking/plugins](https://github.com/containernetworking/plugins)
+reference CNI plugins (`bridge`, `host-local`, `portmap`, `firewall`,
+`loopback`, `macvlan`, `ptp`, `vlan`, `bandwidth`, …) under **`/opt/cni/bin`** —
+the default plugin directory searched by Nomad's `cni_path`, and usable by any
+CNI consumer (Consul Connect, container runtimes, …).
+
+The binaries are downloaded from the upstream release tarball and their
+published `.sha256` is verified during the build. There is no service unit; the
+plugins are invoked by whatever CNI runtime is configured on the host.
+
+## Why `/opt/cni/bin`
+
+`/opt/cni/bin` is the de-facto default CNI plugin directory (e.g. Nomad's
+`cni_path` default). On Flatcar `/opt` is a read-only sysext overlay, so a
+sysext is a natural way to provide these binaries there without a writable-path
+workaround — the plugins simply appear at `/opt/cni/bin` once the sysext is
+merged, and Nomad's `bridge` network mode works with no extra configuration.
+
+## Usage
+
+Download and merge the sysext at provisioning time using the Butane snippet
+below (x86-64 shown; see the release metadata for available versions/arches).
+
+```yaml
+variant: flatcar
+version: 1.0.0
+
+storage:
+  files:
+    - path: /opt/extensions/cni-plugins/cni-plugins-v1.9.1-x86-64.raw
+      mode: 0644
+      contents:
+        source: https://extensions.flatcar.org/extensions/cni-plugins-v1.9.1-x86-64.raw
+    - path: /etc/sysupdate.cni-plugins.d/cni-plugins.conf
+      contents:
+        source: https://extensions.flatcar.org/extensions/cni-plugins.conf
+    - path: /etc/sysupdate.d/noop.conf
+      contents:
+        source: https://extensions.flatcar.org/extensions/noop.conf
+  links:
+    - path: /etc/extensions/cni-plugins.raw
+      target: /opt/extensions/cni-plugins/cni-plugins-v1.9.1-x86-64.raw
+```
+
+Check the metadata releases at
+https://github.com/flatcar/sysext-bakery/releases/tag/cni-plugins for a list of
+all versions available in the bakery.

--- a/docs/cni-plugins.md
+++ b/docs/cni-plugins.md
@@ -24,6 +24,12 @@ merged, and Nomad's `bridge` network mode works with no extra configuration.
 Download and merge the sysext at provisioning time using the Butane snippet
 below (x86-64 shown; see the release metadata for available versions/arches).
 
+The snippet also enables automated updates via systemd-sysupdate. There is no
+service to restart, so a new version is simply staged and the merged sysext is
+refreshed in place — CNI consumers pick up the updated binaries on their next
+invocation, with no reboot required. You can deactivate updates by changing
+`enabled: true` to `enabled: false` in `systemd-sysupdate.timer`.
+
 ```yaml
 variant: flatcar
 version: 1.0.0
@@ -43,6 +49,20 @@ storage:
   links:
     - path: /etc/extensions/cni-plugins.raw
       target: /opt/extensions/cni-plugins/cni-plugins-v1.9.1-x86-64.raw
+      hard: false
+systemd:
+  units:
+    - name: systemd-sysupdate.timer
+      enabled: true
+    - name: systemd-sysupdate.service
+      dropins:
+        - name: cni-plugins.conf
+          contents: |
+            [Service]
+            ExecStartPre=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/cni-plugins.raw > /run/cni-plugins"
+            ExecStartPre=/usr/lib/systemd/systemd-sysupdate -C cni-plugins update
+            ExecStartPost=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/cni-plugins.raw > /run/cni-plugins-new"
+            ExecStartPost=/usr/bin/sh -c "if ! cmp --silent /run/cni-plugins /run/cni-plugins-new; then systemd-sysext refresh; fi"
 ```
 
 Check the metadata releases at

--- a/docs/cni-plugins.md
+++ b/docs/cni-plugins.md
@@ -3,21 +3,45 @@
 This sysext ships the upstream
 [containernetworking/plugins](https://github.com/containernetworking/plugins)
 reference CNI plugins (`bridge`, `host-local`, `portmap`, `firewall`,
-`loopback`, `macvlan`, `ptp`, `vlan`, `bandwidth`, …) under **`/opt/cni/bin`** —
-the default plugin directory searched by Nomad's `cni_path`, and usable by any
-CNI consumer (Consul Connect, container runtimes, …).
+`loopback`, `macvlan`, `ptp`, `vlan`, `bandwidth`, …) under
+**`/usr/libexec/cni`**, for use by any CNI consumer (Nomad, Consul Connect,
+container runtimes, …).
 
 The binaries are downloaded from the upstream release tarball and their
 published `.sha256` is verified during the build. There is no service unit; the
 plugins are invoked by whatever CNI runtime is configured on the host.
 
-## Why `/opt/cni/bin`
+## Why `/usr/libexec/cni` and not `/opt/cni/bin`
 
-`/opt/cni/bin` is the de-facto default CNI plugin directory (e.g. Nomad's
-`cni_path` default). On Flatcar `/opt` is a read-only sysext overlay, so a
-sysext is a natural way to provide these binaries there without a writable-path
-workaround — the plugins simply appear at `/opt/cni/bin` once the sysext is
-merged, and Nomad's `bridge` network mode works with no extra configuration.
+`/opt/cni/bin` is the de-facto upstream default, but on Flatcar `/opt` is
+expected to be writable and shipping a sysext into it would silently turn it
+read-only. The plugins therefore go under `/usr`, which is already read-only on
+Flatcar, so no expectation is violated. This matches `nerdctl.sysext`, which
+puts its optional bundled copy in the same place.
+
+Consumers that default to `/opt/cni/bin` need to be pointed at the new path.
+For Nomad, set `cni_path` in the client block:
+
+```hcl
+client {
+  cni_path = "/usr/libexec/cni"
+}
+```
+
+containerd takes it as `bin_dir` in the CNI section of `config.toml`, and
+CRI-O as `plugin_dirs` in `crio.network`.
+
+If you would rather keep the upstream default working unchanged, create the
+symlink yourself at provisioning time — `/opt` stays writable, so this does not
+need a sysext:
+
+```yaml
+storage:
+  links:
+    - path: /opt/cni/bin
+      target: /usr/libexec/cni
+      hard: false
+```
 
 ## Usage
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -64,6 +64,7 @@ Check out documentation on specific extensions at the navigation menu on the lef
 | `chrony`         |  released    | [chrony versions](https://github.com/flatcar/sysext-bakery/releases/tag/chrony) |
 | `cilium`         |  released    | [cilium versions](https://github.com/flatcar/sysext-bakery/releases/tag/cilium) |
 | `cloud-hypervisor` |  released  | [cloud-hypervisor versions](https://github.com/flatcar/sysext-bakery/releases/tag/cloud-hypervisor) |
+| `cni-plugins`    |  released    | [cni-plugins versions](https://github.com/flatcar/sysext-bakery/releases/tag/cni-plugins) |
 | `coder`          |  released    | [coder versions](https://github.com/flatcar/sysext-bakery/releases/tag/coder) |
 | `consul`          |  released    | [consul versions](https://github.com/flatcar/sysext-bakery/releases/tag/consul) |
 | `containerd`     |  released    | [containerd versions](https://github.com/flatcar/sysext-bakery/releases/tag/containerd) |

--- a/release_build_versions.txt
+++ b/release_build_versions.txt
@@ -121,3 +121,5 @@ dataplaneapi latest
 
 vault 1.20.0
 vault latest
+
+cni-plugins latest


### PR DESCRIPTION
Adds a `cni-plugins` sysext shipping the upstream [containernetworking/plugins](https://github.com/containernetworking/plugins) reference CNI plugins under `/opt/cni/bin`.

## Why

`/opt/cni/bin` is the de-facto default CNI plugin directory. Nomad's `bridge` network
mode (and dynamic container ports / Consul Connect) work.

## What

- `cni-plugins.sysext/create.sh` — downloads the release tarball for the target arch, verifies the upstream-published `.sha256`, extracts into `/opt/cni/bin`.
- `docs/cni-plugins.md` — usage + butane snippet.
- `release_build_versions.txt` — `cni-plugins latest`.

Verified on Flatcar stable that plugins at the CNI path make Nomad bridge networking + dynamic ports work.
