### PR TITLE
tests: add sysext smoke test framework and initial tests for docker, containerd, kubernetes

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -1,0 +1,133 @@
+name: Sysext smoke tests
+
+on:
+  pull_request:
+    paths:
+      - '**.sysext/**'
+      - 'lib/test.sh'
+      - 'bakery.sh'
+      - '.github/workflows/smoke-test.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - '**.sysext/**'
+      - 'lib/test.sh'
+      - 'bakery.sh'
+
+jobs:
+  detect-changed-extensions:
+    runs-on: ubuntu-24.04
+    outputs:
+      extensions: ${{ steps.detect.outputs.extensions }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect changed extensions
+        id: detect
+        run: |
+          set -euo pipefail
+
+          # On a PR, compare against the base branch.
+          # On a push to main, compare against the previous commit.
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            base="${{ github.event.pull_request.base.sha }}"
+          else
+            base="${{ github.event.before }}"
+          fi
+
+          changed="$(git diff --name-only "${base}" HEAD \
+                     | grep -oE '^[^/]+\.sysext' \
+                     | sed 's/\.sysext$//' \
+                     | sort -u || true)"
+
+          # Also always run if lib/test.sh or bakery.sh changed.
+          core_changed="$(git diff --name-only "${base}" HEAD \
+                          | grep -qE '^(lib/test\.sh|bakery\.sh)$' \
+                          && echo 'true' || echo 'false')"
+
+          if [[ "${core_changed}" == 'true' ]]; then
+            # Run tests for every extension that has a non-empty test.sh
+            changed="$(find . -maxdepth 2 -name 'test.sh' -size +0c \
+                        | sed 's|\./\(.*\)\.sysext/test\.sh|\1|' \
+                        | sort -u)"
+          fi
+
+          if [[ -z "${changed}" ]]; then
+            echo "No extensions with changes detected — skipping tests."
+            echo 'extensions=[]' >> "${GITHUB_OUTPUT}"
+          else
+            json="$(echo "${changed}" | jq -R . | jq -sc .)"
+            echo "Extensions to test: ${json}"
+            echo "extensions=${json}" >> "${GITHUB_OUTPUT}"
+          fi
+
+  smoke-test:
+    needs: detect-changed-extensions
+    if: ${{ needs.detect-changed-extensions.outputs.extensions != '[]' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        extension: ${{ fromJson(needs.detect-changed-extensions.outputs.extensions) }}
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install prerequisites
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -yqq \
+            curl \
+            jq \
+            squashfs-tools \
+            xz-utils \
+            erofs-utils
+
+      - name: Build sysext — ${{ matrix.extension }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          version="$(./bakery.sh list "${{ matrix.extension }}" --latest true \
+                     | head -n 1 | awk '{print $1}')"
+
+          if [[ -z "${version}" ]]; then
+            echo "Could not determine latest version for '${{ matrix.extension }}' — skipping build."
+            echo "SKIP_TEST=true" >> "${GITHUB_ENV}"
+            exit 0
+          fi
+
+          echo "Building ${{ matrix.extension }} version ${version}"
+          ./bakery.sh create "${{ matrix.extension }}" "${version}"
+
+      - name: Extract sysext root — ${{ matrix.extension }}
+        if: env.SKIP_TEST != 'true'
+        run: |
+          set -euo pipefail
+
+          imgfile="$(ls ${{ matrix.extension }}-*.raw 2>/dev/null | head -n 1)"
+          if [[ -z "${imgfile}" ]]; then
+            echo "No .raw image found for '${{ matrix.extension }}' — skipping test."
+            echo "SKIP_TEST=true" >> "${GITHUB_ENV}"
+            exit 0
+          fi
+
+          mkdir -p sysext-root
+          # Try unsquashfs first, fall back to mount loop for ext4/erofs images.
+          if file "${imgfile}" | grep -q squashfs; then
+            unsquashfs -d sysext-root "${imgfile}"
+          else
+            sudo mount -o loop,ro "${imgfile}" /mnt
+            sudo cp -a /mnt/. sysext-root/
+            sudo umount /mnt
+            sudo chown -R "$(id -u):$(id -g)" sysext-root
+          fi
+
+      - name: Run smoke tests — ${{ matrix.extension }}
+        if: env.SKIP_TEST != 'true'
+        run: |
+          set -euo pipefail
+          ./bakery.sh test sysext-root "${{ matrix.extension }}"

--- a/_skel.sysext/test.sh
+++ b/_skel.sysext/test.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# vim: et ts=2 syn=bash
+#
+# Smoke test skeleton for sysext bakery extensions.
+#
+# Copy this file to <your-extension>.sysext/test.sh and implement run_tests().
+#
+# All helper functions (test_binary_exists, test_binary_version, etc.) are
+# provided by lib/test.sh and are available here automatically.
+#
+
+# run_tests is called by "bakery.sh test <sysext-root> <extension-name>".
+# The sysext root directory is available as ${_TEST_SYSEXTROOT}.
+function run_tests() {
+  # 1. Verify the extension-release file is present and non-empty.
+  test_extension_release_present "CHANGEME"
+
+  # 2. Verify no /usr/sbin is shipped (Flatcar constraint).
+  test_no_usr_sbin
+
+  # 3. Check that expected binaries are present in the sysext root.
+  test_binary_exists "CHANGEME"
+
+  # 4. After the sysext is merged on a live system, check version output.
+  #    Uncomment and adapt when running an integration test.
+  # test_binary_version "CHANGEME" "--version" "CHANGEME version [0-9]"
+
+  # 5. Check that required systemd unit files are present (if your sysext
+  #    ships a service).
+  # test_service_file_exists "CHANGEME.service"
+}

--- a/bakery.sh
+++ b/bakery.sh
@@ -26,6 +26,8 @@ function usage() {
   echo "  create <sysext> help          - List sysext specific parameters. Rarely used."
   echo "  boot <sysext> [<sysext> ...]  - Boot a local Flatcar VM (qemu) with sysext(s) merged."
   echo "                                  Great for testing and interactively exploring sysexts."
+  echo "  test <sysext-root> <sysext>   - Run smoke tests for <sysext> against a populated sysext"
+  echo "                                  root directory. Does not require a live VM."
   echo
   echo "Use '$0 <command> help' to print help for a specific command."
   echo
@@ -144,10 +146,14 @@ function create_sysext() {
 # --
 
 case "${1:-}" in
-  list|list-bakery|create|boot|test)
+  list|list-bakery|create|boot)
     cmd="${1}"
     shift
     "${cmd}"_sysext "${@}"
+    ;;
+  test)
+    shift
+    test_sysext "${@}"
     ;;
   *) usage;
   ;;

--- a/containerd.sysext/test.sh
+++ b/containerd.sysext/test.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# vim: et ts=2 syn=bash
+#
+# Smoke tests for the containerd sysext.
+#
+# Tests run against the populated sysext root directory (static analysis).
+# They do NOT require a live Flatcar VM.
+#
+
+function run_tests() {
+  # --- Extension metadata ---
+  test_extension_release_present "containerd"
+
+  # --- Flatcar-specific constraint ---
+  test_no_usr_sbin
+
+  # --- Core binaries ---
+  test_binary_exists "containerd"
+  test_binary_exists "containerd-shim-runc-v2"
+  test_binary_exists "ctr"
+  test_binary_exists "runc"
+}

--- a/docker.sysext/test.sh
+++ b/docker.sysext/test.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# vim: et ts=2 syn=bash
+#
+# Smoke tests for the docker sysext.
+#
+# Tests run against the populated sysext root directory (static analysis).
+# They do NOT require a live Flatcar VM.
+#
+
+function run_tests() {
+  # --- Extension metadata ---
+  test_extension_release_present "docker"
+
+  # --- Flatcar-specific constraint ---
+  test_no_usr_sbin
+
+  # --- Core Docker binaries ---
+  test_binary_exists "docker"
+  test_binary_exists "dockerd"
+  test_binary_exists "docker-init"
+  test_binary_exists "docker-proxy"
+
+  # --- Containerd and runc (bundled with docker sysext) ---
+  test_binary_exists "containerd"
+  test_binary_exists "containerd-shim-runc-v2"
+  test_binary_exists "ctr"
+  test_binary_exists "runc"
+
+  # --- systemd unit files ---
+  test_service_file_exists "docker.service"
+  test_service_file_exists "docker.socket"
+  test_service_file_exists "containerd.service"
+
+  # --- containerd config files ---
+  test_file_exists "usr/share/containerd/config.toml"
+}

--- a/kubernetes.sysext/test.sh
+++ b/kubernetes.sysext/test.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# vim: et ts=2 syn=bash
+#
+# Smoke tests for the kubernetes sysext.
+#
+# Tests run against the populated sysext root directory (static analysis).
+# They do NOT require a live Flatcar VM.
+#
+
+function run_tests() {
+  # --- Extension metadata ---
+  test_extension_release_present "kubernetes"
+
+  # --- Flatcar-specific constraint ---
+  test_no_usr_sbin
+
+  # --- Core Kubernetes binaries ---
+  test_binary_exists "kubectl"
+  test_binary_exists "kubeadm"
+  test_binary_exists "kubelet"
+
+  # --- systemd unit files ---
+  test_service_file_exists "kubelet.service"
+
+  # --- Version files written by populate_sysext_root ---
+  test_file_exists "usr/local/share/kubernetes-version"
+  test_file_exists "usr/local/share/kubernetes-cni-version"
+
+  # --- CNI plugin directory ---
+  test_file_exists "usr/local/bin/cni"
+}

--- a/lib/test.sh
+++ b/lib/test.sh
@@ -1,0 +1,239 @@
+#!/usr/bin/env bash
+# vim: et ts=2 syn=bash
+#
+# Bakery library: shared helpers for sysext smoke tests.
+#
+# Copyright (c) 2025 the Flatcar Maintainers.
+# Use of this source code is governed by the Apache 2.0 license.
+#
+# Usage from an extension's test.sh:
+#
+#   source "${scriptroot}/lib/libbakery.sh"
+#
+#   function run_tests() {
+#     test_binary_exists "docker"
+#     test_binary_version "docker" "--version"
+#     test_service_file_exists "docker.service"
+#     # ... add more assertions ...
+#   }
+#
+# All test_* functions increment TESTS_PASSED or TESTS_FAILED counters and
+# print a concise PASS/FAIL line.  Call test_summary at the end to print a
+# result summary and exit with a non-zero code when any test failed.
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+_pass() {
+  local desc="$1"
+  : $(( TESTS_PASSED++ ))
+  echo "  PASS  ${desc}"
+}
+
+_fail() {
+  local desc="$1"
+  local detail="${2:-}"
+  : $(( TESTS_FAILED++ ))
+  echo "  FAIL  ${desc}"
+  if [[ -n "${detail}" ]]; then
+    echo "        ${detail}"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Assertion helpers
+# ---------------------------------------------------------------------------
+
+# test_binary_exists <binary>
+# Assert that <binary> is present somewhere in PATH inside the sysext root.
+function test_binary_exists() {
+  local binary="$1"
+  local sysextroot="${2:-${_TEST_SYSEXTROOT:-}}"
+
+  if [[ -n "${sysextroot}" ]]; then
+    if find "${sysextroot}/usr/bin" "${sysextroot}/usr/sbin" \
+         -maxdepth 1 -name "${binary}" 2>/dev/null | grep -q .; then
+      _pass "binary '${binary}' present in sysext root"
+    else
+      _fail "binary '${binary}' NOT found in sysext root" \
+            "searched: ${sysextroot}/usr/bin, ${sysextroot}/usr/sbin"
+    fi
+  else
+    if command -v "${binary}" &>/dev/null; then
+      _pass "binary '${binary}' found in PATH"
+    else
+      _fail "binary '${binary}' NOT found in PATH"
+    fi
+  fi
+}
+
+# test_binary_version <binary> <version_flag> [expected_pattern]
+# Assert that running "<binary> <version_flag>" exits 0 and optionally that
+# its output matches <expected_pattern> (an ERE passed to grep -E).
+function test_binary_version() {
+  local binary="$1"
+  local flag="${2:---version}"
+  local pattern="${3:-}"
+
+  local output
+  if output="$("${binary}" "${flag}" 2>&1)"; then
+    if [[ -n "${pattern}" ]]; then
+      if echo "${output}" | grep -qE "${pattern}"; then
+        _pass "'${binary} ${flag}' output matches '${pattern}'"
+      else
+        _fail "'${binary} ${flag}' output does NOT match '${pattern}'" \
+              "got: ${output}"
+      fi
+    else
+      _pass "'${binary} ${flag}' exited 0"
+    fi
+  else
+    _fail "'${binary} ${flag}' exited non-zero" "output: ${output}"
+  fi
+}
+
+# test_service_file_exists <unit-file>
+# Assert that <unit-file> exists in the sysext root under
+# usr/lib/systemd/system/.
+function test_service_file_exists() {
+  local unit="$1"
+  local sysextroot="${2:-${_TEST_SYSEXTROOT:-}}"
+
+  if [[ -z "${sysextroot}" ]]; then
+    _fail "test_service_file_exists: sysext root not set" \
+          "pass it as second arg or set _TEST_SYSEXTROOT"
+    return
+  fi
+
+  local path="${sysextroot}/usr/lib/systemd/system/${unit}"
+  if [[ -f "${path}" ]]; then
+    _pass "unit file '${unit}' present in sysext root"
+  else
+    _fail "unit file '${unit}' NOT found in sysext root" \
+          "expected: ${path}"
+  fi
+}
+
+# test_file_exists <path-inside-sysext>
+# Assert that a file exists at <path-inside-sysext> relative to the sysext root.
+function test_file_exists() {
+  local relpath="$1"
+  local sysextroot="${2:-${_TEST_SYSEXTROOT:-}}"
+
+  if [[ -z "${sysextroot}" ]]; then
+    _fail "test_file_exists: sysext root not set"
+    return
+  fi
+
+  local full="${sysextroot}/${relpath}"
+  if [[ -e "${full}" ]]; then
+    _pass "file '${relpath}' present in sysext root"
+  else
+    _fail "file '${relpath}' NOT found in sysext root" \
+          "expected: ${full}"
+  fi
+}
+
+# test_extension_release_present <extension-name>
+# Assert that the extension-release file is present and non-empty.
+function test_extension_release_present() {
+  local extname="$1"
+  local sysextroot="${2:-${_TEST_SYSEXTROOT:-}}"
+
+  if [[ -z "${sysextroot}" ]]; then
+    _fail "test_extension_release_present: sysext root not set"
+    return
+  fi
+
+  local relfile="usr/lib/extension-release.d/extension-release.${extname}"
+  local full="${sysextroot}/${relfile}"
+
+  if [[ -s "${full}" ]]; then
+    _pass "extension-release file present and non-empty"
+  elif [[ -f "${full}" ]]; then
+    _fail "extension-release file exists but is EMPTY" "path: ${full}"
+  else
+    _fail "extension-release file NOT found" "expected: ${full}"
+  fi
+}
+
+# test_no_usr_sbin <sysext-root>
+# Assert that the sysext does NOT ship /usr/sbin (which would shadow the
+# host symlink on Flatcar).
+function test_no_usr_sbin() {
+  local sysextroot="${1:-${_TEST_SYSEXTROOT:-}}"
+
+  if [[ -z "${sysextroot}" ]]; then
+    _fail "test_no_usr_sbin: sysext root not set"
+    return
+  fi
+
+  if [[ -d "${sysextroot}/usr/sbin" ]]; then
+    _fail "sysext ships /usr/sbin — this will shadow the Flatcar host symlink" \
+          "move binaries to /usr/bin instead"
+  else
+    _pass "sysext does not ship /usr/sbin"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Test runner
+# ---------------------------------------------------------------------------
+
+# test_summary
+# Print a summary of all PASS/FAIL results and exit 1 if any test failed.
+function test_summary() {
+  local total=$(( TESTS_PASSED + TESTS_FAILED ))
+  echo
+  echo "  Results: ${TESTS_PASSED}/${total} passed, ${TESTS_FAILED} failed"
+  if [[ ${TESTS_FAILED} -gt 0 ]]; then
+    echo "  OVERALL: FAIL"
+    exit 1
+  else
+    echo "  OVERALL: PASS"
+  fi
+}
+
+# test_sysext <sysext-root> <extension-name>
+# Entry point called by bakery.sh's "test" command.
+# Sources the extension's test.sh and calls run_tests if defined.
+function test_sysext() {
+  (
+    set -euo pipefail
+
+    local sysextroot="$(get_positional_param "1" "${@}")"
+    local extname="$(get_positional_param "2" "${@}")"
+
+    if [[ -z "${sysextroot}" || -z "${extname}" ]]; then
+      echo "Usage: bakery.sh test <sysext-root-dir> <extension-name>"
+      exit 1
+    fi
+
+    export _TEST_SYSEXTROOT="${sysextroot}"
+
+    local testscript="${scriptroot}/${extname}.sysext/test.sh"
+    if [[ ! -f "${testscript}" ]]; then
+      echo "No test.sh found for extension '${extname}' — skipping."
+      exit 0
+    fi
+
+    echo
+    echo "  Running smoke tests for '${extname}'"
+    echo "  Sysext root: ${sysextroot}"
+    echo
+
+    source "${testscript}"
+
+    if declare -f run_tests &>/dev/null; then
+      run_tests
+    else
+      echo "  WARNING: test.sh found but no run_tests() function defined — nothing to run."
+    fi
+
+    test_summary
+  )
+}


### PR DESCRIPTION
## Summary

This PR implements the sysext smoke test framework proposed in [flatcar/Flatcar#2294](https://github.com/flatcar/Flatcar/issues/2294).

All 28 `test.sh` files in the repo were empty placeholders. The `bakery.sh` `case` statement already had a `test` entry but it called a non-existent `test_sysext` function. This PR fills in that entire chain.

---

## Changes

### `lib/test.sh` shared assertion library

New helper functions available to every extension's `test.sh`:

| Function | What it checks |
|---|---|
| `test_binary_exists` | Binary present in sysext root `usr/bin` |
| `test_binary_version` | Binary exits 0 with a version flag |
| `test_service_file_exists` | systemd unit file present in sysext root |
| `test_file_exists` | Arbitrary path present in sysext root |
| `test_extension_release_present` | `extension-release.d` metadata file present and non-empty |
| `test_no_usr_sbin` | Sysext does not ship `/usr/sbin` (Flatcar constraint) |
| `test_summary` | Prints pass/fail summary, exits non-zero on failure |

Also adds `test_sysext()` the entry point called by `bakery.sh test <sysext-root> <extension-name>`.

### `bakery.sh`

- Wires `test_sysext` into the `test` case (previously the stub called a non-existent function)
- Adds `test` command description to usage docs

### Extension `test.sh` implementations

| File | What it tests |
|---|---|
| `_skel.sysext/test.sh` | Template for new extension contributors |
| `docker.sysext/test.sh` | All docker + containerd binaries and unit files |
| `containerd.sysext/test.sh` | containerd + runc binaries |
| `kubernetes.sysext/test.sh` | kubectl/kubeadm/kubelet, kubelet.service, version files, CNI dir |

### `.github/workflows/smoke-test.yml` CI integration

- Detects which extensions changed in a PR using `git diff`
- Builds the latest release of each changed extension via `bakery.sh create`
- Extracts the `.raw` image (squashfs or ext4/erofs) into a sysext root dir
- Runs `bakery.sh test` against the extracted root
- When `lib/test.sh` or `bakery.sh` itself changes, runs tests for **all** extensions that have a non-empty `test.sh`

---

## How tests work

These are **static-analysis tests** they run against the populated sysext root directory on the CI runner, not inside a live Flatcar VM. They validate:

1. The extension ships the expected binaries in `usr/bin`
2. Required systemd unit files are present under `usr/lib/systemd/system`
3. No `/usr/sbin` is shipped (Flatcar-specific constraint, it's a symlink on the host)
4. The `extension-release.d` metadata file is present and non-empty

---

## Next steps (out of scope for this PR)

- Add `test.sh` implementations for the remaining 24 extensions
- Add live VM integration tests using the existing `boot_sysext` infrastructure from `lib/boot.sh`

---

Closes flatcar/Flatcar#2294
