### PR TITLE
netbird: add NetBird mesh VPN sysext

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -81,6 +81,7 @@ Check out documentation on specific extensions at the navigation menu on the lef
 | `kubernetes`     |  released    | [kubernetes versions](https://github.com/flatcar/sysext-bakery/releases/tag/kubernetes) |
 | `llamaedge`      |  released    | [llamaedge versions](https://github.com/flatcar/sysext-bakery/releases/tag/llamaedge) |
 | `nebula`         |  released    | [nebula versions](https://github.com/flatcar/sysext-bakery/releases/tag/nebula) |
+| `netbird`        |  released    | [netbird versions](https://github.com/flatcar/sysext-bakery/releases/tag/netbird) |
 | `nerdctl`        |  released    | [nerdctl versions](https://github.com/flatcar/sysext-bakery/releases/tag/nerdctl) |
 | `nomad`          |  released    | [nomad versions](https://github.com/flatcar/sysext-bakery/releases/tag/nomad) |
 | `nvidia-runtime` |  released    | [nvidia-runtime versions](https://github.com/flatcar/sysext-bakery/releases/tag/nvidia-runtime) |

--- a/docs/netbird.md
+++ b/docs/netbird.md
@@ -1,0 +1,64 @@
+# NetBird sysext
+
+This sysext ships the [NetBird](https://github.com/netbirdio/netbird) client, a WireGuard-based mesh VPN.
+
+The sysext includes a service unit file that starts the NetBird daemon at boot.
+The daemon stays idle until the machine is enrolled with `netbird up --setup-key <key>`; the WireGuard interface (`wt0` by default) only appears after enrollment.
+
+## Usage
+
+The snippet below includes automated updates via systemd-sysupdate.
+Sysupdate will stage updates, refresh the merged sysext, and restart `netbird.service` — no reboot is required.
+You can deactivate updates by changing `enabled: true` to `enabled: false` in `systemd-sysupdate.timer`.
+
+Note that the snippet is for the x86-64 version of NetBird v0.75.0.
+
+Check out the metadata release at https://github.com/flatcar/sysext-bakery/releases/tag/netbird for a list of all versions available in the bakery.
+
+The optional `netbird-up.service` unit enrolls the machine on first boot using a [setup key](https://docs.netbird.io/how-to/register-machines-using-setup-keys); replace `<YOUR-SETUP-KEY>` or drop the unit and enroll manually.
+
+```yaml
+variant: flatcar
+version: 1.0.0
+
+storage:
+  files:
+    - path: /opt/extensions/netbird/netbird-v0.75.0-x86-64.raw
+      mode: 0644
+      contents:
+        source: https://extensions.flatcar.org/extensions/netbird-v0.75.0-x86-64.raw
+    - path: /etc/sysupdate.netbird.d/netbird.conf
+      contents:
+        source: https://extensions.flatcar.org/extensions/netbird.conf
+  links:
+    - target: /opt/extensions/netbird/netbird-v0.75.0-x86-64.raw
+      path: /etc/extensions/netbird.raw
+      hard: false
+systemd:
+  units:
+    - name: netbird-up.service
+      enabled: true
+      contents: |
+        [Unit]
+        Description=Enroll machine with NetBird
+        After=netbird.service
+        ConditionPathExists=!/etc/netbird/config.json
+        [Service]
+        Type=oneshot
+        ExecStart=/usr/bin/netbird up --setup-key <YOUR-SETUP-KEY>
+        Restart=on-failure
+        RestartSec=10
+        [Install]
+        WantedBy=multi-user.target
+    - name: systemd-sysupdate.timer
+      enabled: true
+    - name: systemd-sysupdate.service
+      dropins:
+        - name: netbird.conf
+          contents: |
+            [Service]
+            ExecStartPre=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/netbird.raw > /tmp/netbird"
+            ExecStartPre=/usr/lib/systemd/systemd-sysupdate -C netbird update
+            ExecStartPost=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/netbird.raw > /tmp/netbird-new"
+            ExecStartPost=/usr/bin/sh -c "if ! cmp --silent /tmp/netbird /tmp/netbird-new; then systemd-sysext refresh && systemctl restart netbird.service; fi"
+```

--- a/netbird.sysext/create.sh
+++ b/netbird.sysext/create.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# vim: et ts=2 syn=bash
+#
+# NetBird extension.
+#
+
+RELOAD_SERVICES_ON_MERGE="true"
+
+function list_available_versions() {
+  # NetBird publishes release candidates (e.g. v0.75.0-rc.6) as regular
+  # GitHub releases without the prerelease flag, so only accept stable
+  # vX.Y.Z tags to keep "latest" from resolving to an RC.
+  list_github_releases "netbirdio" "netbird" \
+      | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$'
+}
+# --
+
+function populate_sysext_root() {
+  local sysextroot="$1"
+  local arch="$2"
+  local version="$3"
+
+  local rel_arch="$(arch_transform "x86-64" "amd64" "$arch")"
+  local relver="${version#v}"
+
+  curl --parallel --fail --silent --show-error --location \
+    --remote-name "https://github.com/netbirdio/netbird/releases/download/${version}/netbird_${relver}_linux_${rel_arch}.tar.gz" \
+    --remote-name "https://github.com/netbirdio/netbird/releases/download/${version}/netbird_${relver}_checksums.txt"
+
+  grep "netbird_${relver}_linux_${rel_arch}.tar.gz" "netbird_${relver}_checksums.txt" \
+    | sha256sum --check -
+
+  mkdir -p "${sysextroot}/usr/bin"
+  tar --force-local -xf "netbird_${relver}_linux_${rel_arch}.tar.gz" -C "${sysextroot}/usr/bin" netbird
+  chmod +x "${sysextroot}/usr/bin/netbird"
+}
+# --

--- a/netbird.sysext/files/usr/lib/systemd/network/50-netbird.network
+++ b/netbird.sysext/files/usr/lib/systemd/network/50-netbird.network
@@ -1,0 +1,5 @@
+[Match]
+Name=wt*
+
+[Link]
+Unmanaged=yes

--- a/netbird.sysext/files/usr/lib/systemd/system/multi-user.target.d/10-netbird.conf
+++ b/netbird.sysext/files/usr/lib/systemd/system/multi-user.target.d/10-netbird.conf
@@ -1,0 +1,2 @@
+[Unit]
+Upholds=netbird.service

--- a/netbird.sysext/files/usr/lib/systemd/system/netbird.service
+++ b/netbird.sysext/files/usr/lib/systemd/system/netbird.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=NetBird WireGuard-based mesh VPN client daemon
+Documentation=https://docs.netbird.io
+Wants=network-online.target
+After=network-online.target nss-lookup.target
+
+[Service]
+ExecStart=/usr/bin/netbird service run --config /etc/netbird/config.json --log-file console
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/release_build_versions.txt
+++ b/release_build_versions.txt
@@ -64,6 +64,9 @@ kubernetes latest
 nebula v1.9.5
 nebula latest
 
+netbird v0.75.0
+netbird latest
+
 nerdctl latest
 
 nomad 1.10.0


### PR DESCRIPTION
Adds a sysext for the [NetBird](https://github.com/netbirdio/netbird) client, a WireGuard-based mesh VPN, following the nebula/tailscale extension patterns.

What it ships:
- `netbird` client binary from upstream GitHub release tarballs, sha256-verified against the release's checksums file.
- A `netbird.service` unit (journald logging via `--log-file console`) that auto-starts on merge through an `Upholds=` drop-in on `multi-user.target`. The daemon idles until the machine is enrolled with `netbird up --setup-key`.
- A networkd `50-netbird.network` rule marking the `wt*` WireGuard interface unmanaged, mirroring the tailscale extension.

Notes:
- NetBird publishes release candidates (e.g. `v0.75.0-rc.6`) as regular GitHub releases without the prerelease flag, so `list_available_versions` filters to stable `vX.Y.Z` tags — otherwise `latest` would resolve to an RC.
- Docs page + index row included; `release_build_versions.txt` gets the pin+latest pair (`netbird v0.75.0`, `netbird latest`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)