### PR TITLE
Add blackbox_exporter as sysext

### DIFF
--- a/blackbox_exporter.sysext/create.sh
+++ b/blackbox_exporter.sysext/create.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# vim: et ts=2 syn=bash
+#
+# Prometheus blackbox_exporter sysext.
+#
+
+RELOAD_SERVICES_ON_MERGE="true"
+
+function list_available_versions() {
+  list_github_releases "prometheus" "blackbox_exporter"
+}
+# --
+
+function populate_sysext_root() {
+  local sysextroot="$1"
+  local arch="$2"
+  local version="$3"
+
+  local rel_arch="$(arch_transform "x86-64" "amd64" "$arch")"
+  local tarball="blackbox_exporter-${version#v}.linux-${rel_arch}.tar.gz"
+  local baseurl="https://github.com/prometheus/blackbox_exporter/releases/download/${version}"
+
+  curl --parallel --fail --silent --show-error --location \
+    --remote-name "${baseurl}/${tarball}" \
+    --remote-name "${baseurl}/sha256sums.txt"
+
+  # Verify the tarball against its published checksum. Pick out the specific
+  # entry and fail if it is missing: 'sha256sum --ignore-missing' would exit 0
+  # when nothing matches, verifying nothing at all.
+  local expected
+  # Match the filename with or without the coreutils binary marker ('*').
+  expected="$(awk -v f="${tarball}" '$2 == f || $2 == "*" f' sha256sums.txt)"
+  if [[ -z "${expected}" ]] ; then
+    echo "ERROR: no checksum entry for ${tarball} in sha256sums.txt" >&2
+    return 1
+  fi
+  echo "${expected}" | sha256sum --check --strict -
+
+  tar --force-local --strip-components=1 -xzf "${tarball}"
+
+  mkdir -p "${sysextroot}/usr/bin"
+  mkdir -p "${sysextroot}/usr/share/blackbox_exporter"
+  install -m 0755 blackbox_exporter "${sysextroot}/usr/bin/"
+  # Ship the upstream default config; it is copied to /etc via tmpfiles.
+  install -m 0644 blackbox.yml "${sysextroot}/usr/share/blackbox_exporter/blackbox.yml"
+}
+# --

--- a/blackbox_exporter.sysext/files/usr/lib/systemd/system/blackbox_exporter.service
+++ b/blackbox_exporter.sysext/files/usr/lib/systemd/system/blackbox_exporter.service
@@ -1,0 +1,26 @@
+[Unit]
+Description=Prometheus Blackbox Exporter
+Documentation=https://github.com/prometheus/blackbox_exporter
+Wants=network-online.target
+After=network-online.target
+# Don't start until the config has been seeded into /etc (via tmpfiles).
+ConditionFileNotEmpty=/etc/blackbox_exporter/blackbox.yml
+
+[Service]
+Type=simple
+DynamicUser=yes
+# CAP_NET_RAW is required for the ICMP prober; restrict the bounding set to it.
+AmbientCapabilities=CAP_NET_RAW
+CapabilityBoundingSet=CAP_NET_RAW
+EnvironmentFile=-/etc/blackbox_exporter/blackbox_exporter.env
+ExecStart=/usr/bin/blackbox_exporter --config.file=/etc/blackbox_exporter/blackbox.yml $BLACKBOX_EXPORTER_OPTS
+ExecReload=/bin/kill -HUP $MAINPID
+Restart=on-failure
+RestartSec=5
+NoNewPrivileges=yes
+ProtectSystem=strict
+ProtectHome=yes
+SyslogIdentifier=blackbox_exporter
+
+[Install]
+UpheldBy=multi-user.target

--- a/blackbox_exporter.sysext/files/usr/lib/systemd/system/multi-user.target.upholds/blackbox_exporter.service
+++ b/blackbox_exporter.sysext/files/usr/lib/systemd/system/multi-user.target.upholds/blackbox_exporter.service
@@ -1,0 +1,1 @@
+../blackbox_exporter.service

--- a/blackbox_exporter.sysext/files/usr/lib/tmpfiles.d/10-blackbox_exporter.conf
+++ b/blackbox_exporter.sysext/files/usr/lib/tmpfiles.d/10-blackbox_exporter.conf
@@ -1,0 +1,3 @@
+d /etc/blackbox_exporter 0755 root root - -
+C /etc/blackbox_exporter/blackbox_exporter.env 0644 root root - /usr/share/blackbox_exporter/blackbox_exporter.env
+C /etc/blackbox_exporter/blackbox.yml 0644 root root - /usr/share/blackbox_exporter/blackbox.yml

