### PR TITLE
Add qemu as sysext (full-VM hypervisor)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -86,6 +86,7 @@ Check out documentation on specific extensions at the navigation menu on the lef
 | `nvidia-runtime` |  released    | [nvidia-runtime versions](https://github.com/flatcar/sysext-bakery/releases/tag/nvidia-runtime) |
 | `ollama`         |  released    | [ollama versions](https://github.com/flatcar/sysext-bakery/releases/tag/ollama) |
 | `opkssh`         |  released    | [opkssh versions](https://github.com/flatcar/sysext-bakery/releases/tag/opkssh) |
+| `qemu`           |  released    | [qemu versions](https://github.com/flatcar/sysext-bakery/releases/tag/qemu) |
 | `rke2`           |  released    | [rke2 versions](https://github.com/flatcar/sysext-bakery/releases/tag/rke2) |
 | `scx`            |  released    | [scx versions](https://github.com/flatcar/sysext-bakery/releases/tag/scx) |
 | `tailscale`      |  released    | [tailscale versions](https://github.com/flatcar/sysext-bakery/releases/tag/tailscale) |

--- a/docs/qemu.md
+++ b/docs/qemu.md
@@ -53,9 +53,8 @@ systemd:
         - name: qemu.conf
           contents: |
             [Service]
+            ExecStartPre=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/qemu.raw > /run/qemu"
             ExecStartPre=/usr/lib/systemd/systemd-sysupdate -C qemu update
-            ExecStartPost=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/qemu.raw > /tmp/qemu-old"
-            ExecStartPost=/usr/lib/systemd/systemd-sysupdate -C qemu update
-            ExecStartPost=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/qemu.raw > /tmp/qemu-new"
-            ExecStartPost=/usr/bin/sh -c "if ! cmp --silent /tmp/qemu-old /tmp/qemu-new; then touch /run/reboot-required; fi"
+            ExecStartPost=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/qemu.raw > /run/qemu-new"
+            ExecStartPost=/usr/bin/sh -c "if ! cmp --silent /run/qemu /run/qemu-new; then touch /run/reboot-required; fi"
 ```

--- a/docs/qemu.md
+++ b/docs/qemu.md
@@ -36,10 +36,10 @@ storage:
         source: https://extensions.flatcar.org/extensions/qemu-10.0.11-x86-64.raw
     - path: /etc/sysupdate.qemu.d/qemu.conf
       contents:
-        source: https://github.com/flatcar/sysext-bakery/releases/download/qemu/qemu.conf
+        source: https://extensions.flatcar.org/extensions/qemu.conf
     - path: /etc/sysupdate.d/noop.conf
       contents:
-        source: https://github.com/flatcar/sysext-bakery/releases/download/qemu/noop.conf
+        source: https://extensions.flatcar.org/extensions/noop.conf
   links:
     - target: /opt/extensions/qemu/qemu-10.0.11-x86-64.raw
       path: /etc/extensions/qemu.raw

--- a/docs/qemu.md
+++ b/docs/qemu.md
@@ -1,0 +1,60 @@
+# QEMU sysext
+
+This sysext ships [QEMU](https://www.qemu.org/)'s `qemu-system-x86_64` so a
+Flatcar host can run full virtual machines — for example as the backing
+hypervisor for Nomad's `qemu` task driver.
+
+QEMU has no upstream static/portable release, so the extension bundles the
+`qemu-system-x86_64` binary with its full shared-library closure (including
+glibc and the dynamic loader) plus firmware (SeaBIOS, iPXE option ROMs, OVMF),
+extracted from a Debian container. A `/usr/bin/qemu-system-x86_64` wrapper runs
+the binary through the bundled loader, isolating it from the host's libraries,
+and points QEMU at the bundled firmware with `-L`. User-mode (SLIRP) networking
+is included, so VMs get NAT egress with no host bridge setup.
+
+Only `x86-64` is supported for now.
+
+## Usage
+
+Download and merge the sysext at provisioning time using the below butane
+snippet. The snippet includes automated updates via systemd-sysupdate.
+
+Note that the snippet is for the x86-64 version of qemu 10.0.11.
+
+Check out the metadata release at
+https://github.com/flatcar/sysext-bakery/releases/tag/qemu for a list of all
+versions available in the bakery.
+
+```yaml
+variant: flatcar
+version: 1.1.0
+storage:
+  files:
+    - path: /opt/extensions/qemu/qemu-10.0.11-x86-64.raw
+      contents:
+        source: https://extensions.flatcar.org/extensions/qemu-10.0.11-x86-64.raw
+    - path: /etc/sysupdate.qemu.d/qemu.conf
+      contents:
+        source: https://github.com/flatcar/sysext-bakery/releases/download/qemu/qemu.conf
+    - path: /etc/sysupdate.d/noop.conf
+      contents:
+        source: https://github.com/flatcar/sysext-bakery/releases/download/qemu/noop.conf
+  links:
+    - target: /opt/extensions/qemu/qemu-10.0.11-x86-64.raw
+      path: /etc/extensions/qemu.raw
+      hard: false
+systemd:
+  units:
+    - name: systemd-sysupdate.timer
+      enabled: true
+    - name: systemd-sysupdate.service
+      dropins:
+        - name: qemu.conf
+          contents: |
+            [Service]
+            ExecStartPre=/usr/lib/systemd/systemd-sysupdate -C qemu update
+            ExecStartPost=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/qemu.raw > /tmp/qemu-old"
+            ExecStartPost=/usr/lib/systemd/systemd-sysupdate -C qemu update
+            ExecStartPost=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/qemu.raw > /tmp/qemu-new"
+            ExecStartPost=/usr/bin/sh -c "if ! cmp --silent /tmp/qemu-old /tmp/qemu-new; then touch /run/reboot-required; fi"
+```

--- a/docs/qemu.md
+++ b/docs/qemu.md
@@ -7,10 +7,11 @@ hypervisor for Nomad's `qemu` task driver.
 QEMU has no upstream static/portable release, so the extension bundles the
 `qemu-system-x86_64` binary with its full shared-library closure (including
 glibc and the dynamic loader) plus firmware (SeaBIOS, iPXE option ROMs, OVMF),
-extracted from a Debian container. A `/usr/bin/qemu-system-x86_64` wrapper runs
-the binary through the bundled loader, isolating it from the host's libraries,
-and points QEMU at the bundled firmware with `-L`. User-mode (SLIRP) networking
-is included, so VMs get NAT egress with no host bridge setup.
+extracted from a Debian container via `tools/flix.sh`. flix resolves the library
+closure and patchelf's the binary onto a private loader and rpath, isolating it
+from the host's libraries; QEMU finds the bundled firmware through its
+compiled-in data directory. User-mode (SLIRP) networking is included, so VMs get
+NAT egress with no host bridge setup.
 
 Only `x86-64` is supported for now.
 

--- a/qemu.sysext/create.sh
+++ b/qemu.sysext/create.sh
@@ -4,23 +4,34 @@
 # The QEMU sysext.
 #
 # QEMU has no upstream static/portable release, so this extension bundles the
-# qemu-system-x86_64 binary together with its full shared-library closure
-# (including glibc + the dynamic loader) and firmware, extracted from a Debian
-# container. A /usr/bin wrapper runs the binary through the bundled loader so it
-# is isolated from the host's libraries — making it portable onto Flatcar.
-#
-# The version parameter is the QEMU version; it selects the Debian suite that
-# ships it (stable/testing). Only x86-64 is supported for now.
+# qemu-system-x86_64 binary together with its shared-library closure (including
+# glibc + the dynamic loader) and firmware, extracted from a Debian container.
+# tools/flix.sh resolves the closure and patchelf's the binary onto a private
+# loader/rpath, isolating it from the host's libraries (same approach as
+# tilde.sysext). Debian packages QEMU, so the version parameter selects the
+# Debian suite (stable/testing) that ships it. Only x86-64 is supported for now.
 
 RELOAD_SERVICES_ON_MERGE="false"
 
-function list_available_versions() {
-  # QEMU versions available from Debian stable / testing.
-  curl -fsSL "https://sources.debian.org/api/src/qemu/" 2>/dev/null \
-    | jq -r '.versions[]? | select((.suites // []) | any(. == "stable" or . == "testing"))
-             | .version' \
+DEBIAN_QEMU_API="https://sources.debian.org/api/src/qemu/"
+
+# Print the x.y.z versions Debian stable/testing ship, newest first, from a
+# Debian sources API response passed on stdin.
+function _qemu_debian_versions() {
+  jq -r '.versions[]? | select((.suites // []) | any(. == "stable" or . == "testing")) | .version' \
     | sed -nE 's/^[0-9]+:([0-9]+\.[0-9]+\.[0-9]+).*/\1/p' \
     | sort -Vru
+}
+# --
+
+function list_available_versions() {
+  # Fail hard rather than emit a partial/empty list if the query fails.
+  local api_json
+  api_json="$(curl -fsSL "${DEBIAN_QEMU_API}")" || {
+    echo "ERROR: failed to query the Debian sources API (${DEBIAN_QEMU_API})." >&2
+    return 1
+  }
+  echo "${api_json}" | _qemu_debian_versions
 }
 # --
 
@@ -34,54 +45,89 @@ function populate_sysext_root() {
     return 1
   fi
 
-  # Pick the Debian suite whose qemu matches the requested version.
-  local suite="stable"
-  if ! curl -fsSL "https://sources.debian.org/api/src/qemu/" 2>/dev/null \
-       | jq -e --arg v "${version}" '.versions[]? | select((.suites // []) | index("stable"))
-                                     | select(.version | test("^[0-9]+:" + ($v | gsub("\\.";"\\.")) ))' >/dev/null; then
-    suite="testing"
+  # Fetch the Debian sources API ONCE and fail hard if it can't be retrieved or
+  # parsed. A transient failure must not silently change which suite (and thus
+  # which QEMU version) we build against.
+  local api_json
+  api_json="$(curl -fsSL "${DEBIAN_QEMU_API}")" || {
+    echo "ERROR: failed to query the Debian sources API (${DEBIAN_QEMU_API})." >&2
+    return 1
+  }
+  echo "${api_json}" | jq -e '.versions' >/dev/null 2>&1 || {
+    echo "ERROR: unexpected response from the Debian sources API." >&2
+    return 1
+  }
+
+  # 'latest' resolves to the newest version Debian currently ships, so the suite
+  # selection and version check below have a concrete target.
+  if [[ "${version}" == "latest" ]]; then
+    version="$(echo "${api_json}" | _qemu_debian_versions | head -1)"
+    if [[ -z "${version}" ]]; then
+      echo "ERROR: could not determine the latest qemu version from Debian." >&2
+      return 1
+    fi
   fi
 
-  # Extract qemu + its runtime closure + firmware into the sysext root, and
-  # write the loader wrapper. Runs in a Debian container of the chosen suite.
-  docker run --rm -v "${sysextroot}:/out" "debian:${suite}-slim" bash -euc '
-    export DEBIAN_FRONTEND=noninteractive
-    apt-get update -qq
-    apt-get install -y -qq --no-install-recommends \
-      qemu-system-x86 qemu-system-data seabios ipxe-qemu ovmf >/dev/null
+  # Pick the suite that ships the requested version: prefer stable, else
+  # testing, else fail. Never fall back blindly.
+  local suite="" s
+  for s in stable testing; do
+    if echo "${api_json}" | jq -e --arg v "${version}" --arg s "${s}" '
+        .versions[]?
+        | select((.suites // []) | index($s))
+        | select(.version | test("^[0-9]+:" + ($v | gsub("\\.";"\\.")) + "([-+~]|$)"))
+      ' >/dev/null; then
+      suite="${s}"
+      break
+    fi
+  done
+  if [[ -z "${suite}" ]]; then
+    echo "ERROR: qemu ${version} is not available in Debian stable or testing." >&2
+    return 1
+  fi
 
-    bundle=/out/usr/lib/qemu-bundle
-    mkdir -p "$bundle" /out/usr/bin /out/usr/share
+  # Build the sysext inside a Debian container of the chosen suite: install QEMU,
+  # verify it actually matches the requested version (a moved suite must not
+  # silently produce a different build), then hand the binary + firmware to
+  # tools/flix.sh, which resolves the library closure and patchelf's the binary
+  # onto a private loader/rpath. No -L wrapper is needed: QEMU finds firmware in
+  # its compiled-in data dir (/usr/share/qemu), which we ship.
+  docker run --rm -i \
+    -v "${scriptroot}/tools/":/tools \
+    -v "${sysextroot}":/install_root \
+    --platform linux/amd64 \
+    --pull always \
+    --network host \
+    -e WANT_VERSION="${version}" \
+    "docker.io/debian:${suite}-slim" bash -euc '
+      export DEBIAN_FRONTEND=noninteractive
+      apt-get update -qq
+      apt-get install -y -qq --no-install-recommends \
+        qemu-system-x86 qemu-system-data seabios ipxe-qemu ovmf patchelf >/dev/null
 
-    bin=/usr/bin/qemu-system-x86_64
-    cp -aL "$bin" "$bundle/qemu-system-x86_64"
+      got="$(qemu-system-x86_64 --version \
+        | sed -nE "s/.*version ([0-9]+\.[0-9]+\.[0-9]+).*/\1/p" | head -1)"
+      if [ "${got}" != "${WANT_VERSION}" ]; then
+        echo "ERROR: requested qemu ${WANT_VERSION} but Debian installs ${got}." >&2
+        exit 1
+      fi
 
-    copy_libs() {
-      local f="$1" lib dest
-      ldd "$f" 2>/dev/null | sed -nE "s/.*=> (\/[^ ]+).*/\1/p; s/^\s*(\/lib[^ ]*ld-[^ ]+).*/\1/p" \
-        | sort -u | while read -r lib; do
-          [ -e "$lib" ] || continue
-          dest="$bundle/$(basename "$lib")"
-          [ -e "$dest" ] && continue
-          cp -aL "$lib" "$dest"
-          copy_libs "$lib"
-        done
-    }
-    copy_libs "$bin"
-    [ -d /usr/lib/x86_64-linux-gnu/qemu ] && cp -aL /usr/lib/x86_64-linux-gnu/qemu "$bundle/modules" || true
+      # Bundle the binary plus whichever firmware data dirs the suite ships.
+      paths="/usr/bin/qemu-system-x86_64"
+      for d in qemu seabios ipxe ovmf OVMF; do
+        [ -d "/usr/share/${d}" ] && paths="${paths} /usr/share/${d}"
+      done
 
-    for d in qemu seabios ipxe ovmf OVMF; do
-      [ -d "/usr/share/$d" ] && cp -aL "/usr/share/$d" /out/usr/share/ || true
-    done
+      cd /install_root
+      /tools/flix.sh / qemu ${paths}
 
-    loader="$(basename "$(ls "$bundle"/ld-linux* | head -1)")"
-    cat > /out/usr/bin/qemu-system-x86_64 <<EOF
-#!/bin/sh
-b=/usr/lib/qemu-bundle
-exec "\$b/$loader" --library-path "\$b:\$b/modules" \
-  "\$b/qemu-system-x86_64" -L /usr/share/qemu "\$@"
-EOF
-    chmod +x /out/usr/bin/qemu-system-x86_64
-  '
+      owner="$(stat -c "%u:%g" /install_root)"
+      if [ "${owner}" != "$(id -u):$(id -g)" ]; then
+        chown -R "${owner}" /install_root/qemu
+      fi
+    '
+
+  mv "${sysextroot}/qemu/usr" "${sysextroot}/usr"
+  rmdir "${sysextroot}/qemu"
 }
 # --

--- a/qemu.sysext/create.sh
+++ b/qemu.sysext/create.sh
@@ -15,23 +15,53 @@ RELOAD_SERVICES_ON_MERGE="false"
 
 DEBIAN_QEMU_API="https://sources.debian.org/api/src/qemu/"
 
-# Print the x.y.z versions Debian stable/testing ship, newest first, from a
-# Debian sources API response passed on stdin.
-function _qemu_debian_versions() {
-  jq -r '.versions[]? | select((.suites // []) | any(. == "stable" or . == "testing")) | .version' \
+# Resolve a Debian suite alias (stable/testing) to its codename from the archive
+# Release file, e.g. stable -> trixie. The sources API tags versions by codename
+# only, so we need this mapping. Fails if the lookup can't be made.
+function _debian_codename() {
+  local alias="$1" codename
+  codename="$(curl -fsSL "https://deb.debian.org/debian/dists/${alias}/Release" 2>/dev/null \
+    | sed -nE 's/^Codename:[[:space:]]*([^[:space:]]+).*/\1/p')" || return 1
+  [[ -n "${codename}" ]] || return 1
+  printf '%s\n' "${codename}"
+}
+# --
+
+# Read a Debian sources API response on stdin and print the x.y.z QEMU versions
+# shipped by the given suite codenames (args), newest first.
+function _qemu_versions_in() {
+  jq -r --args '
+      ($ARGS.positional) as $cn
+      | .versions[]?
+      | select((.suites // []) | any(. as $s | $cn | index($s)))
+      | .version' "$@" \
     | sed -nE 's/^[0-9]+:([0-9]+\.[0-9]+\.[0-9]+).*/\1/p' \
     | sort -Vru
 }
 # --
 
+# Return 0 if the given Debian codename ships the requested x.y.z QEMU version.
+function _qemu_version_in() {
+  local api="$1" ver="$2" codename="$3"
+  echo "${api}" | jq -e --arg v "${ver}" --arg c "${codename}" '
+      .versions[]?
+      | select((.suites // []) | index($c))
+      | select(.version | test("^[0-9]+:" + ($v | gsub("\\.";"\\.")) + "([-+~]|$)"))
+    ' >/dev/null
+}
+# --
+
 function list_available_versions() {
-  # Fail hard rather than emit a partial/empty list if the query fails.
-  local api_json
-  api_json="$(curl -fsSL "${DEBIAN_QEMU_API}")" || {
+  local api stable testing
+  stable="$(_debian_codename stable)" && testing="$(_debian_codename testing)" || {
+    echo "ERROR: failed to resolve Debian stable/testing codenames." >&2
+    return 1
+  }
+  api="$(curl -fsSL "${DEBIAN_QEMU_API}")" || {
     echo "ERROR: failed to query the Debian sources API (${DEBIAN_QEMU_API})." >&2
     return 1
   }
-  echo "${api_json}" | _qemu_debian_versions
+  echo "${api}" | _qemu_versions_in "${stable}" "${testing}"
 }
 # --
 
@@ -45,44 +75,43 @@ function populate_sysext_root() {
     return 1
   fi
 
-  # Fetch the Debian sources API ONCE and fail hard if it can't be retrieved or
-  # parsed. A transient failure must not silently change which suite (and thus
+  # Map the stable/testing aliases to codenames (the sources API only tags by
+  # codename) and fetch the version list ONCE. Fail hard on any lookup/parse
+  # error so a transient failure can't silently change which suite (and thus
   # which QEMU version) we build against.
-  local api_json
-  api_json="$(curl -fsSL "${DEBIAN_QEMU_API}")" || {
+  local stable testing api
+  stable="$(_debian_codename stable)" && testing="$(_debian_codename testing)" || {
+    echo "ERROR: failed to resolve Debian stable/testing codenames." >&2
+    return 1
+  }
+  api="$(curl -fsSL "${DEBIAN_QEMU_API}")" || {
     echo "ERROR: failed to query the Debian sources API (${DEBIAN_QEMU_API})." >&2
     return 1
   }
-  echo "${api_json}" | jq -e '.versions' >/dev/null 2>&1 || {
+  echo "${api}" | jq -e '.versions' >/dev/null 2>&1 || {
     echo "ERROR: unexpected response from the Debian sources API." >&2
     return 1
   }
 
-  # 'latest' resolves to the newest version Debian currently ships, so the suite
-  # selection and version check below have a concrete target.
+  # 'latest' resolves to the newest version in stable/testing so the checks below
+  # have a concrete target.
   if [[ "${version}" == "latest" ]]; then
-    version="$(echo "${api_json}" | _qemu_debian_versions | head -1)"
-    if [[ -z "${version}" ]]; then
+    version="$(echo "${api}" | _qemu_versions_in "${stable}" "${testing}" | head -1)"
+    [[ -n "${version}" ]] || {
       echo "ERROR: could not determine the latest qemu version from Debian." >&2
       return 1
-    fi
+    }
   fi
 
-  # Pick the suite that ships the requested version: prefer stable, else
-  # testing, else fail. Never fall back blindly.
-  local suite="" s
-  for s in stable testing; do
-    if echo "${api_json}" | jq -e --arg v "${version}" --arg s "${s}" '
-        .versions[]?
-        | select((.suites // []) | index($s))
-        | select(.version | test("^[0-9]+:" + ($v | gsub("\\.";"\\.")) + "([-+~]|$)"))
-      ' >/dev/null; then
-      suite="${s}"
-      break
-    fi
-  done
-  if [[ -z "${suite}" ]]; then
-    echo "ERROR: qemu ${version} is not available in Debian stable or testing." >&2
+  # Choose the suite that actually ships the requested version: prefer stable,
+  # else testing, else fail. Never fall back blindly.
+  local suite=""
+  if _qemu_version_in "${api}" "${version}" "${stable}"; then
+    suite="stable"
+  elif _qemu_version_in "${api}" "${version}" "${testing}"; then
+    suite="testing"
+  else
+    echo "ERROR: qemu ${version} is not in Debian stable (${stable}) or testing (${testing})." >&2
     return 1
   fi
 

--- a/qemu.sysext/create.sh
+++ b/qemu.sysext/create.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# vim: et ts=2 syn=bash
+#
+# The QEMU sysext.
+#
+# QEMU has no upstream static/portable release, so this extension bundles the
+# qemu-system-x86_64 binary together with its full shared-library closure
+# (including glibc + the dynamic loader) and firmware, extracted from a Debian
+# container. A /usr/bin wrapper runs the binary through the bundled loader so it
+# is isolated from the host's libraries — making it portable onto Flatcar.
+#
+# The version parameter is the QEMU version; it selects the Debian suite that
+# ships it (stable/testing). Only x86-64 is supported for now.
+
+RELOAD_SERVICES_ON_MERGE="false"
+
+function list_available_versions() {
+  # QEMU versions available from Debian stable / testing.
+  curl -fsSL "https://sources.debian.org/api/src/qemu/" 2>/dev/null \
+    | jq -r '.versions[]? | select((.suites // []) | any(. == "stable" or . == "testing"))
+             | .version' \
+    | sed -nE 's/^[0-9]+:([0-9]+\.[0-9]+\.[0-9]+).*/\1/p' \
+    | sort -Vru
+}
+# --
+
+function populate_sysext_root() {
+  local sysextroot="$1"
+  local arch="$2"
+  local version="$3"
+
+  if [[ "${arch}" != "x86-64" ]]; then
+    echo "ERROR: the qemu sysext currently supports only x86-64." >&2
+    return 1
+  fi
+
+  # Pick the Debian suite whose qemu matches the requested version.
+  local suite="stable"
+  if ! curl -fsSL "https://sources.debian.org/api/src/qemu/" 2>/dev/null \
+       | jq -e --arg v "${version}" '.versions[]? | select((.suites // []) | index("stable"))
+                                     | select(.version | test("^[0-9]+:" + ($v | gsub("\\.";"\\.")) ))' >/dev/null; then
+    suite="testing"
+  fi
+
+  # Extract qemu + its runtime closure + firmware into the sysext root, and
+  # write the loader wrapper. Runs in a Debian container of the chosen suite.
+  docker run --rm -v "${sysextroot}:/out" "debian:${suite}-slim" bash -euc '
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get update -qq
+    apt-get install -y -qq --no-install-recommends \
+      qemu-system-x86 qemu-system-data seabios ipxe-qemu ovmf >/dev/null
+
+    bundle=/out/usr/lib/qemu-bundle
+    mkdir -p "$bundle" /out/usr/bin /out/usr/share
+
+    bin=/usr/bin/qemu-system-x86_64
+    cp -aL "$bin" "$bundle/qemu-system-x86_64"
+
+    copy_libs() {
+      local f="$1" lib dest
+      ldd "$f" 2>/dev/null | sed -nE "s/.*=> (\/[^ ]+).*/\1/p; s/^\s*(\/lib[^ ]*ld-[^ ]+).*/\1/p" \
+        | sort -u | while read -r lib; do
+          [ -e "$lib" ] || continue
+          dest="$bundle/$(basename "$lib")"
+          [ -e "$dest" ] && continue
+          cp -aL "$lib" "$dest"
+          copy_libs "$lib"
+        done
+    }
+    copy_libs "$bin"
+    [ -d /usr/lib/x86_64-linux-gnu/qemu ] && cp -aL /usr/lib/x86_64-linux-gnu/qemu "$bundle/modules" || true
+
+    for d in qemu seabios ipxe ovmf OVMF; do
+      [ -d "/usr/share/$d" ] && cp -aL "/usr/share/$d" /out/usr/share/ || true
+    done
+
+    loader="$(basename "$(ls "$bundle"/ld-linux* | head -1)")"
+    cat > /out/usr/bin/qemu-system-x86_64 <<EOF
+#!/bin/sh
+b=/usr/lib/qemu-bundle
+exec "\$b/$loader" --library-path "\$b:\$b/modules" \
+  "\$b/qemu-system-x86_64" -L /usr/share/qemu "\$@"
+EOF
+    chmod +x /out/usr/bin/qemu-system-x86_64
+  '
+}
+# --

--- a/qemu.sysext/create.sh
+++ b/qemu.sysext/create.sh
@@ -16,12 +16,17 @@ RELOAD_SERVICES_ON_MERGE="false"
 
 DEBIAN_QEMU_API="https://sources.debian.org/api/src/qemu/"
 
+# A transient network hiccup should not fail a build; same retry policy the
+# other recipes in this repo use (consul, haproxy, nomad, vault).
+CURL_RETRY=(--retry-delay 1 --retry 60 --retry-connrefused
+            --retry-max-time 60 --connect-timeout 20)
+
 # Resolve a Debian suite alias (stable/testing) to its codename from the archive
 # Release file, e.g. stable -> trixie. The sources API tags versions by codename
 # only, so we need this mapping. Fails if the lookup can't be made.
 function _debian_codename() {
   local alias="$1" codename
-  codename="$(curl -fsSL "https://deb.debian.org/debian/dists/${alias}/Release" 2>/dev/null \
+  codename="$(curl -fsSL "${CURL_RETRY[@]}" "https://deb.debian.org/debian/dists/${alias}/Release" 2>/dev/null \
     | sed -nE 's/^Codename:[[:space:]]*([^[:space:]]+).*/\1/p')" || return 1
   [[ -n "${codename}" ]] || return 1
   printf '%s\n' "${codename}"
@@ -58,7 +63,7 @@ function list_available_versions() {
     echo "ERROR: failed to resolve Debian stable/testing codenames." >&2
     return 1
   }
-  api="$(curl -fsSL "${DEBIAN_QEMU_API}")" || {
+  api="$(curl -fsSL "${CURL_RETRY[@]}" "${DEBIAN_QEMU_API}")" || {
     echo "ERROR: failed to query the Debian sources API (${DEBIAN_QEMU_API})." >&2
     return 1
   }
@@ -85,7 +90,7 @@ function populate_sysext_root() {
     echo "ERROR: failed to resolve Debian stable/testing codenames." >&2
     return 1
   }
-  api="$(curl -fsSL "${DEBIAN_QEMU_API}")" || {
+  api="$(curl -fsSL "${CURL_RETRY[@]}" "${DEBIAN_QEMU_API}")" || {
     echo "ERROR: failed to query the Debian sources API (${DEBIAN_QEMU_API})." >&2
     return 1
   }
@@ -117,8 +122,10 @@ function populate_sysext_root() {
   fi
 
   # Build the sysext inside a Debian container of the chosen suite: install QEMU,
-  # verify it actually matches the requested version (a moved suite must not
-  # silently produce a different build), then hand the binary + firmware to
+  # check the installed binary reports the requested upstream x.y.z (a suite that
+  # moved under us must not silently produce a different QEMU release; note this
+  # does not pin the Debian package revision, so the same x.y.z can still be a
+  # different build), then hand the binary + firmware to
   # tools/flix.sh, which resolves the library closure and patchelf's the binary
   # onto a private loader/rpath. No -L wrapper is needed: QEMU finds firmware in
   # its compiled-in data dir (/usr/share/qemu), which we ship.

--- a/qemu.sysext/create.sh
+++ b/qemu.sysext/create.sh
@@ -8,8 +8,9 @@
 # glibc + the dynamic loader) and firmware, extracted from a Debian container.
 # tools/flix.sh resolves the closure and patchelf's the binary onto a private
 # loader/rpath, isolating it from the host's libraries (same approach as
-# tilde.sysext). Debian packages QEMU, so the version parameter selects the
-# Debian suite (stable/testing) that ships it. Only x86-64 is supported for now.
+# tilde.sysext). The version parameter is a QEMU x.y.z release (or "latest");
+# the recipe then picks whichever Debian suite currently ships that version.
+# Only x86-64 is supported for now.
 
 RELOAD_SERVICES_ON_MERGE="false"
 

--- a/release_build_versions.txt
+++ b/release_build_versions.txt
@@ -74,6 +74,9 @@ nvidia-runtime latest
 
 ollama latest
 
+qemu 10.0.11
+qemu latest
+
 rke2 v1.32.2+rke2r1
 rke2 latest
 


### PR DESCRIPTION
Adds a `qemu` sysext shipping `qemu-system-x86_64`, e.g. as the backing hypervisor for Nomad's `qemu` task driver on Flatcar.

QEMU has no upstream static/portable release, so the recipe bundles the binary with its full shared-library closure (glibc + dynamic loader) and firmware (SeaBIOS, iPXE option ROMs, OVMF), extracted from a Debian container. `tools/flix.sh` resolves the closure and patchelf's the binary onto a private loader and rpath, isolating it from the host's libraries (same approach as `tilde.sysext`). No wrapper script and no `-L` flag are needed: QEMU finds the bundled firmware through its compiled-in data directory (`/usr/share/qemu`), which the sysext ships. User-mode (SLIRP) networking is included so guests get NAT egress with no host bridge setup.

- `qemu.sysext/create.sh`: resolve the Debian suite that ships the requested QEMU version, extract, and bundle via `tools/flix.sh`
- `docs/qemu.md` + index entry
- `release_build_versions.txt`: `qemu 10.0.11`

The version parameter is a QEMU release (`x.y.z` or `latest`); the recipe resolves whichever Debian suite currently ships it and verifies the installed binary matches, so a moved suite cannot silently produce a different build.

x86-64 only for now. Verified on a Flatcar node: the merged sysext's `qemu-system-x86_64` runs and `-netdev user` (SLIRP) works, booting a NixOS guest that reaches multi-user with NAT egress.

Note: this is an unconventional recipe (distro-extraction + glibc bundle) since there's no upstream portable qemu — open to a cleaner approach if maintainers prefer.