### PR TITLE
Add node_exporter as sysext

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -82,6 +82,7 @@ Check out documentation on specific extensions at the navigation menu on the lef
 | `llamaedge`      |  released    | [llamaedge versions](https://github.com/flatcar/sysext-bakery/releases/tag/llamaedge) |
 | `nebula`         |  released    | [nebula versions](https://github.com/flatcar/sysext-bakery/releases/tag/nebula) |
 | `nerdctl`        |  released    | [nerdctl versions](https://github.com/flatcar/sysext-bakery/releases/tag/nerdctl) |
+| `node_exporter`  |  released    | [node_exporter versions](https://github.com/flatcar/sysext-bakery/releases/tag/node_exporter) |
 | `nomad`          |  released    | [nomad versions](https://github.com/flatcar/sysext-bakery/releases/tag/nomad) |
 | `nvidia-runtime` |  released    | [nvidia-runtime versions](https://github.com/flatcar/sysext-bakery/releases/tag/nvidia-runtime) |
 | `ollama`         |  released    | [ollama versions](https://github.com/flatcar/sysext-bakery/releases/tag/ollama) |

--- a/docs/node_exporter.md
+++ b/docs/node_exporter.md
@@ -1,0 +1,52 @@
+# node_exporter sysext
+
+This sysext ships the [Prometheus node_exporter](https://github.com/prometheus/node_exporter).
+
+The sysext includes a service unit file to start node_exporter at boot.
+By default the exporter listens on `:9100`.
+Extra command line flags can be set in `/etc/node_exporter/node_exporter.env` via the `NODE_EXPORTER_OPTS` variable, or the configuration can be replaced via a custom Butane config.
+
+## Usage
+
+The snippet includes automated updates via systemd-sysupdate.
+When a new version is released, sysupdate stages it, refreshes the merged sysext, and restarts `node_exporter.service` (see the `systemd-sysupdate.service` drop-in below).
+You can deactivate updates by changing `enabled: true` to `enabled: false` in `systemd-sysupdate.timer`.
+
+Note that the snippet is for the x86-64 version of node_exporter 1.12.1.
+
+Check out the metadata release at https://github.com/flatcar/sysext-bakery/releases/tag/node_exporter for a list of all versions available in the bakery.
+
+```yaml
+variant: flatcar
+version: 1.0.0
+
+storage:
+  files:
+    - path: /opt/extensions/node_exporter/node_exporter-1.12.1-x86-64.raw
+      mode: 0644
+      contents:
+        source: https://extensions.flatcar.org/extensions/node_exporter-1.12.1-x86-64.raw
+    - path: /etc/sysupdate.node_exporter.d/node_exporter.conf
+      contents:
+        source: https://extensions.flatcar.org/extensions/node_exporter.conf
+  links:
+    - path: /etc/systemd/system/multi-user.target.wants/node_exporter.service
+      target: /usr/lib/systemd/system/node_exporter.service
+      overwrite: true
+    - target: /opt/extensions/node_exporter/node_exporter-1.12.1-x86-64.raw
+      path: /etc/extensions/node_exporter.raw
+      hard: false
+systemd:
+  units:
+    - name: systemd-sysupdate.timer
+      enabled: true
+    - name: systemd-sysupdate.service
+      dropins:
+        - name: node_exporter.conf
+          contents: |
+            [Service]
+            ExecStartPre=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/node_exporter.raw > /run/node_exporter"
+            ExecStartPre=/usr/lib/systemd/systemd-sysupdate -C node_exporter update
+            ExecStartPost=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/node_exporter.raw > /run/node_exporter-new"
+            ExecStartPost=/usr/bin/sh -c "if ! cmp --silent /run/node_exporter /run/node_exporter-new; then systemd-sysext refresh && systemctl restart node_exporter.service; fi"
+```

--- a/docs/node_exporter.md
+++ b/docs/node_exporter.md
@@ -12,7 +12,7 @@ The snippet includes automated updates via systemd-sysupdate.
 When a new version is released, sysupdate stages it, refreshes the merged sysext, and restarts `node_exporter.service` (see the `systemd-sysupdate.service` drop-in below).
 You can deactivate updates by changing `enabled: true` to `enabled: false` in `systemd-sysupdate.timer`.
 
-Note that the snippet is for the x86-64 version of node_exporter 1.12.1.
+Note that the snippet is for the x86-64 version of node_exporter v1.12.1.
 
 Check out the metadata release at https://github.com/flatcar/sysext-bakery/releases/tag/node_exporter for a list of all versions available in the bakery.
 
@@ -22,10 +22,10 @@ version: 1.0.0
 
 storage:
   files:
-    - path: /opt/extensions/node_exporter/node_exporter-1.12.1-x86-64.raw
+    - path: /opt/extensions/node_exporter/node_exporter-v1.12.1-x86-64.raw
       mode: 0644
       contents:
-        source: https://extensions.flatcar.org/extensions/node_exporter-1.12.1-x86-64.raw
+        source: https://extensions.flatcar.org/extensions/node_exporter-v1.12.1-x86-64.raw
     - path: /etc/sysupdate.node_exporter.d/node_exporter.conf
       contents:
         source: https://extensions.flatcar.org/extensions/node_exporter.conf
@@ -33,7 +33,7 @@ storage:
     - path: /etc/systemd/system/multi-user.target.wants/node_exporter.service
       target: /usr/lib/systemd/system/node_exporter.service
       overwrite: true
-    - target: /opt/extensions/node_exporter/node_exporter-1.12.1-x86-64.raw
+    - target: /opt/extensions/node_exporter/node_exporter-v1.12.1-x86-64.raw
       path: /etc/extensions/node_exporter.raw
       hard: false
 systemd:

--- a/node_exporter.sysext/create.sh
+++ b/node_exporter.sysext/create.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# vim: et ts=2 syn=bash
+#
+# Prometheus node_exporter sysext.
+#
+
+RELOAD_SERVICES_ON_MERGE="true"
+
+function list_available_versions() {
+  list_github_releases "prometheus" "node_exporter"
+}
+# --
+
+function populate_sysext_root() {
+  local sysextroot="$1"
+  local arch="$2"
+  local version="$3"
+
+  local rel_arch="$(arch_transform "x86-64" "amd64" "$arch")"
+  local tarball="node_exporter-${version#v}.linux-${rel_arch}.tar.gz"
+  local baseurl="https://github.com/prometheus/node_exporter/releases/download/${version}"
+
+  curl --parallel --fail --silent --show-error --location \
+    --remote-name "${baseurl}/${tarball}" \
+    --remote-name "${baseurl}/sha256sums.txt"
+
+  # Verify the tarball against its published checksum. Pick out the specific
+  # entry and fail if it is missing: 'sha256sum --ignore-missing' would exit 0
+  # when nothing matches, verifying nothing at all.
+  local expected
+  # Match the filename with or without the coreutils binary marker ('*').
+  expected="$(awk -v f="${tarball}" '$2 == f || $2 == "*" f' sha256sums.txt)"
+  if [[ -z "${expected}" ]] ; then
+    echo "ERROR: no checksum entry for ${tarball} in sha256sums.txt" >&2
+    return 1
+  fi
+  echo "${expected}" | sha256sum --check --strict -
+
+  tar --force-local --strip-components=1 -xzf "${tarball}"
+
+  mkdir -p "${sysextroot}/usr/bin"
+  install -m 0755 node_exporter "${sysextroot}/usr/bin/"
+}
+# --

--- a/node_exporter.sysext/files/usr/lib/systemd/system/multi-user.target.upholds/node_exporter.service
+++ b/node_exporter.sysext/files/usr/lib/systemd/system/multi-user.target.upholds/node_exporter.service
@@ -1,0 +1,1 @@
+../node_exporter.service

--- a/node_exporter.sysext/files/usr/lib/systemd/system/node_exporter.service
+++ b/node_exporter.sysext/files/usr/lib/systemd/system/node_exporter.service
@@ -1,0 +1,24 @@
+[Unit]
+Description=Prometheus Node Exporter
+Documentation=https://github.com/prometheus/node_exporter
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=simple
+DynamicUser=yes
+EnvironmentFile=-/etc/node_exporter/node_exporter.env
+ExecStart=/usr/bin/node_exporter $NODE_EXPORTER_OPTS
+Restart=on-failure
+RestartSec=5
+NoNewPrivileges=yes
+ProtectSystem=strict
+ProtectHome=yes
+ProtectKernelTunables=yes
+ProtectControlGroups=yes
+# AF_NETLINK is needed by the netdev/netclass/arp collectors (netlink mode).
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX AF_NETLINK
+SyslogIdentifier=node_exporter
+
+[Install]
+UpheldBy=multi-user.target

--- a/node_exporter.sysext/files/usr/lib/tmpfiles.d/10-node_exporter.conf
+++ b/node_exporter.sysext/files/usr/lib/tmpfiles.d/10-node_exporter.conf
@@ -1,0 +1,2 @@
+d /etc/node_exporter 0755 root root - -
+C /etc/node_exporter/node_exporter.env 0644 root root - /usr/share/node_exporter/node_exporter.env

--- a/node_exporter.sysext/files/usr/share/node_exporter/node_exporter.env
+++ b/node_exporter.sysext/files/usr/share/node_exporter/node_exporter.env
@@ -1,0 +1,5 @@
+# Command line options for node_exporter.
+# See 'node_exporter --help' for the full list of collectors and flags.
+# The exporter listens on :9100 by default.
+#
+# NODE_EXPORTER_OPTS="--web.listen-address=:9100"

--- a/release_build_versions.txt
+++ b/release_build_versions.txt
@@ -69,6 +69,9 @@ nerdctl latest
 nomad 1.10.0
 nomad latest
 
+node_exporter v1.12.1
+node_exporter latest
+
 nvidia-runtime v1.18.1
 nvidia-runtime latest
 

--- a/release_build_versions.txt
+++ b/release_build_versions.txt
@@ -66,11 +66,11 @@ nebula latest
 
 nerdctl latest
 
-nomad 1.10.0
-nomad latest
-
 node_exporter v1.12.1
 node_exporter latest
+
+nomad 1.10.0
+nomad latest
 
 nvidia-runtime v1.18.1
 nvidia-runtime latest


### PR DESCRIPTION
This adds the [Prometheus node_exporter](https://github.com/prometheus/node_exporter) as a system extension.

## What's included
- `node_exporter.sysext/create.sh`: lists releases from `prometheus/node_exporter`, downloads the release tarball for the target arch, verifies it against the upstream `sha256sums.txt`, and installs the `node_exporter` binary to `/usr/bin`.
- A `node_exporter.service` unit that runs the exporter as a `DynamicUser` with hardening (`ProtectSystem=strict`, `NoNewPrivileges`, restricted address families). It is started on merge via a `multi-user.target.upholds` drop-in.
- A default `/etc/node_exporter/node_exporter.env` (seeded via tmpfiles) for passing extra flags through `NODE_EXPORTER_OPTS`.
- Docs page and entries in `docs/index.md` and `release_build_versions.txt` (`v1.12.1` + `latest`).

## Testing
- `./bakery.sh list node_exporter` returns the upstream version list.
- `./bakery.sh create node_exporter v1.12.1 --arch x86-64` downloads and passes checksum verification.