--- a/blackbox_exporter.sysext/files/usr/lib/tmpfiles.d/10-blackbox_exporter.conf
+++ b/blackbox_exporter.sysext/files/usr/lib/tmpfiles.d/10-blackbox_exporter.conf
@@ -1,3 +1,3 @@
 d /etc/blackbox_exporter 0755 root root - -
-C /etc/blackbox_exporter/blackbox_exporter.env 0644 root root - /usr/share/blackbox_exporter/blackbox_exporter.env
+C /etc/blackbox_exporter/blackbox_exporter.env 0640 root root - /usr/share/blackbox_exporter/blackbox_exporter.env
 C /etc/blackbox_exporter/blackbox.yml 0644 root root - /usr/share/blackbox_exporter/blackbox.yml

--- a/blackbox_exporter.sysext/files/usr/share/blackbox_exporter/blackbox_exporter.env
+++ b/blackbox_exporter.sysext/files/usr/share/blackbox_exporter/blackbox_exporter.env
@@ -1,0 +1,6 @@
+# Command line options for blackbox_exporter.
+# See 'blackbox_exporter --help' for the full list of flags.
+# The exporter listens on :9115 by default. The config file is passed
+# separately via the service unit (--config.file=/etc/blackbox_exporter/blackbox.yml).
+#
+# BLACKBOX_EXPORTER_OPTS="--web.listen-address=:9115"

