### PR TITLE
kata-containers: ship under /usr/lib/kata, not /opt/kata

### DIFF
--- a/docs/kata-containers.md
+++ b/docs/kata-containers.md
@@ -6,9 +6,12 @@ for hardware-enforced isolation.
 
 The sysext unpacks the upstream `kata-static` release tarball, which
 bundles the Kata runtime, agent, containerd shim, guest kernel, initrd
-and a hypervisor (QEMU and Cloud Hypervisor) under `/opt/kata`. Symlinks
-in `/usr/bin` expose `kata-runtime`, `containerd-shim-kata-v2` and
+and a hypervisor (QEMU and Cloud Hypervisor). Symlinks in `/usr/bin`
+expose `kata-runtime`, `containerd-shim-kata-v2` and
 `kata-collect-data.sh` on `$PATH` after the sysext is merged.
+
+The tree is installed at `/usr/lib/kata`, with `/opt/kata` kept as a
+symlink to it.
 
 ## Usage
 

--- a/kata-containers.sysext/create.sh
+++ b/kata-containers.sysext/create.sh
@@ -5,7 +5,17 @@
 #
 # Ships the upstream "kata-static" release tarball, which bundles
 # the kata runtime, agent, shim, guest kernel, initrd and a hypervisor
-# (QEMU and/or Cloud Hypervisor) under /opt/kata.
+# (QEMU and/or Cloud Hypervisor).
+#
+# The tarball installs under /opt/kata, but this sysext relocates it to
+# /usr/lib/kata and recreates /opt/kata as a symlink via tmpfiles.d. The reason
+# is that systemd-sysext merges a hierarchy by mounting a READ-ONLY overlay over
+# it, and it merges /opt as well as /usr. So an extension that ships anything
+# under /opt makes the host's entire /opt read-only for as long as the extension
+# is merged -- which breaks any unrelated software that writes there, and is
+# surprising because /opt is writable on a stock Flatcar. Keeping the image
+# clear of /opt leaves the host's /opt writable, and the tmpfiles symlink
+# preserves every /opt/kata path kata itself still refers to.
 #
 
 RELOAD_SERVICES_ON_MERGE="true"
@@ -55,8 +65,13 @@ function populate_sysext_root() {
   # The tarball expands to ./opt/kata/{bin,libexec,share,...}.
   tar --force-local -xf "${tarball}"
 
-  mkdir -p "${sysextroot}/opt"
-  cp -aR opt/kata "${sysextroot}/opt/"
+  # Relocate to /usr/lib/kata: shipping /opt would make the host's /opt a
+  # read-only overlay. files/usr/lib/tmpfiles.d/10-kata-containers-opt.conf
+  # restores /opt/kata as a symlink to this, so kata's compiled-in default
+  # config path and the absolute paths inside the shipped configuration.toml
+  # files keep resolving.
+  mkdir -p "${sysextroot}/usr/lib"
+  cp -aR opt/kata "${sysextroot}/usr/lib/kata"
 
   # Expose the user-facing binaries via /usr/bin so they're on $PATH
   # after the sysext is merged. Use relative symlinks so they continue
@@ -64,14 +79,14 @@ function populate_sysext_root() {
   mkdir -p "${sysextroot}/usr/bin"
   local bin
   for bin in kata-runtime containerd-shim-kata-v2 ; do
-    if [[ ! -e "${sysextroot}/opt/kata/bin/${bin}" ]] ; then
+    if [[ ! -e "${sysextroot}/usr/lib/kata/bin/${bin}" ]] ; then
       echo "ERROR: expected binary ${bin} missing from kata-static ${rel_version}." >&2
       return 1
     fi
-    ln -sf "../../opt/kata/bin/${bin}" "${sysextroot}/usr/bin/${bin}"
+    ln -sf "../lib/kata/bin/${bin}" "${sysextroot}/usr/bin/${bin}"
   done
-  if [[ -e "${sysextroot}/opt/kata/bin/kata-collect-data.sh" ]] ; then
-    ln -sf "../../opt/kata/bin/kata-collect-data.sh" \
+  if [[ -e "${sysextroot}/usr/lib/kata/bin/kata-collect-data.sh" ]] ; then
+    ln -sf "../lib/kata/bin/kata-collect-data.sh" \
       "${sysextroot}/usr/bin/kata-collect-data.sh"
   fi
 }

--- a/kata-containers.sysext/files/usr/lib/tmpfiles.d/10-kata-containers-opt.conf
+++ b/kata-containers.sysext/files/usr/lib/tmpfiles.d/10-kata-containers-opt.conf
@@ -1,0 +1,11 @@
+# Compatibility symlink for Kata's historical install prefix.
+#
+# The sysext ships the kata tree at /usr/lib/kata rather than /opt/kata, so that
+# the image contains no /opt hierarchy -- see the comment in create.sh for why
+# that matters. Kata's own compiled-in default configuration path, the absolute
+# paths inside the shipped configuration.toml files, and any existing user
+# config all still refer to /opt/kata, so recreate it as a symlink here.
+#
+# Plain "L" (not "L+"): if something else already provides /opt/kata, leave it
+# alone rather than deleting it.
+L /opt/kata - - - - /usr/lib/kata


### PR DESCRIPTION
Change kata-container sysext to use /use/lib/kata instead of /opt/kata. Adding /opt to a sysext makes the whole tree ro on flatcar, which is less than idea. This fixes it.