### PR TITLE
nomad: optionally bundle the CNI reference plugins

### DIFF
--- a/docs/nomad.md
+++ b/docs/nomad.md
@@ -6,6 +6,19 @@ The sysext includes a service unit file to start nomad at boot.
 Nomad is configured as a server by default.
 The default configuration can be modified or replaced via a custom Butane config.
 
+## CNI plugins
+
+Nomad's `bridge` network mode needs the CNI reference plugins, which Flatcar does not ship. The sysext build can
+optionally be instructed to include them:
+
+```
+./bakery.sh create nomad 1.10.0 --with-cni v1.9.1
+```
+
+Pass `--with-cni latest` for the newest upstream release. The plugins are installed to `/usr/libexec/cni` and a
+`/etc/nomad.d/cni.hcl` drop-in points Nomad's `cni_path` at them, so `bridge` works with no further configuration.
+Builds without `--with-cni` are unchanged and ship neither the plugins nor the drop-in.
+
 # Usage
 
 The snippet includes automated updates via systemd-sysupdate.

--- a/lib/helpers.sh
+++ b/lib/helpers.sh
@@ -226,3 +226,51 @@ function semver_lower() {
 
   return 0
 }
+
+# --
+
+# Download the upstream containernetworking/plugins release for ${arch} and
+# unpack the binaries into ${destdir} below ${sysextroot}, verifying the
+# published checksum. An empty ${version} (or "latest") resolves to the newest
+# upstream release. The resolved version is returned in ${CNI_PLUGINS_VERSION},
+# which callers need when they record the bundled version.
+#
+# Several extensions bundle CNI for their own runtime (nerdctl, kubernetes,
+# nomad); they differ only in where the binaries go, so keep the download,
+# verification and unpacking here rather than in each recipe.
+function install_cni_plugins() {
+  local sysextroot="$1"
+  local arch="$2"
+  local version="$3"
+  local destdir="$4"
+
+  if [[ -z "${version}" ]] || [[ "${version}" == "latest" ]] ; then
+    version="$(curl_api_wrapper \
+                 https://api.github.com/repos/containernetworking/plugins/releases/latest \
+               | jq -r .tag_name)"
+  fi
+  if [[ -z "${version}" ]] || [[ "${version}" == "null" ]] ; then
+    echo "ERROR: could not determine the CNI plugins version." >&2
+    return 1
+  fi
+
+  local rel_arch
+  rel_arch="$(arch_transform 'x86-64' 'amd64' "${arch}")"
+
+  local tarball="cni-plugins-linux-${rel_arch}-${version}.tgz"
+  local base_url="https://github.com/containernetworking/plugins/releases/download/${version}"
+
+  curl --remote-name -fsSL --retry-delay 1 --retry 60 \
+    --retry-connrefused --retry-max-time 60 --connect-timeout 20 \
+    "${base_url}/${tarball}"
+  curl --remote-name -fsSL --retry-delay 1 --retry 60 \
+    --retry-connrefused --retry-max-time 60 --connect-timeout 20 \
+    "${base_url}/${tarball}.sha256"
+  sha256sum -c "${tarball}.sha256"
+
+  # The tarball expands flat (bridge, host-local, portmap, …) into the target.
+  mkdir -p "${sysextroot}/${destdir}"
+  tar --force-local -xzf "${tarball}" -C "${sysextroot}/${destdir}"
+
+  CNI_PLUGINS_VERSION="${version}"
+}

--- a/nomad.sysext/create.sh
+++ b/nomad.sysext/create.sh
@@ -17,10 +17,22 @@ function list_available_versions() {
 }
 # --
 
+function populate_sysext_root_options() {
+  echo "  --with-cni <version> : Also ship CNI plugin <version> in the sysext, and"
+  echo "                  point Nomad's cni_path at it. Pass 'latest' for the newest"
+  echo "                  release. Nomad needs these for its bridge network mode."
+  echo "                  For a list of CNI plugin versions, please refer to"
+  echo "                  https://github.com/containernetworking/plugins/releases"
+}
+# --
+
 function populate_sysext_root() {
   local sysextroot="$1"
   local arch="$2"
   local version="$3"
+
+  local cni
+  cni="$(get_optional_param "with-cni" "" "$@")"
 
   local rel_arch
   rel_arch="$(arch_transform "x86-64" "amd64" "$arch")"
@@ -31,5 +43,15 @@ function populate_sysext_root() {
   mkdir -p "${sysextroot}/usr/bin"
   unzip -q "nomad_${version}_linux_${rel_arch}.zip"
   install -m 0755 nomad "${sysextroot}/usr/bin"
+
+  if [[ -n "${cni}" ]] ; then
+    install_cni_plugins "${sysextroot}" "${arch}" "${cni}" "usr/libexec/cni"
+    announce "Bundled CNI plugins ${CNI_PLUGINS_VERSION}"
+  else
+    # Without the plugins the cni_path drop-in would point Nomad at an empty
+    # directory, so drop it and leave the stock config alone.
+    rm -f "${sysextroot}/usr/share/nomad/cni.hcl" \
+          "${sysextroot}/usr/lib/tmpfiles.d/11-nomad-cni.conf"
+  fi
 }
 # --

--- a/nomad.sysext/files/usr/share/nomad/cni.hcl
+++ b/nomad.sysext/files/usr/share/nomad/cni.hcl
@@ -1,0 +1,6 @@
+# Shipped only when the sysext was built with --with-cni. Nomad merges every
+# .hcl file in /etc/nomad.d, so this adds cni_path to the client block in
+# nomad.hcl without replacing the rest of that configuration.
+client {
+  cni_path = "/usr/libexec/cni"
+}


### PR DESCRIPTION
Adds `--with-cni <version>`, mirroring the option `nerdctl` and `kubernetes` already expose:

```
./bakery.sh create nomad 1.10.0 --with-cni v1.9.1
```

The plugins go to `/usr/libexec/cni`. A `cni.hcl` drop-in seeds `/etc/nomad.d` and points `cni_path` at it, so `bridge` works with no further configuration.

Builds without the flag are unchanged: neither the plugins nor the drop-in are installed.

The download, checksum verification and unpacking move into `install_cni_plugins` in `lib/helpers.sh`. 
Kubernetes and nerdctl PRs using that shared helper should merge after this one.