### PR TITLE
node-exporter: add prometheus node-exporter system extension

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -81,6 +81,7 @@ Check out documentation on specific extensions at the navigation menu on the lef
 | `kubernetes`     |  released    | [kubernetes versions](https://github.com/flatcar/sysext-bakery/releases/tag/kubernetes) |
 | `llamaedge`      |  released    | [llamaedge versions](https://github.com/flatcar/sysext-bakery/releases/tag/llamaedge) |
 | `nebula`         |  released    | [nebula versions](https://github.com/flatcar/sysext-bakery/releases/tag/nebula) |
+| `node-exporter`  |  released    | [node-exporter versions](https://github.com/flatcar/sysext-bakery/releases/tag/node-exporter) |
 | `nerdctl`        |  released    | [nerdctl versions](https://github.com/flatcar/sysext-bakery/releases/tag/nerdctl) |
 | `nomad`          |  released    | [nomad versions](https://github.com/flatcar/sysext-bakery/releases/tag/nomad) |
 | `nvidia-runtime` |  released    | [nvidia-runtime versions](https://github.com/flatcar/sysext-bakery/releases/tag/nvidia-runtime) |

--- a/docs/node_exporter.md
+++ b/docs/node_exporter.md
@@ -1,0 +1,51 @@
+# Prometheus Node Exporter sysext
+
+This sysext ships [Prometheus Node Exporter](https://github.com/prometheus/node_exporter).
+
+The sysext includes a service unit file to start node-exporter at boot.
+The default configuration can be modified or replaced via a custom Butane config.
+
+# Usage
+
+The snippet includes automated updates via systemd-sysupdate.
+Sysupdate will stage updates, refresh the merged sysext, and restart `node-exporter.service` — no reboot is required.
+You can deactivate updates by changing `enabled: true` to `enabled: false` in `systemd-sysupdate.timer`.
+
+Note that the snippet is for the x86-64 version of node-exporter 1.12.1.
+
+Check out the metadata release at https://github.com/flatcar/sysext-bakery/releases/tag/node-exporter for a list of all versions available in the bakery.
+
+```yaml
+variant: flatcar
+version: 1.0.0
+
+storage:
+  files:
+    - path: /opt/extensions/node-exporter/node-exporter-v1.12.1-x86-64.raw
+      mode: 0644
+      contents:
+        source: https://extensions.flatcar.org/extensions/node-exporter-v1.12.1-x86-64.raw
+    - path: /etc/sysupdate.node-exporter.d/node-exporter.conf
+      contents:
+        source: https://extensions.flatcar.org/extensions/node-exporter.conf
+  links:
+    - path: /etc/systemd/system/multi-user.target.wants/node-exporter.service
+      target: /usr/lib/systemd/system/node-exporter.service
+      overwrite: true
+    - target: /opt/extensions/node-exporter/node-exporter-v1.12.1-x86-64.raw
+      path: /etc/extensions/node-exporter.raw
+      hard: false
+systemd:
+  units:
+    - name: systemd-sysupdate.timer
+      enabled: true
+    - name: systemd-sysupdate.service
+      dropins:
+        - name: node-exporter.conf
+          contents: |
+            [Service]
+            ExecStartPre=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/node-exporter.raw > /tmp/node-exporter"
+            ExecStartPre=/usr/lib/systemd/systemd-sysupdate -C node-exporter update
+            ExecStartPost=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/node-exporter.raw > /tmp/node-exporter-new"
+            ExecStartPost=/usr/bin/sh -c "if ! cmp --silent /tmp/node-exporter /tmp/node-exporter-new; then systemd-sysext refresh && systemctl restart node-exporter.service; fi"
+```

--- a/node-exporter.sysext/create.sh
+++ b/node-exporter.sysext/create.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# vim: et ts=2 syn=bash
+#
+# Prometheus Node Exporter system extension.
+#
+
+RELOAD_SERVICES_ON_MERGE="true"
+
+function list_available_versions() {
+  list_github_releases "prometheus" "node_exporter"
+}
+# --
+
+function populate_sysext_root() {
+  local sysextroot="$1"
+  local arch="$2"
+  local version="$3"
+
+  local rel_arch="$(arch_transform "x86-64" "amd64" "$arch")"
+  local raw_version="${version#v}"
+  local tarball="node_exporter-${raw_version}.linux-${rel_arch}.tar.gz"
+
+  curl --parallel --fail --silent --show-error --location \
+    --remote-name "https://github.com/prometheus/node_exporter/releases/download/${version}/${tarball}"
+
+  tar --force-local --strip-components=1 -xf "${tarball}"
+
+  mkdir -p "${sysextroot}/usr/bin"
+  cp -a node_exporter "${sysextroot}/usr/bin/"
+}
+# --

--- a/node-exporter.sysext/files/usr/lib/systemd/system/multi-user.target.d/10-node-exporter.conf
+++ b/node-exporter.sysext/files/usr/lib/systemd/system/multi-user.target.d/10-node-exporter.conf
@@ -1,0 +1,2 @@
+[Unit]
+Upholds=node-exporter.service

--- a/node-exporter.sysext/files/usr/lib/systemd/system/node-exporter.service
+++ b/node-exporter.sysext/files/usr/lib/systemd/system/node-exporter.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Prometheus Node Exporter
+Documentation=https://github.com/prometheus/node_exporter
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+EnvironmentFile=-/usr/share/node-exporter/node-exporter.env
+EnvironmentFile=-/etc/default/node-exporter
+ExecStart=/usr/bin/node_exporter $NODE_EXPORTER_OPTS
+Restart=on-failure
+RestartSec=5
+
+[Install]
+UpheldBy=multi-user.target

--- a/node-exporter.sysext/files/usr/share/node-exporter/node-exporter.env
+++ b/node-exporter.sysext/files/usr/share/node-exporter/node-exporter.env
@@ -1,0 +1,2 @@
+NODE_EXPORTER_OPTS=""
+

--- a/release_build_versions.txt
+++ b/release_build_versions.txt
@@ -64,6 +64,9 @@ kubernetes latest
 nebula v1.9.5
 nebula latest
 
+node-exporter v1.12.1
+node-exporter latest
+
 nerdctl latest
 
 nomad 1.10.0


### PR DESCRIPTION
# node-exporter: add prometheus node-exporter system extension

This PR adds the Prometheus Node Exporter system extension (`node-exporter.sysext`) to the Bakery. The extension downloads the official upstream Node Exporter binary and packages it into a system extension image alongside a systemd unit file and default configuration.

The Node Exporter service is integrated using a systemd `Upholds` drop-in on `multi-user.target` to ensure the service automatically starts and remains active when the system enters multi-user mode. Default environment options are shipped under `/usr/share/node-exporter/node-exporter.env` and loaded by the service unit, which also supports user-provided overrides from `/etc/default/node-exporter`.

Additionally, user documentation has been added under `docs/node_exporter.md` with instructions on how to use, configure, and automate updates for this extension using Butane and `systemd-sysupdate`.

## How to use

Reviewers can build and run the Node Exporter system extension locally using the Bakery script:

1. Build the system extension image:
   ```bash
   ./bakery.sh create node-exporter v1.12.1
   ```

2. Boot a local Flatcar VM with the built system extension:
   ```bash
   ./bakery.sh boot node-exporter.raw --ports 9200:9100
   ```

3. Log in to the VM and verify the status of the service, and verify that the metrics endpoint is responding on the forwarded host port `9200`.

## Testing done

- Built the extension successfully using `./bakery.sh create node-exporter v1.12.1`.
- Booted the extension in QEMU via `./bakery.sh boot node-exporter.raw --ports 9200:9100`.
- Verified the binary is present and correct:
  ```bash
  core@localhost ~ $ node_exporter --version
  node_exporter, version 1.12.1 (branch: HEAD, revision: 6044da783597cc3b57aef7580ddcdcff58a4ee99)
    build user:       root@3a6b59999579
    build date:       20260714-12:05:11
    go version:       go1.26.5
    platform:         linux/amd64
    tags:             unknown
  ```
- Verified the systemd service starts automatically at boot and runs successfully:
  ```bash
  core@localhost ~ $ systemctl status node-exporter.service
  ● node-exporter.service - Prometheus Node Exporter
       Loaded: loaded (/usr/lib/systemd/system/node-exporter.service; disabled; preset: enabled)
       Active: active (running) since Thu 2026-08-13 18:09:39 UTC; 12min ago
     Invocation: 2aa630f4dfe74435b64ea922e66d696b
           Docs: https://github.com/prometheus/node_exporter
       Main PID: 2072 (node_exporter)
          Tasks: 7 (limit: 15176)
         Memory: 26.4M (peak: 27.5M)
            CPU: 89ms
         CGroup: /system.slice/node-exporter.service
                 └─2072 /usr/bin/node_exporter
  ```
- Verified metrics collection on the host machine via forwarded port `9200`:
  ```bash
  curl http://localhost:9200/metrics
  ```
  Output returned correct Prometheus Exposition Text Format metrics successfully (e.g. `go_gc_duration_seconds{quantile="0"} 1.9324e-05` and various host stats).

- [ ] Changelog entries added in the respective `changelog/` directory (Note: changelog/ directory is not used in this repository)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.
