### PR TITLE
feat(coredns): add CoreDNS system extension

### DIFF
--- a/coredns.sysext/create.sh
+++ b/coredns.sysext/create.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# vim: et ts=2 syn=bash
+#
+# CoreDNS system extension.
+#
+
+RELOAD_SERVICES_ON_MERGE="true"
+
+function list_available_versions() {
+  # CoreDNS also carries pre-1.0 tags like "v011" that sort above "v1.14.7"
+  # and predate the current release archives. Keep semver tags only.
+  list_github_releases "coredns" "coredns" \
+    | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$'
+}
+# --
+
+function populate_sysext_root() {
+  local sysextroot="$1"
+  local arch="$2"
+  local version="$3"
+
+  # Release tags are "vX.Y.Z" but the release archives drop the leading "v".
+  local relver="${version#v}"
+
+  local rel_arch
+  rel_arch="$(arch_transform "x86-64" "amd64" "$arch")"
+
+  local tarball="coredns_${relver}_linux_${rel_arch}.tgz"
+  local baseurl="https://github.com/coredns/coredns/releases/download/v${relver}"
+
+  announce "Fetching CoreDNS ${version} for ${arch}"
+  curl -fsSLZ --retry-delay 1 --retry 60 \
+    --retry-connrefused --retry-max-time 60 --connect-timeout 20 \
+    -O "${baseurl}/${tarball}" \
+    -O "${baseurl}/${tarball}.sha256"
+
+  announce "Verifying ${tarball}"
+  sha256sum --check --strict "${tarball}.sha256"
+
+  tar --force-local -xf "${tarball}" coredns
+  mkdir -p "${sysextroot}/usr/bin"
+  install -m 0755 coredns "${sysextroot}/usr/bin"
+}
+# --

--- a/coredns.sysext/files/usr/lib/systemd/system/coredns.service
+++ b/coredns.sysext/files/usr/lib/systemd/system/coredns.service
@@ -1,0 +1,42 @@
+[Unit]
+Description=CoreDNS DNS server
+Documentation=https://coredns.io/manual/toc/
+Wants=network-online.target
+After=network-online.target
+# The extension ships /usr/lib/sysusers.d/coredns.conf; order after the
+# generator that turns it into the "coredns" user this unit runs as.
+After=systemd-sysusers.service
+# CoreDNS exits when an address in a "bind" directive is not up yet. Do not
+# rate limit restarts, so a node recovers on its own once the address appears.
+StartLimitIntervalSec=0
+
+[Service]
+# Site policy decides the config. The extension ships no Corefile, and cannot:
+# a sysext merges /usr and /opt only, never /etc. See
+# /usr/share/doc/coredns/Corefile.example for a starting point.
+ExecStart=/usr/bin/coredns -conf /etc/coredns/Corefile
+ExecReload=/bin/kill -SIGUSR1 $MAINPID
+WorkingDirectory=-/etc/coredns
+
+User=coredns
+Group=coredns
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+NoNewPrivileges=yes
+
+Restart=on-failure
+RestartSec=2s
+LimitNOFILE=65536
+
+ProtectSystem=full
+ProtectHome=yes
+PrivateTmp=yes
+ProtectControlGroups=yes
+ProtectKernelModules=yes
+ProtectKernelTunables=yes
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX AF_NETLINK
+RestrictRealtime=yes
+LockPersonality=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/coredns.sysext/files/usr/lib/sysusers.d/coredns.conf
+++ b/coredns.sysext/files/usr/lib/sysusers.d/coredns.conf
@@ -1,0 +1,1 @@
+u coredns - "CoreDNS" - /sbin/nologin

--- a/coredns.sysext/files/usr/share/doc/coredns/Corefile.example
+++ b/coredns.sysext/files/usr/share/doc/coredns/Corefile.example
@@ -1,0 +1,17 @@
+# Example CoreDNS configuration. This file is documentation only. CoreDNS never
+# reads it. Copy it to /etc/coredns/Corefile and edit it to suit the node.
+#
+# See https://coredns.io/manual/toc/ for the plugin reference.
+
+.:53 {
+    errors
+    log
+    health
+    ready
+    # Forward everything else to an upstream resolver.
+    forward . 9.9.9.9 1.1.1.1
+    cache 30
+    loop
+    reload
+    loadbalance
+}

