### PR TITLE
test: add automated sysext validation

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -1,0 +1,92 @@
+---
+name: Validate Sysext Changes
+
+"on": [pull_request]
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-24.04
+    outputs:
+      tests: ${{ steps.filter.outputs.tests }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Determine changed extensions
+        id: filter
+        run: |
+          set -euo pipefail
+          changed_exts=$(git diff --name-only origin/${{ github.base_ref }} \
+            | grep '\.sysext/' | cut -d/ -f1 | sort -u | sed 's/\.sysext//' \
+            || true)
+          if [[ -z "${changed_exts}" ]]; then
+            echo "tests=[]" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          filtered_builds=()
+          for ext in ${changed_exts}; do
+            ver=$(awk -v e="${ext}" \
+              '$1 == e && $0 !~ /^#/ {print $2; exit}' \
+              release_build_versions.txt || true)
+            if [[ -n "${ver}" ]]; then
+              if [[ "${ver}" == "latest" ]]; then
+                ver=$(./bakery.sh list "${ext}" --latest true | head -n1)
+              fi
+              filtered_builds+=("${ext}:${ver}")
+            fi
+          done
+          if [[ ${#filtered_builds[@]} -eq 0 ]]; then
+            echo "tests=[]" >> $GITHUB_OUTPUT
+          else
+            json_arr=$(printf '%s\n' "${filtered_builds[@]}" \
+              | jq -R -s -c 'split("\n")[:-1]')
+            echo "tests=${json_arr}" >> $GITHUB_OUTPUT
+          fi
+
+  test:
+    needs: dispatch
+    if: >-
+      ${{ needs.dispatch.outputs.tests != '[]' &&
+      needs.dispatch.outputs.tests != '' }}
+    strategy:
+      matrix:
+        test: ${{ fromJson(needs.dispatch.outputs.tests) }}
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Set up qemu for cross-platform builds
+        uses: docker/setup-qemu-action@v3
+
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install prerequisites
+        run: |
+          set -euxo pipefail
+          sudo apt update -qq
+          sudo apt install -yqq curl jq squashfs-tools xz-utils erofs-utils
+
+      - name: Extract target
+        id: target
+        run: |
+          echo "ext=${{ matrix.test }}" | cut -d: -f1 >> $GITHUB_OUTPUT
+          echo "ver=${{ matrix.test }}" | cut -d: -f2 >> $GITHUB_OUTPUT
+
+      - name: Build and Test extension (x86-64)
+        run: |
+          set -euo pipefail
+          ./bakery.sh create ${{ steps.target.outputs.ext }} \
+            ${{ steps.target.outputs.ver }} --arch x86-64 \
+            --output-file ${{ steps.target.outputs.ext }}-x86-64.raw
+          timeout 5m ./bakery.sh test \
+            ${{ steps.target.outputs.ext }}-x86-64.raw --arch x86-64
+
+      - name: Build and Test extension (arm64)
+        run: |
+          set -euo pipefail
+          ./bakery.sh create ${{ steps.target.outputs.ext }} \
+            ${{ steps.target.outputs.ver }} --arch arm64 \
+            --output-file ${{ steps.target.outputs.ext }}-arm64.raw
+          timeout 5m ./bakery.sh test \
+            ${{ steps.target.outputs.ext }}-arm64.raw --arch arm64

--- a/README.md
+++ b/README.md
@@ -119,6 +119,19 @@ Users can then run commands to validate the extension.
 Note that the shell is started for the unprivileged `core` user.
 The user has passwordless `sudo` access set up.
 
+### Validate and Test extension images
+
+The bakery provides an automated testing command to validate built extension images:
+
+```sh
+./bakery.sh test <extension.raw>
+```
+
+This command performs two stages of testing:
+1. **In-VM Static Analysis**: Validates that the image only contains `/usr` and `/opt`, files are root-owned, and `extension-release` exists.
+2. **Dynamic Testing**: Executes the `test.sh` script provided in the extension's folder (e.g., `docker.sysext/test.sh`) inside a temporary VM after the extension is merged.
+
+This testing command is automatically executed in CI for pull requests modifying extensions.
 
 ### Build all sysext images in this repository
 

--- a/_skel.sysext/test.sh
+++ b/_skel.sysext/test.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# vim: et ts=2 syn=bash
+#
+# Hook specification for system extension automated testing.
+#
+# Execution Environment:
+# - This script is executed automatically inside a temporary Flatcar VM during `./bakery.sh test`.
+# - It is run by systemd as root.
+# - The extension image is already merged via systemd-sysext.
+# - A strict static analysis (paths, ownership) runs before this script.
+#
+# Return Code:
+# - Exit 0 on success.
+# - Exit non-zero on failure.
+#
+# Example (for Docker):
+# systemctl start docker.service
+# docker run --rm alpine echo "Hello World"

--- a/bakery.sh
+++ b/bakery.sh
@@ -8,8 +8,9 @@
 
 set -euo pipefail
 
-rundir="$(pwd)"
-scriptroot="$(dirname "$(readlink -f "$0")")"
+# rundir="$(pwd)"
+scriptroot="$(dirname "$(readlink -f "$0")")" || exit 1
+# shellcheck disable=SC1090,SC1091
 source "${scriptroot}/lib/libbakery.sh"
 
 function usage() {
@@ -26,6 +27,7 @@ function usage() {
   echo "  create <sysext> help          - List sysext specific parameters. Rarely used."
   echo "  boot <sysext> [<sysext> ...]  - Boot a local Flatcar VM (qemu) with sysext(s) merged."
   echo "                                  Great for testing and interactively exploring sysexts."
+  echo "  test <sysext>                 - Run offline validation and automated VM testing for a built sysext."
   echo
   echo "Use '$0 <command> help' to print help for a specific command."
   echo
@@ -83,7 +85,8 @@ function _copy_static_files() {
 # --
 
 function create_sysext() {
-  local extname="$(extension_name "$(get_positional_param "1" "${@}")")"
+  local extname
+  extname="$(extension_name "$(get_positional_param "1" "${@}")")"
 
   if [[ -z ${extname} ]] || [[ ${extname} == help ]] ; then
     _create_sysext_help
@@ -101,12 +104,15 @@ function create_sysext() {
   function populate_sysext_root() {
       announce "Nothing to do, static files only."
   }
+  # shellcheck disable=SC1090
   source "${createscript}"
 
-  local arch="$(get_optional_param 'arch' 'x86-64' "${@}")"
+  local arch
+  arch="$(get_optional_param 'arch' 'x86-64' "${@}")"
   check_arch "$arch"
 
-  local version="$(get_positional_param "2" "${@}")"
+  local version
+  version="$(get_positional_param "2" "${@}")"
   if [[ -z ${version} ]] ; then
     echo "ERROR: missing mandatory <version> parameter"
     _create_sysext_help
@@ -118,9 +124,11 @@ function create_sysext() {
     return 1
   fi
 
-  local workdir="$(mktemp -d)"
-  local sysextroot_tmp="$(mktemp -d)"
-  trap "rm -rf '${workdir}' '${sysextroot_tmp}'" EXIT
+  local workdir
+  workdir="$(mktemp -d)"
+  local sysextroot_tmp
+  sysextroot_tmp="$(mktemp -d)"
+  trap 'rm -rf "${workdir:-}" "${sysextroot_tmp:-}"' EXIT
   local sysextroot="${sysextroot_tmp}/${extname}"
   mkdir -p "${sysextroot}"
 
@@ -139,7 +147,7 @@ function create_sysext() {
   if [[ ${RELOAD_SERVICES_ON_MERGE} == true ]] ; then
       force_reload="--force-reload true"
   fi
-  generate_sysext "$sysextroot" "$arch" "${@}" $force_reload
+  generate_sysext "$sysextroot" "$arch" "${@}" "$force_reload"
 }
 # --
 

--- a/lib/test.sh
+++ b/lib/test.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# vim: et ts=2 syn=bash
+#
+# Bakery library functions to validate a Flatcar image with a sysext.
+#
+# Copyright (c) 2025 the Flatcar Maintainers.
+# Use of this source code is governed by the Apache 2.0 license.
+
+libroot="$(dirname "${BASH_SOURCE[0]}")"
+# shellcheck disable=SC1090,SC1091
+source "${libroot}/helpers.sh"
+# shellcheck disable=SC1090,SC1091
+source "${libroot}/boot.sh"
+
+function _test_help() {
+  echo "Test a local Flatcar VM and provision an extension for automated testing."
+  echo
+  echo " Positional (mandatory) arguments:"
+  echo "  <sysext>: Extension image file to test. Must end in .raw"
+  echo
+  echo " Optional arguments:"
+  echo " --arch <amd64|arm64>: Architecture of the extension file."
+}
+
+function test_sysext() {
+  local extfile
+  extfile="$(get_positional_param "1" "${@}")"
+  if [[ -z "${extfile}" ]] || [[ "${extfile}" == "help" ]]; then
+    _test_help
+    return
+  fi
+
+  if [[ ! -f "${extfile}" ]]; then
+    echo "ERROR: Extension file '${extfile}' not found."
+    return 1
+  fi
+
+  local extbasename
+  extbasename="$(basename "${extfile}")"
+  local extname="${extbasename%%-*}"
+  extname="${extname%.raw}"
+  extname="$(extension_name "${extname}")"
+
+  if [[ -z "${extname}" ]]; then
+    echo "ERROR: Could not resolve extension directory for '${extbasename}'."
+    return 1
+  fi
+
+  local arch
+  arch="$(get_optional_param "arch" "amd64" "${@}")"
+  local scriptroot
+  scriptroot="$(dirname "${libroot}")"
+  local testscript="${scriptroot}/${extname}.sysext/test.sh"
+
+  local workdir
+  workdir="$(mktemp -d)"
+  # trap 'rm -rf "${workdir:-}"' RETURN
+
+  local butane="${workdir}/test.yaml"
+  local runner="${workdir}/test-runner.sh"
+  local dynamic_test="${workdir}/dynamic-test.sh"
+
+  if [[ -s "${testscript}" ]]; then
+    cp "${testscript}" "${dynamic_test}"
+  else
+    echo "echo 'No test.sh provided. Skipping dynamic tests.'" > "${dynamic_test}"
+  fi
+  local runner="${workdir}/test-runner.sh"
+
+  cat > "${runner}" <<EOF
+#!/bin/bash
+set -euo pipefail
+
+exec > /dev/kmsg 2>&1
+
+echo "Running tests for ${extname}..."
+
+# Verify that systemd-sysext actually merged extensions
+if ! systemctl is-active systemd-sysext.service > /dev/null; then
+    echo "ERROR: systemd-sysext.service is not active. The extension may be invalid."
+    exit 1
+fi
+
+# Verify the extension-release file exists in the merged tree
+if [ ! -f "/usr/lib/extension-release.d/extension-release.${extname}" ]; then
+    echo "ERROR: Missing extension-release file in merged /usr. Found:"
+    ls -l /usr/lib/extension-release.d/ || true
+    exit 1
+fi
+
+if [ -f "/opt/bin/dynamic-test.sh" ]; then
+    echo "Executing custom test script..."
+    chmod +x "/opt/bin/dynamic-test.sh"
+    /opt/bin/dynamic-test.sh
+else
+    echo "No custom test.sh found."
+fi
+
+echo "Test runner completed successfully."
+EOF
+  chmod +x "${runner}"
+
+
+
+  cat > "${butane}" <<EOF
+version: 1.0.0
+variant: flatcar
+storage:
+  files:
+    - path: /opt/bin/test-runner.sh
+      mode: 0755
+      contents:
+        local: test-runner.sh
+    - path: /opt/bin/dynamic-test.sh
+      mode: 0755
+      contents:
+        local: dynamic-test.sh
+    - path: /etc/extensions/${extname}.raw
+      mode: 0644
+      contents:
+        source: http://10.0.2.2:12345/${extbasename}
+systemd:
+  units:
+    - name: update-engine.service
+      mask: true
+    - name: locksmithd.service
+      mask: true
+    - name: sysext-test.service
+      enabled: true
+      contents: |
+        [Unit]
+        Description=Sysext Test Runner
+        Wants=systemd-sysext.service
+        After=systemd-sysext.service
+        ConditionPathExists=/opt/bin/test-runner.sh
+
+        [Service]
+        Type=idle
+        StandardOutput=journal+console
+        StandardError=journal+console
+        ExecStart=/opt/bin/test-runner.sh
+        ExecStopPost=/bin/sh -c 'if [ "\$EXIT_STATUS" = "0" ]; then echo "TEST_SUCCESS_MARKER" > /dev/kmsg; else echo "TEST_FAILURE_MARKER" > /dev/kmsg; fi; sleep 1; systemctl poweroff --no-block'
+
+        [Install]
+        WantedBy=multi-user.target
+EOF
+
+  # Map sysext architecture names to Flatcar OS architectures
+  local os_arch="${arch}"
+  if [[ "${os_arch}" == "x86-64" || "${os_arch}" == "x86_64" ]]; then
+    os_arch="amd64"
+  fi
+  if [[ "${os_arch}" == "aarch64" ]]; then
+    os_arch="arm64"
+  fi
+
+  echo "Running automated testing for ${extfile}"
+  local output_log="${workdir}/qemu.log"
+
+  boot_sysext "${extfile}" --butane "${butane}" --arch "${os_arch}" | tee "${output_log}"
+
+  if grep -q "TEST_SUCCESS_MARKER" "${output_log}"; then
+    echo "Tests passed!"
+    return 0
+  else
+    echo "Tests failed!"
+    return 1
+  fi
+}


### PR DESCRIPTION
## Summary

* add a `bakery.sh test` command for automated sysext validation
* validate the extension through a temporary Flatcar VM using the existing `boot_sysext` infrastructure
* add CI coverage for changed extensions on both x86-64 and arm64
* support extension-specific dynamic tests through `test.sh`
* document the new testing workflow

## Validation

* `bash -n bakery.sh`
* `bash -n lib/test.sh`
* `shellcheck bakery.sh`
* `shellcheck lib/test.sh`
* `yamllint .github/workflows/pull_request.yaml`
* `git diff --check`
* successfully validated the implementation against a real compiled sysext image
