### PR TITLE
dataplaneapi: reload HAProxy without sudo (root unit)

### DIFF
--- a/dataplaneapi.sysext/files/usr/lib/systemd/system/dataplaneapi.service
+++ b/dataplaneapi.sysext/files/usr/lib/systemd/system/dataplaneapi.service
@@ -17,7 +17,7 @@ Restart=on-failure
 RestartSec=5
 
 # Dataplane API needs to invoke `systemctl reload haproxy.service`
-# (reload_strategy: systemd in dataplaneapi.yml), so it runs as root.
+# (reload_strategy: custom in dataplaneapi.yml), so it runs as root.
 # Drop-ins can trim this if you switch to a socket-based reload
 # strategy and grant the coordinating user access to the HAProxy
 # master socket.

--- a/dataplaneapi.sysext/files/usr/share/dataplaneapi/dataplaneapi.yml
+++ b/dataplaneapi.sysext/files/usr/share/dataplaneapi/dataplaneapi.yml
@@ -31,8 +31,11 @@ haproxy:
   haproxy_bin: /usr/bin/haproxy
   reload:
     reload_delay: 5
-    service_name: haproxy
-    reload_strategy: systemd
+    # Root unit: reload via systemctl directly. The "systemd" strategy's
+    # `sudo -n systemctl reload` fails without passwordless sudo.
+    reload_strategy: custom
+    reload_cmd: systemctl reload haproxy
+    restart_cmd: systemctl restart haproxy
 log_targets:
 - log_to: stdout
   log_level: info

--- a/dataplaneapi.sysext/files/usr/share/dataplaneapi/dataplaneapi.yml
+++ b/dataplaneapi.sysext/files/usr/share/dataplaneapi/dataplaneapi.yml
@@ -34,8 +34,8 @@ haproxy:
     # Root unit: reload via systemctl directly. The "systemd" strategy's
     # `sudo -n systemctl reload` fails without passwordless sudo.
     reload_strategy: custom
-    reload_cmd: systemctl reload haproxy
-    restart_cmd: systemctl restart haproxy
+    reload_cmd: systemctl reload haproxy.service
+    restart_cmd: systemctl restart haproxy.service
 log_targets:
 - log_to: stdout
   log_level: info

--- a/docs/dataplaneapi.md
+++ b/docs/dataplaneapi.md
@@ -58,12 +58,15 @@ frontend with mTLS, etc.).
 
 ## Privileges
 
-The unit runs as `root` because the default `reload_strategy: systemd`
-requires the API process to invoke `systemctl reload
-haproxy.service`. If you switch to a socket-based strategy (talking to
-`/run/haproxy/haproxy-master.sock` directly), drop-in a lower-privilege
-`User=`/`Group=` under `/etc/systemd/system/dataplaneapi.service.d/`
-and grant that user access to the master socket.
+The unit runs as `root` so it can invoke `systemctl reload
+haproxy.service`. The shipped config therefore uses a `custom` reload
+strategy that calls `systemctl` directly, rather than the `systemd`
+strategy's `sudo -n systemctl reload` (sudo is pointless for a root
+process and fails without a passwordless sudoers entry). If you switch to
+a socket-based strategy (talking to `/run/haproxy/haproxy-master.sock`
+directly), drop-in a lower-privilege `User=`/`Group=` under
+`/etc/systemd/system/dataplaneapi.service.d/` and grant that user access
+to the master socket.
 
 ## Usage
 


### PR DESCRIPTION
The dataplaneapi sysext ships a `dataplaneapi.yml` with
`reload_strategy: systemd`, which makes the Data Plane API shell out to
`sudo -n systemctl reload haproxy` on every config change.

But the shipped `dataplaneapi.service` runs the process as **root**, so:

- `sudo` is unnecessary, and
- `sudo -n` **fails** on hosts without a passwordless sudoers entry for root
  (e.g. Flatcar), with `exit status 1`.

A failed reload is worse than a no-op: the Data Plane API **reverts its last
working config**. In practice, e.g. Consul service-discovery backends get
created in the API model but are never applied to HAProxy — they silently
disappear, which is very hard to diagnose.

This switches the shipped config to a `custom` reload strategy that calls
`systemctl` directly (`reload_cmd`/`restart_cmd`), which works for the root
unit. Verified on Flatcar stable: with `systemd`+sudo the reloads fail and
Consul-discovered backends never load; with `custom` they apply correctly.
Also updates the Privileges section of the docs.