--- a/coredns.sysext/test.sh
+++ b/coredns.sysext/test.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# vim: et ts=2 syn=bash
+#
+# Test script for the coredns sysext.
+#
+# Usage: ./coredns.sysext/test.sh [<image.raw>]
+#
+# Checks a built squashfs image. Defaults to "coredns.raw" in the current
+# directory. "coredns -version" only runs when the image arch matches the host.
+
+set -euo pipefail
+
+image="${1:-coredns.raw}"
+
+if [[ ! -f ${image} ]] ; then
+  echo "ERROR: no such image '${image}'. Build one with './bakery.sh create coredns <version>'."
+  exit 1
+fi
+
+failures=0
+
+function check() {
+  local what="$1"
+  shift
+
+  if "${@}" ; then
+    echo "PASS: ${what}"
+  else
+    echo "FAIL: ${what}"
+    : $((failures++))
+  fi
+}
+# --
+
+workdir="$(mktemp -d)"
+trap "rm -rf '${workdir}'" EXIT
+
+unsquashfs -no-progress -force -dest "${workdir}/root" "${image}" >/dev/null
+root="${workdir}/root"
+
+# The image must merge into /usr only. A sysext merges both /usr and /opt, and
+# a hierarchy becomes a read-only overlay as soon as any merged image ships it.
+# Shipping /opt here would hide files consumers place there at install time.
+function only_usr() {
+  local stray
+  stray="$(find "${root}" -mindepth 1 -maxdepth 1 -not -name usr -printf '%f\n')"
+
+  if [[ -n ${stray} ]] ; then
+    echo "  unexpected top level entries: ${stray//$'\n'/ }"
+    return 1
+  fi
+}
+# --
+
+check "image contains no path outside /usr" only_usr
+check "/usr/bin/coredns is a regular file" test -f "${root}/usr/bin/coredns"
+check "/usr/bin/coredns is executable" test -x "${root}/usr/bin/coredns"
+check "ships a coredns.service unit" \
+  test -f "${root}/usr/lib/systemd/system/coredns.service"
+check "ships a sysusers.d entry for the coredns user" \
+  test -f "${root}/usr/lib/sysusers.d/coredns.conf"
+check "ships no Corefile CoreDNS would read by default" \
+  test ! -e "${root}/usr/share/coredns/Corefile"
+
+# Read e_machine from the ELF header to learn what the binary was built for.
+# 0x3e is x86-64, 0xb7 is aarch64.
+function elf_machine() {
+  od -An -tx1 -j18 -N2 "$1" | tr -d ' \n'
+}
+# --
+
+host_machine=""
+case "$(uname -m)" in
+  x86_64)  host_machine="3e00";;
+  aarch64) host_machine="b700";;
+esac
+
+# The binary is static, so it runs straight out of the extracted tree.
+if [[ -n ${host_machine} ]] \
+   && [[ "$(elf_machine "${root}/usr/bin/coredns")" == "${host_machine}" ]] ; then
+  check "coredns -version runs" "${root}/usr/bin/coredns" -version
+else
+  echo "SKIP: coredns -version (image architecture differs from the host)"
+fi
+
+echo
+if [[ ${failures} -gt 0 ]] ; then
+  echo "${failures} check(s) failed."
+  exit 1
+fi
+
+echo "All checks passed."

