### PR TITLE
Implement `bakery.sh test` to validate built sysext images and gate pull requests on it

### DIFF
--- a/.github/workflows/test-extensions.yaml
+++ b/.github/workflows/test-extensions.yaml
@@ -1,0 +1,121 @@
+name: Build and validate extensions changed by a pull request
+
+on:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      extensions:
+        description: 'space separated list of extensions to build and validate'
+        type: string
+        required: false
+
+permissions:
+  contents: read
+
+jobs:
+  list-extensions:
+    runs-on: ubuntu-24.04
+    outputs:
+      extensions: ${{ steps.list.outputs.extensions }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # the full history is needed to diff against the pull request's base
+          fetch-depth: 0
+          path: bakery
+
+      - name: list extensions to validate
+        id: list
+        env:
+          # Never interpolate inputs into the script itself; they are attacker
+          #  controlled and would be executed by the shell.
+          requested_extensions: ${{ inputs.extensions }}
+          base_ref: ${{ github.base_ref }}
+          # Extensions to validate when the bakery itself changed. These are
+          #  cheap to build and cover both a plain binary and a service unit.
+          fallback_extensions: 'docker-compose tailscale'
+        run: |
+          set -euo pipefail
+          pushd bakery
+
+          if [[ -n "${requested_extensions}" ]] ; then
+            extensions="${requested_extensions}"
+          elif [[ -n "${base_ref}" ]] ; then
+            git fetch --quiet origin "${base_ref}"
+            files="$(git diff --name-only "origin/${base_ref}...HEAD")"
+
+            # Extensions the pull request touches, plus the fallback set if it
+            #  touches the build and test tooling all extensions share.
+            extensions="$(echo "${files}" | sed --silent -r 's,^([^/]+)\.sysext/.*,\1,p')"
+            if echo "${files}" | grep -qE '^(bakery\.sh|lib/|tools/)' ; then
+              extensions+=" ${fallback_extensions}"
+            fi
+          else
+            extensions="${fallback_extensions}"
+          fi
+
+          # The skeleton is a template, not a buildable extension.
+          extensions="$(echo "${extensions}" | tr ' ' '\n' | { grep -v '^_skel$' || true ; } | sort -u)"
+
+          echo "Extensions to validate: $(echo ${extensions})"
+          echo "extensions=$(echo "${extensions}" | jq -R -s -c 'split("\n") | map(select(length > 0))')" \
+            >> "${GITHUB_OUTPUT}"
+
+  validate-extensions:
+    needs: list-extensions
+    if: ${{ needs.list-extensions.outputs.extensions != '[]' && needs.list-extensions.outputs.extensions != '' }}
+    strategy:
+      # Report all broken extensions / architectures, not just the first one.
+      fail-fast: false
+      matrix:
+        extension: ${{ fromJson(needs.list-extensions.outputs.extensions) }}
+        arch: [ x86-64, arm64 ]
+
+    runs-on: ubuntu-24.04
+    env:
+      extension: ${{ matrix.extension }}
+      arch: ${{ matrix.arch }}
+    steps:
+      - name: Set up qemu / binfmt misc for cross-platform builds
+        uses: docker/setup-qemu-action@v3
+
+      - uses: actions/checkout@v4
+        with:
+          path: bakery
+
+      - name: install prerequisites
+        run: |
+          set -euxo pipefail
+
+          sudo apt update -qq && sudo apt install -yqq \
+            curl \
+            jq \
+            squashfs-tools \
+            xz-utils \
+            erofs-utils
+
+      - name: build the extension
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          pushd bakery
+
+          version="$(./bakery.sh list "${extension}" --latest true | head -n 1)"
+          if [[ -z "${version}" ]] ; then
+            echo "ERROR: no version to build. Does '${extension}.sysext/create.sh'"
+            echo "       implement list_available_versions()?"
+            exit 1
+          fi
+
+          echo "Building ${extension} ${version} for ${arch}"
+          ./bakery.sh create "${extension}" "${version}" --arch "${arch}"
+
+      - name: validate the extension image
+        run: |
+          set -euo pipefail
+          pushd bakery
+
+          # Image validation only; the extensions' smoke tests need a VM and are
+          #  run locally via './bakery.sh test <extension> --vm true'.
+          ./bakery.sh test "${extension}" --arch "${arch}"

--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,5 @@ tags
 
 *test.json
 *test.yaml
+*-vm-test.log
 *flatcar_production_*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,3 +13,36 @@ If you want to file an issue for any Flatcar repository, please use the [central
 Any guidelines specific to this repository that are not covered in the main contribution guide will be listed here.
 
 <!-- Add repo-specific guidelines below this line -->
+
+### Test your extension before opening a pull request
+
+Build the extension and validate the resulting image:
+
+```sh
+./bakery.sh create <extension> <version>
+./bakery.sh test <extension>
+```
+
+`bakery.sh test` checks the image for the metadata, layout, and file ownership
+`systemd-sysext` requires, for binaries built for the wrong architecture, and for systemd
+units running commands that are not shipped. It exits non-zero if any check fails.
+
+Please validate both architectures when you change how an extension is built:
+
+```sh
+./bakery.sh create <extension> <version> --arch arm64
+./bakery.sh test <extension> --arch arm64
+```
+
+Pull requests that touch an extension - or the shared build and test code in `lib/` -
+build and validate the affected extensions automatically for both architectures.
+
+Extensions may also ship smoke tests in `<extension>.sysext/test.sh` that run on a booted
+system with the extension merged. Implementing them is optional but appreciated:
+
+```sh
+./bakery.sh test <extension> --vm true
+```
+
+The hook contract is documented in [`_skel.sysext/test.sh`](_skel.sysext/test.sh).
+Running these tests needs qemu and docker; they are not part of the pull request CI.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,8 +24,11 @@ Build the extension and validate the resulting image:
 ```
 
 `bakery.sh test` checks the image for the metadata, layout, and file ownership
-`systemd-sysext` requires, for binaries built for the wrong architecture, and for systemd
-units running commands that are not shipped. It exits non-zero if any check fails.
+`systemd-sysext` requires, and for binaries built for the wrong architecture. It also checks
+the systemd units the extension ships: a unit running a binary the extension ships at a
+different path fails the check, and a command the extension does not ship at all is reported
+as a warning, since it has to be provided by the OS image. It exits non-zero if any check
+fails.
 
 Please validate both architectures when you change how an extension is built:
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,53 @@ to display these; e.g.
 ./bakery.sh create docker help
 ```
 
+### Validate extension images
+
+Built extension images can be validated with
+
+```sh
+./bakery.sh test <extension>
+```
+
+, e.g.
+```sh
+./bakery.sh test kubernetes
+```
+
+The command checks the image for everything that makes `systemd-sysext` merge it, and makes
+ the merged extension work:
+- the extension release metadata is present, names the extension, and matches the target OS
+  and architecture,
+- all files are shipped below `usr/` or `opt/` - files anywhere else are dropped on merge,
+- the image ships no `usr/sbin` directory, which would replace Flatcar's `/usr/sbin` symlink
+  and hide all host binaries in it,
+- all files are owned by `root`,
+- all shipped binaries are built for the target architecture,
+- all commands the shipped systemd units run exist, either in the extension or in the OS image.
+
+The command exits non-zero if any check fails, so it can be used in scripts and CI.
+It takes an extension name, or the path of an image built with `--output-file`:
+
+```sh
+./bakery.sh test kubernetes-v1.32.0-arm64.raw --arch arm64
+```
+
+Pull requests that change an extension are built and validated automatically; see
+ [`.github/workflows/test-extensions.yaml`](.github/workflows/test-extensions.yaml).
+
+Extensions can additionally implement smoke tests in `<extension>.sysext/test.sh` that run
+ on a booted system with the extension merged:
+
+```sh
+./bakery.sh test <extension> --vm true
+```
+
+This boots a local Flatcar VM (see below), merges the extension, runs the extension's
+ `run_tests()` hook, and reports the result.
+See [`_skel.sysext/test.sh`](_skel.sysext/test.sh) for the hook contract, and
+ [tailscale](/tailscale.sysext/test.sh), [btop](/btop.sysext/test.sh), and
+ [docker-compose](/docker-compose.sysext/test.sh) for examples.
+
 ### Interactively test extension images in a local VM
 
 Extension images can be tested and explored interactively in a local Flatcar VM.
@@ -156,9 +203,18 @@ To add an extension:
    - `populate_sysext_root` populates the system extension root directory (available via `$sysextroot`).
       This function runs in a temporary directory; stuff can be downloaded / built in `./` and then moved to `$sysextroot`.
       The temporary directory will be removed when the extension build is complete (or when it errors out); no need to clean up manually.
-4. Add `docs/<my-extension-name>.md` with documentation and example configuration for the new extension, and reference the new file from the list of extensions in `docs/index.md`.
-5. Optionally add the new extension name to [release_build_versions.txt](https://github.com/flatcar/sysext-bakery/blob/main/release_build_versions.txt) to automatically build it when new upstream versions are released.
-6. File a PR.
+4. Build the extension and validate the image:
+  ```sh
+  ./bakery.sh create <my-extension-name> <version>
+  ./bakery.sh test <my-extension-name>
+  ```
+   The same validation runs on every pull request.
+5. Optionally implement the `run_tests` stub in `test.sh` to smoke test the extension on a
+   running system, and try it out with `./bakery.sh test <my-extension-name> --vm true`.
+   Delete `test.sh` if there is nothing to test.
+6. Add `docs/<my-extension-name>.md` with documentation and example configuration for the new extension, and reference the new file from the list of extensions in `docs/index.md`.
+7. Optionally add the new extension name to [release_build_versions.txt](https://github.com/flatcar/sysext-bakery/blob/main/release_build_versions.txt) to automatically build it when new upstream versions are released.
+8. File a PR.
 
 Done!
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,8 @@ The command checks the image for everything that makes `systemd-sysext` merge it
 - all files are shipped below `usr/` or `opt/` - files anywhere else are dropped on merge,
 - the image ships no `usr/sbin` directory, which would replace Flatcar's `/usr/sbin` symlink
   and hide all host binaries in it,
-- all files are owned by `root`,
+- all files are owned by `root`, read from the image itself. This is reported as skipped for
+  `erofs` images, whose ownership the bakery fixes to `root` at build time anyway,
 - all shipped binaries are built for the target architecture,
 - the commands the shipped systemd units run are shipped at the path the unit uses.
   A unit running a binary the extension ships somewhere else fails the check; a command the

--- a/README.md
+++ b/README.md
@@ -121,9 +121,14 @@ The command checks the image for everything that makes `systemd-sysext` merge it
   and hide all host binaries in it,
 - all files are owned by `root`,
 - all shipped binaries are built for the target architecture,
-- all commands the shipped systemd units run exist, either in the extension or in the OS image.
+- the commands the shipped systemd units run are shipped at the path the unit uses.
+  A unit running a binary the extension ships somewhere else fails the check; a command the
+  extension does not ship at all is reported as a warning, as it has to come with the OS image
+  and cannot be verified from the extension alone.
 
 The command exits non-zero if any check fails, so it can be used in scripts and CI.
+Images built with `--format ext2`, `--format ext4`, or `--format btrfs` cannot be validated;
+ only the default `squashfs` and `erofs` images can be read without root privileges.
 It takes an extension name, or the path of an image built with `--output-file`:
 
 ```sh

--- a/_skel.sysext/test.sh
+++ b/_skel.sysext/test.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# vim: et ts=2 syn=bash
+#
+# Extension test skeleton script for sysext bakery extensions.
+#
+
+# This script is optional. Delete it if the extension has nothing to smoke test.
+#
+# The functions in this script run INSIDE a Flatcar test VM that has the
+#  extension merged, started by
+#    ./bakery.sh test <extension> --vm true
+# The image itself - metadata, layout, file ownership, binary architecture, and
+#  the commands its systemd units refer to - is validated by 'bakery.sh test'
+#  before the VM is booted; there is no need to re-test any of that here.
+#
+# Only define functions here. This file is sourced, so any code at the top level
+#  runs on the host as well, e.g. when 'bakery.sh list' inspects the extension.
+
+# Smoke test the extension on a running Flatcar system.
+# Called by 'bakery.sh test <extension> --vm true' without arguments, as root.
+#
+# The test harness provides
+#   check "<description>" <command> [<argument> ...]
+# which runs <command>, reports the result, and records a failure if <command>
+#  exits non-zero. Failing checks do not abort the test run, so that a single
+#  run reports all problems. Alternatively, return a non-zero exit code to fail.
+#
+# Keep tests hermetic: they run in a throw-away VM without credentials, and
+#  network access to third parties makes CI flaky. Test that what the extension
+#  ships is there and works, not that the shipped application is correct.
+function run_tests() {
+  # TODO: add smoke tests for the extension here, e.g.
+  # check "the frobnicator runs"                 frobnicate --version
+  # check "the frobnicator service is running"   systemctl is-active frobnicator.service
+  # check "the default configuration is shipped" test -s /usr/share/frobnicator/config.toml
+  true
+}
+# --

--- a/bakery.sh
+++ b/bakery.sh
@@ -26,6 +26,9 @@ function usage() {
   echo "  create <sysext> help          - List sysext specific parameters. Rarely used."
   echo "  boot <sysext> [<sysext> ...]  - Boot a local Flatcar VM (qemu) with sysext(s) merged."
   echo "                                  Great for testing and interactively exploring sysexts."
+  echo "  test <sysext>                 - Validate a built system extension image."
+  echo "                                  Add '--vm true' to also run the extension's smoke"
+  echo "                                  tests in a local Flatcar VM."
   echo
   echo "Use '$0 <command> help' to print help for a specific command."
   echo

--- a/btop.sysext/test.sh
+++ b/btop.sysext/test.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# vim: et ts=2 syn=bash
+#
+# Smoke tests for the btop sysext.
+# See _skel.sysext/test.sh for the test hook contract.
+
+function run_tests() {
+  # btop ships as a flatwrap (see tools/flatwrap.sh): an entry point script in
+  #  /usr/bin that runs the real binary in a sandbox built from the extension's
+  #  own /usr/local tree. Running it covers the entry point, the sandbox setup,
+  #  and the shared libraries shipped alongside the binary.
+  check "btop runs" btop --version
+
+  check "the btop sandbox root is shipped" test -d /usr/local/btop
+}
+# --

--- a/docker-compose.sysext/test.sh
+++ b/docker-compose.sysext/test.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# vim: et ts=2 syn=bash
+#
+# Smoke tests for the docker-compose sysext.
+# See _skel.sysext/test.sh for the test hook contract.
+
+function run_tests() {
+  check "the compose plugin is installed" \
+        test -x /usr/local/lib/docker/cli-plugins/docker-compose
+
+  # Compose is a docker CLI plugin: it is only useful if the docker that comes
+  #  with the OS image picks it up from the directory the extension ships it in.
+  check "docker finds the compose plugin" docker compose version
+}
+# --

--- a/lib/list.sh
+++ b/lib/list.sh
@@ -55,7 +55,7 @@ function _list_all_sysexts() {
       has_files="Yes"
     fi
     local has_build="$(_has_function "${dir}/create.sh" "populate_sysext_root")"
-    local has_test="$(_has_function "${dir}/create.sh" "run_tests")"
+    local has_test="$(_has_function "${dir}/test.sh" "run_tests")"
 
     _print_line "${extname%.sysext}" "${has_files}" "${has_build}" "${has_test}"
   done

--- a/lib/test.sh
+++ b/lib/test.sh
@@ -1,0 +1,845 @@
+#!/usr/bin/env bash
+# vim: et ts=2 syn=bash
+#
+# Bakery library functions for validating built sysext images.
+#
+# Two layers of tests are implemented:
+#  1. Offline validation of the extension image itself. These checks run
+#     against the image file, do not need a VM, and are cheap enough for CI.
+#  2. Smoke tests of the extension on a running system. These are implemented
+#     by the extension in "<extension>.sysext/test.sh" and run in a local
+#     Flatcar VM (see lib/boot.sh) with the extension merged.
+#
+# Copyright (c) 2025 the Flatcar Maintainers.
+# Use of this source code is governed by the Apache 2.0 license.
+
+# Top level directories an extension may ship. Anything else is dropped when
+#  the extension is merged (systemd-sysext only overlays /usr and /opt).
+_sysext_top_level_dirs=( usr opt )
+
+# Directories an extension must never ship.
+#  On Flatcar /usr/sbin is a symlink to /usr/bin. An extension shipping a real
+#  usr/sbin directory replaces that symlink on merge, which hides all host
+#  binaries in /usr/sbin.
+_sysext_forbidden_dirs=( usr/sbin )
+
+# ELF machine types (e_machine, see <elf.h>) of the architectures we build for.
+declare -A _elf_machine_types=( [x86-64]=62 [arm64]=183 )
+
+# Commands commonly provided by the OS image. Units referring to these are not
+#  reported when the extension does not ship them itself.
+_os_provided_commands=( bash cat cp env kill ln mkdir modprobe mount mv rm
+                        sed sh sleep systemctl systemd-run touch umount )
+
+# Where the in-VM test harness and the extension's test hook are installed.
+_vm_test_dir="/var/lib/bakery-test"
+
+# Printed by the in-VM test harness to report the test result to the host.
+_vm_test_marker="__BAKERY_TEST_RESULT__"
+
+#
+#  ---------------- test result accounting ----------------
+#
+
+_test_failures=0
+_test_warnings=0
+
+# Maximum number of files reported individually per check. Anything beyond is
+#  summarised, to keep the output of a broken image readable.
+_test_max_reported=10
+
+function _test_section() {
+  echo
+  echo "== ${*}"
+}
+# --
+
+function _test_ok()   { echo "   ok   | ${*}"; }
+function _test_skip() { echo "   skip | ${*}"; }
+# --
+
+function _test_warn() {
+  echo "   warn | ${*}"
+  _test_warnings=$((_test_warnings + 1))
+}
+# --
+
+function _test_fail() {
+  echo "   FAIL | ${*}"
+  _test_failures=$((_test_failures + 1))
+}
+# --
+
+#
+#  ---------------- image inspection helpers ----------------
+#
+
+# Print <count> bytes read at <offset> of <file> as a plain hex string.
+function _read_hex() {
+  local file="$1"
+  local offset="$2"
+  local count="$3"
+
+  od --address-radix=n --format=x1 --skip-bytes="${offset}" --read-bytes="${count}" -v "${file}" \
+    | tr -d ' \n'
+}
+# --
+
+# Print the file system format of an extension image, detected from the file
+#  system's magic bytes. Prints nothing if the format is not recognised.
+function _image_format() {
+  local image="$1"
+
+  # squashfs: "hsqs" at offset 0.
+  if [[ $(_read_hex "${image}" 0 4) == 68737173 ]] ; then
+    echo "squashfs"
+  # erofs: 0xe0f5e1e2 (little endian) at offset 1024.
+  elif [[ $(_read_hex "${image}" 1024 4) == e2e1f5e0 ]] ; then
+    echo "erofs"
+  # ext2/ext4: 0xef53 (little endian) at offset 1080.
+  elif [[ $(_read_hex "${image}" 1080 2) == 53ef ]] ; then
+    echo "ext"
+  # btrfs: "_BHRfS_M" at offset 0x10040.
+  elif [[ $(_read_hex "${image}" 65600 8) == 5f42485266535f4d ]] ; then
+    echo "btrfs"
+  fi
+}
+# --
+
+# Extract an extension image to <destdir>.
+# Extraction runs unprivileged, so file ownership of the extracted tree is
+#  meaningless; use _image_list_non_root() to validate ownership.
+function _image_extract() {
+  local image="$1"
+  local format="$2"
+  local destdir="$3"
+
+  local log="${destdir}.extract.log"
+  local rc=0
+
+  case "${format}" in
+    squashfs) unsquashfs -no-xattrs -force -dest "${destdir}" "${image}" >"${log}" 2>&1 || rc=$? ;;
+    erofs)    fsck.erofs "--extract=${destdir}" "${image}" >"${log}" 2>&1 || rc=$? ;;
+    *)
+      echo "ERROR: cannot extract '${format}' images."
+      echo "       Offline validation supports squashfs and erofs images."
+      return 1
+      ;;
+  esac
+
+  if [[ ${rc} -ne 0 ]] ; then
+    echo "ERROR: failed to extract '${image}':"
+    cat "${log}"
+    return 1
+  fi
+}
+# --
+
+# Print all image entries not owned by root:root, as "<uid>/<gid> <path>",
+#  with <path> relative to the root of the image.
+# Returns 1 if ownership cannot be read from the image's format.
+function _image_list_non_root() {
+  local image="$1"
+  local format="$2"
+
+  case "${format}" in
+    squashfs)
+      # "-lln" prints a numeric "ls -l" style listing, e.g.
+      #   -rwxr-xr-x 0/0  26936 1970-01-01 00:00 squashfs-root/usr/bin/demo
+      unsquashfs -lln "${image}" 2>/dev/null \
+        | awk '$2 ~ /^[0-9]+\/[0-9]+$/ && $2 != "0/0" {
+                 path = $6
+                 for (i = 7; i <= NF; i++) { path = path " " $i }
+                 # strip unsquashfs extraction directory ("squashfs-root")
+                 sub(/^[^\/]+/, "", path)
+                 print $2 " " (path == "" ? "/" : path)
+               }'
+      ;;
+    *) return 1 ;;
+  esac
+}
+# --
+
+# Print the ELF machine type (e_machine) of <file> as a decimal number.
+# Returns 1 if <file> is not an ELF binary.
+function _elf_machine() {
+  local file="$1"
+  local -a header=()
+
+  read -r -a header <<< "$(_read_hex "${file}" 0 20 | sed --regexp-extended 's/(..)/\1 /g')"
+  if [[ ${#header[@]} -ne 20 ]] ; then
+    return 1
+  fi
+
+  # e_ident starts with 0x7f "ELF"; EI_DATA (byte order) is at offset 5.
+  if [[ "${header[0]}${header[1]}${header[2]}${header[3]}" != 7f454c46 ]] ; then
+    return 1
+  fi
+
+  # e_machine is a 16 bit field at offset 18, stored in the ELF's byte order
+  #  (EI_DATA: 1 - least significant byte first, 2 - most significant first).
+  if [[ ${header[5]} == 01 ]] ; then
+    echo $((16#${header[19]}${header[18]}))
+  else
+    echo $((16#${header[18]}${header[19]}))
+  fi
+}
+# --
+
+# Print the merged location of an absolute path on Flatcar.
+# Flatcar is a usr-merged distribution: /bin, /sbin, /usr/sbin, /lib, and /lib64
+#  are symlinks into /usr, so a unit may legitimately refer to a file the
+#  extension ships below /usr by any of these paths.
+function _merged_path() {
+  local path="$1"
+
+  case "${path}" in
+    /bin/*)      echo "/usr/bin/${path#/bin/}" ;;
+    /sbin/*)     echo "/usr/bin/${path#/sbin/}" ;;
+    /usr/sbin/*) echo "/usr/bin/${path#/usr/sbin/}" ;;
+    /lib/*)      echo "/usr/lib/${path#/lib/}" ;;
+    /lib64/*)    echo "/usr/lib64/${path#/lib64/}" ;;
+    *)           echo "${path}" ;;
+  esac
+}
+# --
+
+# Check whether an absolute path exists in the extension image extracted to
+#  <root>. Symlinks are resolved with <root> as the file system root to mimic
+#  what the path will look like on a host that merged the extension.
+function _image_path_exists() {
+  local root="$1"
+  local path="$(_merged_path "$2")"
+
+  local hops=0 target=""
+  while [[ -L "${root}${path}" ]] && [[ ${hops} -lt 10 ]] ; do
+    target="$(readlink "${root}${path}")"
+    if [[ ${target} == /* ]] ; then
+      path="$(_merged_path "${target}")"
+    else
+      path="$(dirname "${path}")/${target}"
+    fi
+    hops=$((hops + 1))
+  done
+
+  [[ -e "${root}${path}" ]]
+}
+# --
+
+# Print the path of the extension release file of the image extracted to <root>.
+# Prints nothing if the image ships no (or more than one) release file.
+function _extension_release_file() {
+  local root="$1"
+  local -a files=()
+
+  readarray -t files < <(find "${root}/usr/lib/extension-release.d" \
+                              -maxdepth 1 -type f -name 'extension-release.*' 2>/dev/null)
+
+  if [[ ${#files[@]} -eq 1 ]] ; then
+    echo "${files[0]}"
+  fi
+}
+# --
+
+# Print the value of <key> in an extension release file.
+function _extension_release_field() {
+  local key="$1"
+  local file="$2"
+
+  sed --silent --regexp-extended "s/^${key}=\"?([^\"]*)\"?$/\1/p" "${file}"
+}
+# --
+
+#
+#  ---------------- offline image checks ----------------
+#
+
+# The extension release metadata is what makes an image a system extension:
+#  systemd refuses to merge an extension whose metadata is missing, is named
+#  after a different extension, or does not match the host.
+function _check_metadata() {
+  local root="$1"
+  local image="$2"
+  local extname="$3"
+  local arch="$4"
+
+  local reldir="usr/lib/extension-release.d"
+  local -a files=()
+  readarray -t files < <(find "${root}/${reldir}" -maxdepth 1 -type f 2>/dev/null | sort)
+
+  if [[ ${#files[@]} -eq 0 ]] ; then
+    _test_fail "no extension release file in '${reldir}/'; the image will not be merged."
+    return
+  fi
+
+  if [[ ${#files[@]} -gt 1 ]] ; then
+    _test_fail "'${reldir}/' holds ${#files[@]} files; an extension must ship exactly one."
+    return
+  fi
+
+  local relfile="${files[0]}"
+  local relname="$(basename "${relfile}")"
+  if [[ ${relname} != extension-release.?* ]] ; then
+    _test_fail "'${reldir}/${relname}' is not named 'extension-release.<extension>'."
+    return
+  fi
+  _test_ok "extension release metadata '${reldir}/${relname}'."
+
+  # systemd matches the metadata file name against the name of the image it
+  #  merges, i.e. the image file name without the ".raw" suffix. Release builds
+  #  add a "-<version>-<arch>" suffix to the image file name; those images are
+  #  deployed through the sysupdate configuration, which links them to
+  #  "/etc/extensions/<extension>.raw" (see lib/sysupdate.conf.tmpl).
+  local name="${relname#extension-release.}"
+  local imagename="$(basename "${image}" .raw)"
+  if [[ ${imagename} != "${name}" ]] && [[ ${imagename} != "${name}-"* ]] ; then
+    _test_fail "image '${imagename}.raw' ships metadata for extension '${name}';" \
+               "systemd will not merge it."
+  elif [[ -n ${extname} ]] && [[ ${name} != "${extname}" ]] ; then
+    _test_fail "the image ships metadata for extension '${name}', not for '${extname}'."
+  fi
+
+  local id="$(_extension_release_field "ID" "${relfile}")"
+  local sysext_level="$(_extension_release_field "SYSEXT_LEVEL" "${relfile}")"
+  case "${id}" in
+    "")
+      _test_fail "metadata has no 'ID='; systemd cannot tell which OS the extension is for." ;;
+    _any)
+      _test_ok "metadata matches any OS (ID=_any)." ;;
+    *)
+      if [[ -z ${sysext_level} ]] ; then
+        _test_fail "metadata sets 'ID=${id}' but no 'SYSEXT_LEVEL='."
+      else
+        _test_ok "metadata matches OS '${id}' (SYSEXT_LEVEL=${sysext_level})."
+      fi
+      ;;
+  esac
+
+  local image_arch="$(_extension_release_field "ARCHITECTURE" "${relfile}")"
+  if [[ -z ${image_arch} ]] ; then
+    _test_fail "metadata has no 'ARCHITECTURE='; the extension merges on any architecture."
+  elif [[ ${image_arch} != "${arch}" ]] ; then
+    _test_fail "metadata declares architecture '${image_arch}', expected '${arch}'."
+  else
+    _test_ok "metadata declares architecture '${arch}'."
+  fi
+}
+# --
+
+# Extensions are overlaid onto /usr and /opt; files anywhere else are silently
+#  dropped on merge, and shipping usr/sbin breaks Flatcar's usr-merge symlink.
+function _check_layout() {
+  local root="$1"
+  local failures_before=${_test_failures}
+
+  local entry=""
+  while read -r entry; do
+    if [[ " ${_sysext_top_level_dirs[*]} " == *" ${entry} "* ]] ; then
+      continue
+    fi
+    _test_fail "'${entry}' is not below '${_sysext_top_level_dirs[*]/%//}';" \
+               "it will not be present on the host after merge."
+  done < <(find "${root}" -mindepth 1 -maxdepth 1 -printf '%P\n' | sort)
+
+  local forbidden=""
+  for forbidden in "${_sysext_forbidden_dirs[@]}"; do
+    if [[ -e "${root}/${forbidden}" ]] ; then
+      _test_fail "'${forbidden}' must not be shipped; it replaces the host's" \
+                 "'/${forbidden}' symlink on merge and hides its contents."
+    fi
+  done
+
+  if [[ ${_test_failures} -eq ${failures_before} ]] ; then
+    _test_ok "all files are shipped below '${_sysext_top_level_dirs[*]/%//}'."
+  fi
+}
+# --
+
+# Extension images are merged into the host's /usr, which is owned by root.
+# Files owned by the (unprivileged) build user leak the build environment into
+#  the extension and may render shipped binaries writable to unrelated users.
+function _check_ownership() {
+  local image="$1"
+  local format="$2"
+
+  local listing=""
+  if ! listing="$(_image_list_non_root "${image}" "${format}")" ; then
+    _test_skip "file ownership cannot be read from '${format}' images."
+    return
+  fi
+
+  if [[ -z ${listing} ]] ; then
+    _test_ok "all files are owned by root."
+    return
+  fi
+
+  local owner="" path="" reported=0 suppressed=0
+  while read -r owner path; do
+    if [[ ${reported} -ge ${_test_max_reported} ]] ; then
+      suppressed=$((suppressed + 1))
+      continue
+    fi
+    _test_fail "'${path}' is owned by ${owner} (uid/gid), expected 0/0."
+    reported=$((reported + 1))
+  done <<< "${listing}"
+
+  if [[ ${suppressed} -gt 0 ]] ; then
+    _test_fail "... and ${suppressed} more file(s) not owned by root."
+  fi
+}
+# --
+
+# A binary built for the wrong architecture is the classic copy-and-paste bug
+#  in populate_sysext_root(); it only shows once the extension is deployed.
+function _check_binaries() {
+  local root="$1"
+  local arch="$2"
+
+  local expected="${_elf_machine_types[${arch}]}"
+  local failures_before=${_test_failures}
+  local file="" machine="" binaries=0 reported=0 suppressed=0
+
+  while read -r file; do
+    if ! machine="$(_elf_machine "${file}")" ; then
+      continue
+    fi
+    binaries=$((binaries + 1))
+    if [[ ${machine} -eq ${expected} ]] ; then
+      continue
+    fi
+    if [[ ${reported} -ge ${_test_max_reported} ]] ; then
+      suppressed=$((suppressed + 1))
+      continue
+    fi
+    _test_fail "'${file#${root}}' is an ELF binary for machine type ${machine}," \
+               "expected ${expected} (${arch})."
+    reported=$((reported + 1))
+  done < <(find "${root}" -type f)
+
+  if [[ ${suppressed} -gt 0 ]] ; then
+    _test_fail "... and ${suppressed} more binaries not built for ${arch}."
+  fi
+
+  if [[ ${binaries} -eq 0 ]] ; then
+    _test_skip "the extension ships no ELF binaries."
+  elif [[ ${_test_failures} -eq ${failures_before} ]] ; then
+    _test_ok "all ${binaries} ELF binaries are built for ${arch}."
+  fi
+}
+# --
+
+# Print the command of a systemd "Exec*=" setting, i.e. without the special
+#  execution modifier prefixes ("@", "-", ":", "+", "!", "!!") and arguments.
+function _unit_exec_command() {
+  local setting="$1"
+
+  setting="${setting#"${setting%%[![:space:]]*}"}"
+  setting="${setting#"${setting%%[!@:+!-]*}"}"
+
+  echo "${setting%%[[:space:]]*}"
+}
+# --
+
+# Every unit shipped by an extension must be able to start on a merged system.
+# Wrong binary paths in units are a recurring source of 203/EXEC failures that
+#  only surface at runtime, long after the extension was released.
+function _check_units() {
+  local root="$1"
+
+  local unitdir="${root}/usr/lib/systemd"
+  if [[ ! -d ${unitdir} ]] ; then
+    _test_skip "the extension ships no systemd units."
+    return
+  fi
+
+  local failures_before=${_test_failures}
+  local unit="" setting="" exec_path="" exec_name="" shipped="" units=0
+
+  while read -r unit; do
+    units=$((units + 1))
+    while read -r setting; do
+      exec_path="$(_unit_exec_command "${setting}")"
+
+      # Commands without a path are looked up in systemd's built-in $PATH at
+      #  runtime; there is nothing we can validate offline.
+      if [[ ${exec_path} != /* ]] ; then
+        continue
+      fi
+
+      if _image_path_exists "${root}" "${exec_path}" ; then
+        continue
+      fi
+
+      # The command is not shipped by the extension. If the extension ships a
+      #  binary of that name elsewhere the unit points at the wrong path,
+      #  otherwise the command is expected to come with the OS image.
+      exec_name="$(basename "${exec_path}")"
+      shipped="$(find "${root}" -type f -name "${exec_name}" -printf '%P\n' -quit)"
+      if [[ -n ${shipped} ]] ; then
+        _test_fail "unit '${unit#${root}}' runs '${exec_path}'," \
+                   "but the extension ships it as '/${shipped}'."
+      elif [[ " ${_os_provided_commands[*]} " != *" ${exec_name} "* ]] ; then
+        _test_warn "unit '${unit#${root}}' runs '${exec_path}' which the extension" \
+                   "does not ship; make sure the OS image provides it."
+      fi
+    done < <(sed --silent --regexp-extended \
+                 's/^[[:space:]]*Exec(Start|StartPre|StartPost|Stop|StopPost|Reload|Condition)=(.+)$/\2/p' \
+                 "${unit}")
+  done < <(find "${unitdir}" -type f \
+                \( -name '*.service' -o -name '*.socket' -o -name '*.mount' \
+                   -o -name '*.path' -o -name '*.timer' -o -name '*.conf' \) | sort)
+
+  if [[ ${units} -eq 0 ]] ; then
+    _test_skip "the extension ships no systemd units."
+  elif [[ ${_test_failures} -eq ${failures_before} ]] ; then
+    _test_ok "all commands of the ${units} systemd unit file(s) shipped are available."
+  fi
+}
+# --
+
+#
+#  ---------------- extension smoke tests in a VM ----------------
+#
+
+# Generate the test harness that runs the extension's test hook in the VM.
+function _generate_vm_runner() {
+  local extname="$1"
+
+  # Parameters from the host; the harness itself follows verbatim below.
+  cat <<EOF
+#!/usr/bin/env bash
+#
+# Generated by the sysext bakery. Runs an extension's test hook in a test VM.
+
+extension="${extname}"
+testdir="${_vm_test_dir}"
+marker="${_vm_test_marker}"
+EOF
+
+  cat <<'EOF'
+# Do not abort on failing tests; we want to run and report all of them.
+set -uo pipefail
+
+# The host reads the test results from the VM's serial console. Systemd's
+#  "StandardOutput=+console" writes to /dev/console, which is whatever the last
+#  "console=" on the kernel command line names - tty0 for Flatcar's qemu
+#  images, which a headless VM never shows. Write to the serial console the
+#  host does read, whatever it is called on this architecture.
+for tty in $(</sys/class/tty/console/active); do
+  case "${tty}" in
+    ttyS*|ttyAMA*|hvc*)
+      exec >"/dev/${tty}" 2>&1
+      break
+      ;;
+  esac
+done
+
+declare -i failures=0
+
+# check <description> <command> [<argument> ...]
+# Run <command> and report the result. Available to run_tests().
+function check() {
+  local description="$1"
+  shift
+
+  local output=""
+  if output="$("${@}" 2>&1)" ; then
+    echo "   ok   | ${description}"
+    return 0
+  fi
+
+  echo "   FAIL | ${description}"
+  echo "        | command: ${*}"
+  if [[ -n ${output} ]] ; then
+    echo "${output}" | sed 's/^/        | /'
+  fi
+
+  failures+=1
+  return 1
+}
+# --
+
+echo "Running smoke tests of extension '${extension}'"
+
+# The extension release file only shows up in /usr once the image is merged,
+#  so this also validates that systemd-sysext accepted the image.
+check "extension '${extension}' is merged into the running system" \
+      test -e "/usr/lib/extension-release.d/extension-release.${extension}"
+
+if [[ -s "${testdir}/test.sh" ]] ; then
+  source "${testdir}/test.sh"
+fi
+
+if [[ $(type -t run_tests) == function ]] ; then
+  declare -i reported="${failures}"
+  run_tests
+  rc=$?
+  # Hooks either use check() or just return a non-zero exit code. Only count
+  #  the exit code if the hook did not report failures of its own; a hook using
+  #  check() returns the status of its last check.
+  if [[ ${rc} -ne 0 ]] && [[ ${failures} -eq ${reported} ]] ; then
+    echo "   FAIL | run_tests() returned ${rc}"
+    failures+=1
+  fi
+else
+  echo "   skip | extension '${extension}' implements no run_tests() hook"
+fi
+
+echo "${marker} failures=${failures}"
+EOF
+}
+# --
+
+# Generate the provisioning config of the test VM.
+# All files are served by the local webserver started by _run_vm_tests().
+function _generate_vm_butane() {
+  local extname="$1"
+
+  cat <<EOF
+version: 1.0.0
+variant: flatcar
+
+storage:
+  files:
+    # The image file name must match the extension release file it ships,
+    #  otherwise systemd-sysext refuses to merge the extension.
+    - path: /etc/extensions/${extname}.raw
+      mode: 0644
+      contents:
+        # QEmu's default traffic-to-host IP
+        source: http://10.0.2.2:12345/${extname}.raw
+    - path: ${_vm_test_dir}/test.sh
+      mode: 0644
+      contents:
+        source: http://10.0.2.2:12345/test.sh
+    - path: ${_vm_test_dir}/run-tests.sh
+      mode: 0755
+      contents:
+        source: http://10.0.2.2:12345/run-tests.sh
+
+systemd:
+  units:
+    - name: update-engine.service
+      mask: true
+    - name: locksmithd.service
+      mask: true
+    - name: bakery-test.service
+      enabled: true
+      contents: |
+        [Unit]
+        Description=Sysext bakery extension smoke tests
+        # Run on a fully booted system, with the extension merged. A failed
+        #  merge is reported by the tests rather than skipping the run.
+        After=systemd-sysext.service multi-user.target
+
+        [Service]
+        Type=oneshot
+        ExecStart=${_vm_test_dir}/run-tests.sh
+        # The host reads the test result from the VM's console.
+        StandardOutput=journal+console
+        StandardError=journal+console
+        # Shut the VM down in any case, including a failing test run.
+        ExecStopPost=/usr/bin/systemctl poweroff
+
+        [Install]
+        WantedBy=multi-user.target
+EOF
+}
+# --
+
+# Boot a Flatcar VM with the extension merged and run its test hook.
+function _run_vm_tests() {
+  local image="$1"
+  local extname="$2"
+  local arch="$3"
+  local timeout="$4"
+
+  local hook="${scriptroot}/${extname}.sysext/test.sh"
+  # Absolute, as the VM runs in a temporary working directory below.
+  local console_log="$(pwd)/${extname}-vm-test.log"
+
+  if [[ ! -s ${hook} ]] ; then
+    _test_warn "extension '${extname}' implements no test hook in" \
+               "'${extname}.sysext/test.sh'; only checking that it merges."
+    hook="/dev/null"
+  fi
+
+  # Run in a sub-shell b/c we will change into a temporary working directory
+  (
+    set -euo pipefail
+    local workdir="$(mktemp -d)"
+    # clean up: webserver (once started, below) and work dir
+    trap "kill %1 >/dev/null 2>&1; rm -rf '${workdir}'" EXIT
+
+    _generate_vm_runner "${extname}" >"${workdir}/run-tests.sh"
+    _generate_vm_butane "${extname}" >"${workdir}/test.yaml"
+    cp "${hook}" "${workdir}/test.sh"
+    cp "${image}" "${workdir}/${extname}.raw"
+    transpile "${workdir}/test.yaml" "${workdir}/test.json"
+
+    # The OS image is downloaded to (and re-used from) the current directory.
+    _download_os_image "$(arch_transform 'x86-64' 'amd64' "${arch}")"
+    cp "${_flatcar_image_files[@]}" "${workdir}/"
+
+    webserver "${workdir}" &
+
+    # '-nographic' makes qemu multiplex its monitor onto the console, and qemu
+    #  shuts the VM down as soon as that console reaches EOF. Feed the console
+    #  from a fifo opened for reading *and* writing: it never signals EOF, and
+    #  nothing is ever written to it.
+    mkfifo "${workdir}/console-input"
+
+    cd "${workdir}"
+    echo "Booting test VM (test run timeout: ${timeout}s)"
+    # The VM powers itself off when the tests are done. Keep going on timeouts
+    #  and boot failures; the console log tells us what happened.
+    timeout --foreground --kill-after 30 "${timeout}" \
+        ./flatcar_production_qemu_uefi.sh -i "test.json" "-snapshot" "-nographic" \
+      <>"console-input" 2>&1 | tee "${console_log}" || true
+
+    local failures="$(sed --silent --regexp-extended \
+                          "s/.*${_vm_test_marker} failures=([0-9]+).*/\1/p" \
+                          "${console_log}" | tail -n 1)"
+
+    echo
+    if [[ -z ${failures} ]] ; then
+      echo "ERROR: the test VM did not report a result. The extension may have failed"
+      echo "       to merge, or the tests did not finish within ${timeout} seconds."
+      echo "       Console output: '${console_log}'"
+      exit 1
+    fi
+
+    if [[ ${failures} -ne 0 ]] ; then
+      echo "ERROR: ${failures} smoke test(s) failed."
+      echo "       Console output: '${console_log}'"
+      exit 1
+    fi
+
+    rm -f "${console_log}"
+  )
+}
+# --
+
+#
+#  ---------------- high level functions ----------------
+#
+
+function _test_help() {
+  echo "Validate a built extension image."
+  echo
+  echo "The image is checked for the metadata, layout, and file ownership systemd-sysext"
+  echo " expects, for binaries built for the wrong architecture, and for systemd units"
+  echo " referring to files the extension does not ship."
+  echo "With '--vm true' the extension's test hook ('<extension>.sysext/test.sh') is run"
+  echo " in a local Flatcar VM with the extension merged."
+  echo
+  echo " Positional (mandatory) arguments:"
+  echo "  <extension|image>:   Name of a built extension, e.g. 'docker', or the path of an"
+  echo "                         extension image, e.g. 'docker-28.5.2-arm64.raw'."
+  echo "                         Build the image first: '$0 create <extension> <version>'."
+  echo
+  echo " Optional arguments:"
+  echo " --arch <arch>:        Architecture the image is expected to be built for."
+  echo "                         Either x86-64 or arm64. Defaults to the image's metadata."
+  echo " --vm <true|false>:    Also run the extension's test hook in a local Flatcar VM."
+  echo "                         Defaults to 'false'. Requires qemu and docker."
+  echo " --timeout <seconds>:  Time budget for the VM test run. Defaults to 600."
+}
+# --
+
+function test_sysext() {
+  local target="$(get_positional_param "1" "${@}")"
+
+  if [[ -z ${target} ]] || [[ ${target} == help ]] ; then
+    _test_help
+    return
+  fi
+
+  # The target is either an image file or the name of a built extension.
+  local image="${target}" extname=""
+  if [[ ! -f ${image} ]] ; then
+    extname="$(extension_name "${target}")"
+    if [[ -z ${extname} ]] ; then
+      echo "ERROR: '${target}' is neither an extension image nor a known extension."
+      echo "       Use '$0 list' to list all extensions."
+      return 1
+    fi
+
+    image="${extname}.raw"
+    if [[ ! -f ${image} ]] ; then
+      echo "ERROR: extension image '${image}' not found. Build it first, using"
+      echo "         $0 create ${extname} <version>"
+      return 1
+    fi
+  fi
+
+  local format="$(_image_format "${image}")"
+  if [[ -z ${format} ]] ; then
+    echo "ERROR: '${image}' is not a file system image."
+    return 1
+  fi
+
+  local workdir="$(mktemp -d)"
+  trap "rm -rf '${workdir}'" EXIT
+
+  announce "Validating '${image}' (${format})"
+
+  local root="${workdir}/root"
+  if ! _image_extract "${image}" "${format}" "${root}" ; then
+    return 1
+  fi
+
+  # The extension release file is the only place that tells us the name and the
+  #  architecture of an extension image, independent of the image's file name.
+  local relfile="$(_extension_release_file "${root}")"
+  local arch="$(get_optional_param "arch" "" "${@}")"
+  if [[ -n ${arch} ]] ; then
+    check_arch "${arch}"
+  else
+    # Default to the architecture the image declares. Images with missing or
+    #  bogus metadata are reported by the metadata check below; fall back to
+    #  the default architecture to still run all remaining checks on them.
+    arch="$(_extension_release_field "ARCHITECTURE" "${relfile:-/dev/null}")"
+    if [[ -z ${arch} ]] || [[ -z ${_elf_machine_types[${arch}]:-} ]] ; then
+      arch="x86-64"
+    fi
+  fi
+
+  _test_section "Extension metadata"
+  _check_metadata "${root}" "${image}" "${extname}" "${arch}"
+  _test_section "Image layout"
+  _check_layout "${root}"
+  _test_section "File ownership"
+  _check_ownership "${image}" "${format}"
+  _test_section "Binary architecture"
+  _check_binaries "${root}" "${arch}"
+  _test_section "Systemd units"
+  _check_units "${root}"
+
+  echo
+  if [[ ${_test_failures} -gt 0 ]] ; then
+    announce "FAILED: ${_test_failures} check(s) failed, ${_test_warnings} warning(s)"
+    return 1
+  fi
+  announce "PASSED: image validation, ${_test_warnings} warning(s)"
+
+  if [[ $(get_optional_param "vm" "false" "${@}") != true ]] ; then
+    return 0
+  fi
+
+  # The smoke tests need the extension name to locate the extension's test hook.
+  if [[ -z ${extname} ]] ; then
+    extname="$(basename "${relfile}")"
+    extname="${extname#extension-release.}"
+  fi
+
+  local timeout="$(get_optional_param "timeout" "600" "${@}")"
+  announce "Running smoke tests of '${extname}' in a Flatcar VM"
+  if ! _run_vm_tests "${image}" "${extname}" "${arch}" "${timeout}" ; then
+    announce "FAILED: smoke tests of '${extname}'"
+    return 1
+  fi
+
+  announce "PASSED: smoke tests of '${extname}'"
+}
+# --

--- a/lib/test.sh
+++ b/lib/test.sh
@@ -212,14 +212,30 @@ function _image_path_exists() {
   local path="$(_merged_path "$2")"
 
   local hops=0 target=""
-  while [[ -L "${root}${path}" ]] && [[ ${hops} -lt 10 ]] ; do
+  while true ; do
+    # A path holding '..' components, or a symlink pointing out of the image,
+    #  resolves to a file on the build host rather than to one the extension
+    #  ships. Stop before the check consults the host's file system.
+    if [[ "$(realpath -m -s --relative-base="${root}" "${root}${path}")" == /* ]] ; then
+      return 1
+    fi
+
+    if [[ ! -L "${root}${path}" ]] ; then
+      break
+    fi
+
+    # Give up on implausibly long symlink chains rather than spinning on a loop.
+    if [[ ${hops} -ge 10 ]] ; then
+      return 1
+    fi
+    hops=$((hops + 1))
+
     target="$(readlink "${root}${path}")"
     if [[ ${target} == /* ]] ; then
       path="$(_merged_path "${target}")"
     else
       path="$(dirname "${path}")/${target}"
     fi
-    hops=$((hops + 1))
   done
 
   [[ -e "${root}${path}" ]]
@@ -452,7 +468,7 @@ function _check_units() {
     return
   fi
 
-  local failures_before=${_test_failures}
+  local failures_before=${_test_failures} warnings_before=${_test_warnings}
   local unit="" setting="" exec_path="" exec_name="" shipped="" units=0
 
   while read -r unit; do
@@ -491,7 +507,8 @@ function _check_units() {
 
   if [[ ${units} -eq 0 ]] ; then
     _test_skip "the extension ships no systemd units."
-  elif [[ ${_test_failures} -eq ${failures_before} ]] ; then
+  elif [[ ${_test_failures} -eq ${failures_before} ]] \
+    && [[ ${_test_warnings} -eq ${warnings_before} ]] ; then
     _test_ok "all commands of the ${units} systemd unit file(s) shipped are available."
   fi
 }

--- a/lib/test.sh
+++ b/lib/test.sh
@@ -584,7 +584,12 @@ check "extension '${extension}' is merged into the running system" \
       test -e "/usr/lib/extension-release.d/extension-release.${extension}"
 
 if [[ -s "${testdir}/test.sh" ]] ; then
-  source "${testdir}/test.sh"
+  # A hook that fails to load leaves run_tests() undefined, which would be
+  #  reported as "no hook implemented" and quietly pass the whole run.
+  if ! source "${testdir}/test.sh" ; then
+    echo "   FAIL | the extension's test hook failed to load"
+    failures+=1
+  fi
 fi
 
 if [[ $(type -t run_tests) == function ]] ; then
@@ -679,6 +684,10 @@ function _run_vm_tests() {
     _test_warn "extension '${extname}' implements no test hook in" \
                "'${extname}.sysext/test.sh'; only checking that it merges."
     hook="/dev/null"
+  elif ! bash -n "${hook}" ; then
+    # Catch this before spending a VM boot on a hook that cannot run.
+    _test_fail "the test hook '${extname}.sysext/test.sh' does not parse."
+    return 1
   fi
 
   # Run in a sub-shell b/c we will change into a temporary working directory

--- a/tailscale.sysext/test.sh
+++ b/tailscale.sysext/test.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# vim: et ts=2 syn=bash
+#
+# Smoke tests for the tailscale sysext.
+# See _skel.sysext/test.sh for the test hook contract.
+
+function run_tests() {
+  check "the tailscale CLI runs" tailscale version
+
+  # The extension ships a multi-user.target drop-in that starts tailscaled on
+  #  merge. The daemon comes up without credentials and waits for 'tailscale
+  #  up', so it must be running even in a throw-away VM.
+  check "tailscaled is running" systemctl is-active tailscaled.service
+
+  # The CLI talks to the daemon through this socket; the daemon only creates it
+  #  once it is up and reading its (tmpfiles-provisioned) default settings.
+  check "the tailscaled socket is served" test -S /run/tailscale/tailscaled.sock
+
+  check "the default settings are provisioned" test -s /etc/default/tailscaled
+
+  # Note: do not log in. The test VM has no credentials, and a login attempt
+  #  would tie the test to the availability of the coordination server.
+}
+# --


### PR DESCRIPTION
## Implement `bakery.sh test` to validate built sysext images

Fixes #247 

The `test` command was already in the `bakery.sh` dispatcher but nobody ever wrote it. Running `./bakery.sh test docker` just failed with `test_sysext: command not found`. It was missing from `usage()` too, so there was no sign it was unfinished. This adds the implementation in `lib/test.sh`.

By default it checks the built `.raw` file and exits non-zero if something is wrong. It looks at the extension release metadata, checks that all files sit under `usr/` or `opt/`, rejects a shipped `usr/sbin`, checks that files are owned by root, checks that binaries match the target architecture, and checks that the commands in shipped systemd units actually exist. Unit paths are resolved through Flatcar's usr-merge, so `/usr/sbin/chronyd` for a binary in `/usr/bin` still passes. A unit pointing at a path where the extension does not ship the binary but ships it somewhere else fails. That is the keepalived and docker-buildx bug.

With `--vm true` it also boots a local Flatcar VM and runs the extension's `run_tests()` hook from `test.sh`. That hook was scaffolded a while back and left empty everywhere, so this PR defines the contract in `_skel.sysext/test.sh` and fills it in for btop, docker-compose and tailscale. There is also a new workflow that builds and validates the extensions a PR touches, for both architectures. One small fix on the side: the Test column in `bakery.sh list` looked for `run_tests()` in `create.sh` instead of `test.sh`, so it always said No.

## How to use

You need `curl`, `jq` and `squashfs-tools`. For the VM part you also need `qemu` and `docker`.

```bash
./bakery.sh create docker-compose 5.4.0
./bakery.sh test docker-compose                # passes
./bakery.sh test docker-compose --arch arm64   # fails, wrong arch
./bakery.sh test tailscale --vm true           # boots a VM and runs the hook
```

To see the CI job without opening a PR, go to Actions, pick "Build and validate extensions changed by a pull request", run it with `extensions` set to `docker-compose tailscale`.

## Testing done

Built and validated real extensions on Flatcar alpha 4757.0.0, x86-64.

```console
$ ./bakery.sh create docker-compose 5.4.0 && ./bakery.sh test docker-compose
== Extension metadata
   ok   | extension release metadata 'usr/lib/extension-release.d/extension-release.docker-compose'.
   ok   | metadata matches any OS (ID=_any).
   ok   | metadata declares architecture 'x86-64'.
== Image layout
   ok   | all files are shipped below 'usr/ opt/'.
== File ownership
   ok   | all files are owned by root.
== Binary architecture
   ok   | all 1 ELF binaries are built for x86-64.
== Systemd units
   skip | the extension ships no systemd units.
    ----- ===== ##### PASSED: image validation, 0 warning(s) ##### ===== -----
exit=0
```

Same for tailscale v1.102.2. I also built 16 broken images on purpose to check each rule fires. Here is one that breaks several at once:

```console
$ ./bakery.sh test bad.raw
   FAIL | 'etc' is not below 'usr/ opt/'; it will not be present on the host after merge.
   FAIL | 'usr/sbin' must not be shipped; it replaces the host's '/usr/sbin' symlink on merge and hides its contents.
   FAIL | unit '/usr/lib/systemd/system/bad.service' runs '/opt/bad/bin/bad', but the extension ships it as '/usr/bin/bad'.
   warn | unit '/usr/lib/systemd/system/bad.service' runs '/usr/bin/definitely-not-here' which the extension does not ship; make sure the OS image provides it.
    ----- ===== ##### FAILED: 3 check(s) failed, 1 warning(s) ##### ===== -----
exit=1
```

The VM run:

```console
$ ./bakery.sh test tailscale --vm true
Running smoke tests of extension 'tailscale'
   ok   | extension 'tailscale' is merged into the running system
   ok   | the tailscale CLI runs
   ok   | tailscaled is running
   ok   | the tailscaled socket is served
   ok   | the default settings are provisioned
__BAKERY_TEST_RESULT__ failures=0
    ----- ===== ##### PASSED: smoke tests of 'tailscale' ##### ===== -----
exit=0
```

I added a check that cannot pass and confirmed it gets reported with the command output and exits 1. I also tested an erofs image and a 30 MB image with 440 files and symlinks, which takes 1.3 seconds.

Booting a real VM turned up two bugs I would have missed otherwise. qemu shuts the guest down when the `-nographic` console hits EOF, so `</dev/null` powered the VM off before the tests ran. And Flatcar boots with `console=ttyS0 console=tty0`, so the last one wins and systemd wrote the results to the graphical console that a headless VM never shows. Both are fixed.

Not tested: the smoke tests on arm64. Only x86-64 VMs so far.

## Checklist

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)

  n/a, this repo has no `changelog/` directory. The change is documented in `README.md` and `CONTRIBUTING.md`.

- [x] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

  n/a, no OS image changes here.