### PR TITLE
Update extension metadata even if one of them fails

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -53,7 +53,7 @@ jobs:
     # Job fails can be transient and will be re-tried every time this action runs.
     # NOTE that this will cause succeeding jobs (update metadata) to run even if the whole matrix fails.
     #      This is intended and should not cause any issues[tm].
-    continue-on-error: true 
+    continue-on-error: true
 
     runs-on: ubuntu-24.04
     permissions:
@@ -104,8 +104,10 @@ jobs:
     needs: [ list-builds, create-release ]
     if: ${{ needs.list-builds.outputs.extensions != '[]' && needs.list-builds.outputs.extensions != '' }}
     strategy:
+      fail-fast: false
       matrix:
         extension: ${{ fromJson(needs.list-builds.outputs.extensions) }}
+    continue-on-error: true
     runs-on: ubuntu-24.04
     permissions:
       # allow the action to create a release


### PR DESCRIPTION
# Update extension metadata even if one of them fails

Currently there is some issue with `kata-containers 4.0.0` - probably related to [github release 2GiB limit
](https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases#storage-and-bandwidth-quotas), which causes metadata not update for all other extensions.

E.g. even though there is a new release for Tailscale https://github.com/flatcar/sysext-bakery/releases/tag/tailscale-v1.102.2, I'm still getting https://github.com/flatcar/sysext-bakery/releases/tag/tailscale-v1.98.9 as the newest one. 

## How to use

This github action should now update the extensions even with the `kata` one failing.

## Testing done

Probably easiest to test from this branch on this repo with gh actions.