--- a/docs/coredns.md
+++ b/docs/coredns.md
@@ -1,0 +1,115 @@
+# CoreDNS sysext
+
+This sysext ships [CoreDNS](https://coredns.io/), the pluggable DNS server, as the static release binary published by the CoreDNS project.
+
+The image contains:
+
+- the `coredns` binary at `/usr/bin/coredns`
+- a `coredns.service` unit that runs CoreDNS as an unprivileged `coredns` user with `CAP_NET_BIND_SERVICE`, so it can bind port 53 without root
+- a `sysusers.d` entry that creates that `coredns` system user
+- a commented example configuration at `/usr/share/doc/coredns/Corefile.example`
+
+Everything the image ships lives under `/usr`. A hierarchy becomes a read-only overlay as soon as one merged image ships it, so an extension that shipped an `/opt` path would hide files a node placed there at install time. This one never does that.
+
+## Configuration
+
+The extension ships no `Corefile`, and it cannot: a sysext merges `/usr` and `/opt`, never `/etc`. The unit reads `/etc/coredns/Corefile`, which is the common convention. Write that file with Ignition, with config management, or by hand. Start from `/usr/share/doc/coredns/Corefile.example`. CoreDNS never reads the example itself.
+
+CoreDNS exits when an address named in a `bind` directive is not up yet. That happens on a node that binds a link-local address on an interface `systemd-networkd` brings up during boot. The unit therefore sets `Restart=on-failure` with `RestartSec=2s`, and disables start rate limiting with `StartLimitIntervalSec=0`, so the service recovers on its own once the address appears.
+
+`systemctl reload coredns` sends `SIGUSR1`, which makes CoreDNS re-read the `Corefile` without dropping queries.
+
+## Service ordering
+
+The shipped unit orders itself after `network-online.target` and nothing else, because what CoreDNS must start before is a site decision. Add your own ordering with a drop-in rather than replacing the unit:
+
+```yaml
+systemd:
+  units:
+    - name: coredns.service
+      enabled: true
+      dropins:
+        - name: 10-local-ordering.conf
+          contents: |
+            [Unit]
+            Wants=sys-devices-virtual-net-nodelocal0.device
+            After=sys-devices-virtual-net-nodelocal0.device
+            Before=consul.service
+```
+
+The extension does not start CoreDNS by itself. It ships no `multi-user.target.upholds` drop-in, so a node that merges the image before its `Corefile` exists does not get a failing service. Enable the unit when the config is in place, as the snippet below does.
+
+The extension also does not touch `systemd-resolved`. Whether CoreDNS replaces the stub resolver is up to you.
+
+## Usage
+
+Download and merge the sysext at provisioning time using the below Butane snippet.
+
+The snippet includes automated updates via systemd-sysupdate.
+Sysupdate will stage updates, refresh the merged sysext, and restart `coredns.service` — no reboot is required.
+You can deactivate updates by changing `enabled: true` to `enabled: false` in `systemd-sysupdate.timer`.
+
+Note that the snippet is for the x86-64 version of CoreDNS v1.14.7.
+
+Check out the metadata release at https://github.com/flatcar/sysext-bakery/releases/tag/coredns for a list of all versions available in the bakery.
+
+```yaml
+variant: flatcar
+version: 1.0.0
+
+storage:
+  files:
+    - path: /opt/extensions/coredns/coredns-v1.14.7-x86-64.raw
+      mode: 0644
+      contents:
+        source: https://extensions.flatcar.org/extensions/coredns-v1.14.7-x86-64.raw
+    - path: /etc/sysupdate.coredns.d/coredns.conf
+      contents:
+        source: https://extensions.flatcar.org/extensions/coredns.conf
+    - path: /etc/sysupdate.d/noop.conf
+      contents:
+        source: https://extensions.flatcar.org/extensions/noop.conf
+    - path: /etc/coredns/Corefile
+      mode: 0644
+      contents:
+        inline: |
+          .:53 {
+              errors
+              health
+              ready
+              forward . 9.9.9.9 1.1.1.1
+              cache 30
+              loop
+              reload
+          }
+  links:
+    - target: /opt/extensions/coredns/coredns-v1.14.7-x86-64.raw
+      path: /etc/extensions/coredns.raw
+      hard: false
+systemd:
+  units:
+    - name: coredns.service
+      enabled: true
+    - name: systemd-sysupdate.timer
+      enabled: true
+    - name: systemd-sysupdate.service
+      dropins:
+        - name: coredns.conf
+          contents: |
+            [Service]
+            ExecStartPre=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/coredns.raw > /run/coredns-sysext"
+            ExecStartPre=/usr/lib/systemd/systemd-sysupdate -C coredns update
+            ExecStartPost=/usr/bin/sh -c "readlink --canonicalize /etc/extensions/coredns.raw > /run/coredns-sysext-new"
+            ExecStartPost=/usr/bin/sh -c "if ! cmp --silent /run/coredns-sysext /run/coredns-sysext-new; then systemd-sysext refresh && systemctl restart coredns.service; fi"
+```
+
+## Testing a built image
+
+`coredns.sysext/test.sh` checks a locally built image:
+
+```bash
+./bakery.sh create coredns v1.14.7
+./coredns.sysext/test.sh coredns.raw
+```
+
+It asserts the binary is present and executable, that `coredns -version` runs when the image architecture matches the host, and that the image contains no path outside `/usr`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -67,6 +67,7 @@ Check out documentation on specific extensions at the navigation menu on the lef
 | `coder`          |  released    | [coder versions](https://github.com/flatcar/sysext-bakery/releases/tag/coder) |
 | `consul`          |  released    | [consul versions](https://github.com/flatcar/sysext-bakery/releases/tag/consul) |
 | `containerd`     |  released    | [containerd versions](https://github.com/flatcar/sysext-bakery/releases/tag/containerd) |
+| `coredns`        |  released    | [coredns versions](https://github.com/flatcar/sysext-bakery/releases/tag/coredns) |
 | `crio`           |  released    | [crio versions](https://github.com/flatcar/sysext-bakery/releases/tag/crio) |
 | `dataplaneapi`   |  released    | [dataplaneapi versions](https://github.com/flatcar/sysext-bakery/releases/tag/dataplaneapi) |
 | `docker-buildx`  |  released    | [docker-buildx versions](https://github.com/flatcar/sysext-bakery/releases/tag/docker-buildx) |

--- a/release_build_versions.txt
+++ b/release_build_versions.txt
@@ -29,6 +29,9 @@ containerd 2.0.0
 containerd 1.7.29
 containerd latest
 
+coredns v1.14.7
+coredns latest
+
 crio latest
 
 docker-buildx 0.25.0


### PR DESCRIPTION
Ships the static CoreDNS release binary at /usr/bin/coredns, a coredns.service unit, and a sysusers.d entry for the unprivileged coredns user the unit runs as.

Everything lives under /usr. The image ships no Corefile, does not start the service by itself, and does not touch systemd-resolved, so a consumer keeps control of the config, the start ordering, and the stub resolver.

# [Title: describe the change in one sentence]

[ describe the change in 1 - 3 paragraphs ]

## How to use

[ describe what reviewers need to do in order to validate this PR ]

## Testing done

[Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got.]

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