--- a/docs/blackbox_exporter.md
+++ b/docs/blackbox_exporter.md
@@ -1,0 +1,52 @@
+# blackbox_exporter sysext
+
+This sysext ships the [Prometheus blackbox_exporter](https://github.com/prometheus/blackbox_exporter).
+
+The sysext includes a service unit file to start blackbox_exporter at boot.
+By default the exporter listens on `:9115` and reads its probe configuration from `/etc/blackbox_exporter/blackbox.yml` (seeded with the upstream default).
+Extra command line flags can be set in `/etc/blackbox_exporter/blackbox_exporter.env` via the `BLACKBOX_EXPORTER_OPTS` variable, or the configuration can be replaced via a custom Butane config.
+
+## Usage
+
+The snippet includes automated updates via systemd-sysupdate.
+When a new version is released, sysupdate stages it, refreshes the merged sysext, and restarts `blackbox_exporter.service` (see the `systemd-sysupdate.service` drop-in below).
+You can deactivate updates by changing `enabled: true` to `enabled: false` in `systemd-sysupdate.timer`.
+
+Note that the snippet is for the x86-64 version of blackbox_exporter 0.28.0.
+
+Check out the metadata release at https://github.com/flatcar/sysext-bakery/releases/tag/blackbox_exporter for a list of all versions available in the bakery.
+
+```yaml
+variant: flatcar
+version: 1.0.0
+
+storage:
+  files:
+    - path: /opt/extensions/blackbox_exporter/blackbox_exporter-0.28.0-x86-64.raw
+      mode: 0644
+      contents:
+        source: https://extensions.flatcar.org/extensions/blackbox_exporter-0.28.0-x86-64.raw
+    - path: /etc/sysupdate.blackbox_exporter.d/blackbox_exporter.conf
+      contents:
+        source: https://extensions.flatcar.org/extensions/blackbox_exporter.conf
+  links:
+    - path: /etc/systemd/system/multi-user.target.wants/blackbox_exporter.service
+      target: /usr/lib/systemd/system/blackbox_exporter.service
+      overwrite: true
+    - target: /opt/extensions/blackbox_exporter/blackbox_exporter-0.28.0-x86-64.raw
+      path: /etc/extensions/blackbox_exporter.raw
+      hard: false
+systemd:
+  units:
+    - name: systemd-sysupdate.timer
+      enabled: true
+    - name: systemd-sysupdate.service
+      dropins:
+        - name: blackbox_exporter.conf
+          contents: |
+            [Service]
+            ExecStartPre=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/blackbox_exporter.raw > /run/blackbox_exporter"
+            ExecStartPre=/usr/lib/systemd/systemd-sysupdate -C blackbox_exporter update
+            ExecStartPost=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/blackbox_exporter.raw > /run/blackbox_exporter-new"
+            ExecStartPost=/usr/bin/sh -c "if ! cmp --silent /run/blackbox_exporter /run/blackbox_exporter-new; then systemd-sysext refresh && systemctl restart blackbox_exporter.service; fi"
+```

--- a/docs/blackbox_exporter.md
+++ b/docs/blackbox_exporter.md
@@ -12,7 +12,7 @@ The snippet includes automated updates via systemd-sysupdate.
 When a new version is released, sysupdate stages it, refreshes the merged sysext, and restarts `blackbox_exporter.service` (see the `systemd-sysupdate.service` drop-in below).
 You can deactivate updates by changing `enabled: true` to `enabled: false` in `systemd-sysupdate.timer`.
 
-Note that the snippet is for the x86-64 version of blackbox_exporter 0.28.0.
+Note that the snippet is for the x86-64 version of blackbox_exporter v0.28.0.
 
 Check out the metadata release at https://github.com/flatcar/sysext-bakery/releases/tag/blackbox_exporter for a list of all versions available in the bakery.
 
@@ -22,10 +22,10 @@ version: 1.0.0
 
 storage:
   files:
-    - path: /opt/extensions/blackbox_exporter/blackbox_exporter-0.28.0-x86-64.raw
+    - path: /opt/extensions/blackbox_exporter/blackbox_exporter-v0.28.0-x86-64.raw
       mode: 0644
       contents:
-        source: https://extensions.flatcar.org/extensions/blackbox_exporter-0.28.0-x86-64.raw
+        source: https://extensions.flatcar.org/extensions/blackbox_exporter-v0.28.0-x86-64.raw
     - path: /etc/sysupdate.blackbox_exporter.d/blackbox_exporter.conf
       contents:
         source: https://extensions.flatcar.org/extensions/blackbox_exporter.conf
@@ -33,7 +33,7 @@ storage:
     - path: /etc/systemd/system/multi-user.target.wants/blackbox_exporter.service
       target: /usr/lib/systemd/system/blackbox_exporter.service
       overwrite: true
-    - target: /opt/extensions/blackbox_exporter/blackbox_exporter-0.28.0-x86-64.raw
+    - target: /opt/extensions/blackbox_exporter/blackbox_exporter-v0.28.0-x86-64.raw
       path: /etc/extensions/blackbox_exporter.raw
       hard: false
 systemd:

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,6 +61,7 @@ Check out documentation on specific extensions at the navigation menu on the lef
 |    Extension     | Availability | Versions available |
 | ---------------- | ------------ | ------------- |
 | `bird`           |  released    | [bird versions](https://github.com/flatcar/sysext-bakery/releases/tag/bird) |
+| `blackbox_exporter` | released  | [blackbox_exporter versions](https://github.com/flatcar/sysext-bakery/releases/tag/blackbox_exporter) |
 | `chrony`         |  released    | [chrony versions](https://github.com/flatcar/sysext-bakery/releases/tag/chrony) |
 | `cilium`         |  released    | [cilium versions](https://github.com/flatcar/sysext-bakery/releases/tag/cilium) |
 | `cloud-hypervisor` |  released  | [cloud-hypervisor versions](https://github.com/flatcar/sysext-bakery/releases/tag/cloud-hypervisor) |

--- a/release_build_versions.txt
+++ b/release_build_versions.txt
@@ -121,3 +121,6 @@ dataplaneapi latest
 
 vault 1.20.0
 vault latest
+
+blackbox_exporter v0.28.0
+blackbox_exporter latest


### PR DESCRIPTION
This adds the [Prometheus blackbox_exporter](https://github.com/prometheus/blackbox_exporter) as a system extension.

## What's included
- `blackbox_exporter.sysext/create.sh`: lists releases from `prometheus/blackbox_exporter`, downloads the release tarball for the target arch, verifies it against the upstream `sha256sums.txt`, and installs the `blackbox_exporter` binary to `/usr/bin` plus the upstream default `blackbox.yml` to `/usr/share/blackbox_exporter`.
- A `blackbox_exporter.service` unit that runs as a `DynamicUser` with `AmbientCapabilities=CAP_NET_RAW` (needed for the ICMP prober) and hardening. It reads its config from `/etc/blackbox_exporter/blackbox.yml` and is started on merge via a `multi-user.target.upholds` drop-in.
- The upstream default probe config and an environment file are seeded into `/etc/blackbox_exporter/` via tmpfiles; extra flags can be passed through `BLACKBOX_EXPORTER_OPTS`.
- Docs page and entries in `docs/index.md` and `release_build_versions.txt` (`v0.28.0` + `latest`).

## Testing
- `./bakery.sh list blackbox_exporter` returns the upstream version list.
- `./bakery.sh create blackbox_exporter v0.28.0 --arch x86-64` downloads and passes checksum verification; the tarball contains both the binary and `blackbox.yml` as expected.