### PR TITLE
Fixes for the extension releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,6 +47,7 @@ jobs:
     needs: list-builds
     if: ${{ needs.list-builds.outputs.builds != '[]' && needs.list-builds.outputs.builds != '' }}
     strategy:
+      fail-fast: false
       matrix:
         release: ${{ fromJson(needs.list-builds.outputs.builds) }}
     # Try to finish all jobs even if one fails.
@@ -102,7 +103,7 @@ jobs:
 
   update-extension-metadata:
     needs: [ list-builds, create-release ]
-    if: ${{ needs.list-builds.outputs.extensions != '[]' && needs.list-builds.outputs.extensions != '' }}
+    if: ${{ !cancelled() && needs.list-builds.outputs.extensions != '[]' && needs.list-builds.outputs.extensions != '' }}
     strategy:
       fail-fast: false
       matrix:
@@ -147,8 +148,8 @@ jobs:
             bakery/*.conf
 
   update-global-metadata:
-    needs: update-extension-metadata
-    if: ${{ needs.list-builds.outputs.extensions != '[]' && needs.list-builds.outputs.extensions != '' }}
+    needs: [ list-builds, update-extension-metadata ]
+    if: ${{ !cancelled() && needs.list-builds.outputs.extensions != '[]' && needs.list-builds.outputs.extensions != '' }}
     runs-on: ubuntu-24.04
     permissions:
       # allow the action to create a release

--- a/.github/workflows/update-all-metadata.yaml
+++ b/.github/workflows/update-all-metadata.yaml
@@ -35,8 +35,10 @@ jobs:
   update-extension-metadata:
     needs: [ list-extensions ]
     strategy:
+      fail-fast: false
       matrix:
         extension: ${{ fromJson(needs.list-extensions.outputs.extensions) }}
+    continue-on-error: true
     runs-on: ubuntu-24.04
     permissions:
       # allow the action to create a release
@@ -74,6 +76,7 @@ jobs:
 
   update-global-metadata:
     needs: update-extension-metadata
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-24.04
     permissions:
       # allow the action to create a release


### PR DESCRIPTION
# Update extension metadata even if one of them fails part 2

Seems like https://github.com/flatcar/sysext-bakery/pull/250 didn't fully resolve the issue.

Now the new versions of extensions do indeed build correctly e.g. https://github.com/flatcar/sysext-bakery/releases/tag/tailscale-v1.102.3 **but** the release version list is stil stale https://github.com/flatcar/sysext-bakery/releases/tag/tailscale
```
...
Updated 2026-07-01 06:37:58+00:00

tailscale-v1.98.8
tailscale-v1.98.3
tailscale-v1.98.2
...
```

So it still won't update to the newest one:
```
# /usr/lib/systemd/systemd-sysupdate -C tailscale update
[...]
Determining installed update sets…
Determining available update sets…
Selected update 'v1.98.8' for install.
```

## How to use

`fail-fast` in this case skipped everything when one of the builds failed (nvidia or kata containers atm it seems).
`continue-on-error: true` should help, but also using `!cancelled()` is the additional guard to only skip if the build was indeed canceled (but tbh could also probably just use `always()` maybe cleaner?)

**Maintainer would need to run** `update-all-metadata.yaml` to update all of the old not-updated releases.

## Testing done

Lint resolves fine, couldn't test anything more. 